### PR TITLE
docs: feature/4321 API 가이드 동기화 (백업 복제 리전 노출 정합화)

### DIFF
--- a/en/api-guide-v1.0.md
+++ b/en/api-guide-v1.0.md
@@ -1567,7 +1567,8 @@ POST /v1.0/db-instances/{dbInstanceId}/backup
 
 ```json
 {
-"backupName": "backupName-example"
+"backupName": "backupName-example",
+"backupMethodType": "FULL"
 }
 ```
 
@@ -1576,6 +1577,7 @@ POST /v1.0/db-instances/{dbInstanceId}/backup
 | Name | Type | Required | Description |
 |-----|-----|-----|-----|
 | backupName | String | Y | Name to identify backups |
+| backupMethodType | Enum | N | Backup method<br/>- FULL<br/>- SNAPSHOT |
 
 #### Response
 
@@ -3539,7 +3541,7 @@ This API does not require a request body.
 | restorableBackups.dbInstanceId | UUID | Original DB instance identifier |
 | restorableBackups.dbInstanceName | String | Original DB instance name |
 | restorableBackups.dbVersion | String | DB engine type |
-| restorableBackups.backupType | Enum | Backup type<br/>- AUTO<br/>- MANUAL |
+| restorableBackups.backupType | Enum | Backup type<br/>- AUTO: `Auto Backup`<br/>- MANUAL: `Manual Backup` |
 | restorableBackups.backupSize | Number | Backup size |
 | restorableBackups.failoverCount | Number | Number of failovers |
 | restorableBackups.walFileName | String | WAL file name |
@@ -3961,7 +3963,7 @@ This API does not require a request body.
 | backups.backupStatus | Enum | Backup current status<br/>- BACKING_UP: `Backup in progress (spinner)`<br/>- VERIFYING: `Verifying (spinner)`<br/>- COMPLETED: `Available (green icon)`<br/>- DELETING: `Deleting (spinner)`<br/>- DELETED: `Deleted (gray icon)`<br/>- ERROR: `Error (red icon)` |
 | backups.dbInstanceId | UUID | Original DB instance identifier |
 | backups.dbVersion | String | DB version information |
-| backups.backupType | Enum | Backup type<br/>- AUTO<br/>- MANUAL |
+| backups.backupType | Enum | Backup type<br/>- AUTO: `Auto Backup`<br/>- MANUAL: `Manual Backup` |
 | backups.backupSize | Number | Size of the backup (Bytes) |
 | backups.startYmdt | DateTime | Start date and time |
 | backups.createdYmdt | DateTime | Created date and time |

--- a/en/api-guide-v1.0.md
+++ b/en/api-guide-v1.0.md
@@ -56,20 +56,7 @@ The API responds with "200 OK" to all API requests. For more information on the 
 | resultMessage | String    | Result message                           |
 | successful    | Boolean   | Successful or not                        |
 
-## DB version
-
-| DB version        | Available for creation |
-|-------------------|------------------------|
-| POSTGRESQL_V14_6  |                        |
-| POSTGRESQL_V14_15 |                        |
-| POSTGRESQL_V14_17 | O                      |
-| POSTGRESQL_V14_19 | O                      |
-| POSTGRESQL_V17_2  |                        |
-| POSTGRESQL_V17_4  | O                      |
-| POSTGRESQL_V17_6  | O                      |
-
-* You can use that value for dbVersion fields of type ENUM.
-* Depending on the version, there may be some cases where it is not possible to create or restore.
+## DB Version
 
 ### View DB Version List
 
@@ -77,10 +64,10 @@ The API responds with "200 OK" to all API requests. For more information on the 
 GET /v1.0/db-versions
 ```
 
-#### Required permissions
+#### Required Permissions
 
-| Permission Name                 | Description          |
-|---------------------------------|----------------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforPostgreSQL:DbVersion.List | View DB Version List |
 
 #### Request
@@ -89,14 +76,16 @@ This API does not require a request body.
 
 #### Response
 
-| Name                         | Type | Format  | Description                                           |
-|------------------------------|------|---------|-------------------------------------------------------|
-| dbVersions                   | Body | Array   | DB version list                                       |
-| dbVersions.dbVersion         | Body | String  | DB version                                            |
-| dbVersions.dbVersionName     | Body | String  | DB version name                                       |
-| dbVersions.restorableFromObs | Body | Boolean | Restoring backup from object storage available or not |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| dbVersions | Body | Array | DB version information |
+| dbVersions.dbVersionCode | Body | Enum | DB version code<br/>- MYSQL_V5633<br/>- MYSQL_V5715<br/>- MYSQL_V5719<br/>- MYSQL_V5726<br/>- MYSQL_V5731<br/>- MYSQL_V5733<br/>- MYSQL_V5737<br/>- MYSQL_V8018<br/>- MYSQL_V8023<br/>- MYSQL_V8028<br/>- MYSQL_V8032<br/>- MYSQL_V8033<br/>- MYSQL_V8034<br/>- MYSQL_V8035<br/>- MYSQL_V8036<br/>- MYSQL_V8040<br/>- MYSQL_V8041<br/>- MYSQL_V8042<br/>- MYSQL_V8043<br/>- MYSQL_V8044<br/>- MYSQL_V8045<br/>- MYSQL_V8405<br/>- MYSQL_V8406<br/>- MYSQL_V8407<br/>- MYSQL_V8408<br/>- MYSQL_V8409<br/>- MARIADB_V10330<br/>- MARIADB_V10611<br/>- MARIADB_V10612<br/>- MARIADB_V10616<br/>- MARIADB_V10622<br/>- MARIADB_V10625<br/>- MARIADB_V101107<br/>- MARIADB_V101108<br/>- MARIADB_V101113<br/>- MARIADB_V101116<br/>- MARIADB_V11407<br/>- MARIADB_V11410<br/>- MARIADB_V11806<br/>- POSTGRESQL_V14_6<br/>- POSTGRESQL_V14_15<br/>- POSTGRESQL_V14_17<br/>- POSTGRESQL_V14_19<br/>- POSTGRESQL_V17_2<br/>- POSTGRESQL_V17_4<br/>- POSTGRESQL_V17_6 |
+| dbVersions.dbMajorVersionCode | Body | Enum | DB major version code<br/>- MYSQL_V56<br/>- MYSQL_V57<br/>- MYSQL_V80<br/>- MYSQL_V84<br/>- MARIADB_V103<br/>- MARIADB_V106<br/>- MARIADB_V1011<br/>- MARIADB_V114<br/>- MARIADB_V118<br/>- POSTGRES_V14<br/>- POSTGRES_V17 |
+| dbVersions.name | Body | String | DB version name |
+| dbVersions.canCreate | Body | Boolean | Whether new creation is available |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -107,14 +96,19 @@ This API does not require a request body.
     },
     "dbVersions": [
         {
-            "dbVersion": "POSTGRESQL_V17_6",
-            "dbVersionName": "PostgreSQL V17.6",
-            "restorableFromObs": true
+            "dbVersionCode": "MYSQL_V5633",
+            "dbMajorVersionCode": "MYSQL_V56",
+            "name": "PostgreSQL V14.6",
+            "canCreate": false
         }
     ]
 }
 ```
+
+</p>
 </details>
+
+---
 
 ## Specifications of DB Instance
 
@@ -124,10 +118,10 @@ This API does not require a request body.
 GET /v1.0/db-flavors
 ```
 
-#### Required permissions
+#### Required Permissions
 
-| Permission Name                            | Description               |
-|--------------------------------|------------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforPostgreSQL:DbFlavor.List | List DB Instance Specifications |
 
 #### Request
@@ -136,15 +130,16 @@ This API does not require a request body.
 
 #### Response
 
-| Name                     | Type   | Format     | Description              |
-|------------------------|------|--------|-----------------|
-| dbFlavors              | Body | Array  | List of DB instance specifications   |
-| dbFlavors.dbFlavorId   | Body | UUID   | Identifier of DB instance specifications |
-| dbFlavors.dbFlavorName | Body | String | Name of DB instance specifications   |
-| dbFlavors.ram          | Body | Number | Memory size (MB)      |
-| dbFlavors.vcpus        | Body | Number | CPU cores        |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| dbFlavors | Body | Array | List of DB instance specifications |
+| dbFlavors.dbFlavorId | Body | UUID | Identifier of DB instance specifications |
+| dbFlavors.dbFlavorName | Body | String | Name of DB instance specifications |
+| dbFlavors.ram | Body | Number | Memory size (MB) |
+| dbFlavors.vcpus | Body | Number | CPU cores |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -155,29 +150,33 @@ This API does not require a request body.
     },
     "dbFlavors": [
         {
-            "dbFlavorId": "50be6d9c-02d6-4594-a2d4-12010eb65ec0",
-            "dbFlavorName": "m2.c1m2",
-            "ram": 2048,
-            "vcpus": 1
+            "dbFlavorId": "289e34e9-cd8a-4baf-82e3-a3d013c5186b",
+            "dbFlavorName": "r2.c2m4",
+            "ram": 4096,
+            "vcpus": 2
         }
     ]
 }
 ```
+
+</p>
 </details>
+
+---
 
 ## Project Information
 
-### List Regions
+### List Project Members
 
 ```http
-GET /v1.0/project/regions
+GET /v1.0/project/members
 ```
 
-#### Required permissions
+#### Required Permissions
 
-| Permission Name                          | Description         |
-|------------------------------|------------|
-| RDSforPostgreSQL:Project.Get | Get project information |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:Project.Get | List Project Members |
 
 #### Request
 
@@ -185,13 +184,66 @@ This API does not require a request body.
 
 #### Response
 
-| Name                 | Type   | Format      | Description                           |
-|--------------------|------|---------|------------------------------|
-| regions            | Body | Array   | Region list                        |
-| regions.regionCode | Body | Enum    | Region code<br/>`KR1`: Korea (Pangyo) Region |
-| regions.isEnabled  | Body | Boolean | Whether to enable a region                   |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| projectMembers | Body | Array | Project member information |
+| projectMembers.memberId | Body | UUID | Project member identifier |
+| projectMembers.memberName | Body | String | Project member name |
+| projectMembers.emailAddress | Body | String | Project member email address |
+| projectMembers.phoneNumber | Body | String | Project member phone number |
 
 <details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "projectMembers": [
+        {
+            "memberId": "550e8400-e29b-41d4-a716-446655440000",
+            "memberName": "memberName-example",
+            "emailAddress": "user@example.com",
+            "phoneNumber": "010-1234-5678"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### List Regions
+
+```http
+GET /v1.0/project/regions
+```
+
+#### Required Permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:Project.Get | List Regions |
+
+#### Request
+
+This API does not require a request body.
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| regions | Body | Array | Region information |
+| regions.regionCode | Body | Enum | Region code<br/>- KR1: `Korea (Pangyo)`<br/>- KR2: `Korea (Pyeongchon)` |
+| regions.isEnabled | Body | Boolean | Whether the region is enabled |
+
+<details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -203,59 +255,16 @@ This API does not require a request body.
     "regions": [
         {
             "regionCode": "KR1",
-            "isEnabled": true
+            "isEnabled": false
         }
     ]
 }
 ```
+
+</p>
 </details>
 
-### List Project Members
-
-```http
-GET /v1.0/project/members
-```
-
-#### Required permissions
-
-| Permission Name                          | Description         |
-|------------------------------|------------|
-| RDSforPostgreSQL:Project.Get | Get project information |
-
-#### Request
-
-This API does not require a request body.
-
-#### Response
-
-| Name                   | Type   | Format     | Description              |
-|----------------------|------|--------|-----------------|
-| members              | Body | Array  | Project member list      |
-| members.memberId     | Body | UUID   | Project member identifier    |
-| members.memberName   | Body | String | Project member name     |
-| members.emailAddress | Body | String | Project member email address |
-| members.phoneNumber  | Body | String | Project member mobile   |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "members": [
-        {
-            "memberId": "1b1d3627-507a-49ea-8cb7-c86dfa9caa58",
-            "memberName": "Hong Gildong",
-            "emailAddress": "gildong.hong@nhn.com",
-            "phoneNumber": "+821012345678"
-        }
-    ]
-}
-```
-</details>
+---
 
 ## Network
 
@@ -265,10 +274,10 @@ This API does not require a request body.
 GET /v1.0/network/subnets
 ```
 
-#### Required permissions
+#### Required Permissions
 
-| Permission Name                           | Description        |
-|-------------------------------|-----------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforPostgreSQL:Network.List | List Subnets |
 
 #### Request
@@ -277,17 +286,17 @@ This API does not require a request body.
 
 #### Response
 
-| Name                       | Type   | Format      | Description               |
-|--------------------------|------|---------|------------------|
-| subnets                  | Body | Array   | Subnet list           |
-| subnets.subnetId         | Body | UUID    | Subnet identifier         |
-| subnets.subnetName       | Body | String  | Name to identify subnets |
-| subnets.subnetCidr       | Body | String  | CIDR of subnet        |
-| subnets.usingGateway     | Body | Boolean | Whether to use gateway      |
-| subnets.availableIpCount | Body | Number  | Number of available IPs      |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| subnets | Body | Array | Subnet information |
+| subnets.subnetId | Body | UUID | Subnet identifier |
+| subnets.subnetName | Body | String | Name to identify subnets |
+| subnets.subnetCidr | Body | String | Subnet CIDR |
+| subnets.usingGateway | Body | Boolean | Whether to use gateway |
+| subnets.availableIpCount | Body | Number | Number of available IPs |
 
-<details>
-<summary>Example</summary>
+<details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -298,30 +307,34 @@ This API does not require a request body.
     },
     "subnets": [
         {
-            "subnetId": "1b2a9b23-0725-4b92-8c78-35db66b8ad9f",
-            "subnetName": "Default Network",
+            "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+            "subnetName": "subnetName-example",
             "subnetCidr": "192.168.0.0/24",
-            "usingGateway": true,
-            "availableIpCount": 240
+            "usingGateway": false,
+            "availableIpCount": 1
         }
     ]
 }
 ```
+
+</p>
 </details>
+
+---
 
 ## Storage
 
-### View the list of storage types
+### View the List of Storage Types
 
 ```http
 GET /v1.0/storage-types
 ```
 
-#### Required permissions
+#### Required Permissions
 
-| Permission Name                           | Description            |
-|-------------------------------|---------------|
-| RDSforPostgreSQL:Storage.List | View the list of storage types |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:Storage.List | View the List of Storage Types |
 
 #### Request
 
@@ -329,11 +342,12 @@ This API does not require a request body.
 
 #### Response
 
-| Name           | Type   | Format    | Description         |
-|--------------|------|-------|------------|
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
 | storageTypes | Body | Array | List of storage types |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -348,43 +362,65 @@ This API does not require a request body.
     ]
 }
 ```
+
+</p>
 </details>
+
+---
 
 ## Task Information
 
-### List Task Details
+### Task Status
+
+| Status | Description |
+|--------------------|----------------------|
+| `PREPARING` | When the task is being prepared |
+| `READY` | When the task is ready |
+| `RUNNING` | When the task is in progress |
+| `COMPLETED` | When the task is complete |
+| `REGISTERED` | When the task is registered |
+| `WAIT_TO_REGISTER` | When the task is waiting to be registered |
+| `INTERRUPTED` | When an interrupt occurred while the task was in progress |
+| `CANCELED` | When the task is canceled |
+| `FAILED` | When the task has failed |
+| `ERROR` | When an error occurred while the task was in progress |
+| `DELETED` | When the task has been deleted |
+| `FAIL_TO_READY` | When the task failed to be ready |
+
+### View Task Details
 
 ```http
-GET /v3.0/jobs/{jobId}
+GET /v1.0/jobs/{jobId}
 ```
 
-#### Required permissions
+#### Required Permissions
 
-| Permission Name                      | Description          |
-|--------------------------|-------------|
-| RDSforPostgreSQL:Job.Get | List Task Details |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:Job.Get | View Task Details |
 
 #### Request
 
 This API does not require a request body.
 
-| Name    | Type  | Format   | Required | Description      |
-|-------|-----|------|----|---------|
-| jobId | URL | UUID | O  | Task identifier |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| jobId | URL | UUID | O |  |
 
 #### Response
 
-| Name                             | Type   | Format       | Description                                                                                                                                                                                                                                                                                                                                                                                                              |
-|--------------------------------|------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| jobId                          | Body | UUID     | Task identifier                                                                                                                                                                                                                                                                                                                                                                                                         |
-| jobStatus                      | Body | Enum     | Current task status<br/>- `PREPARING`: If the task is being prepared<br/>- `READY`: When the task is ready<br/>- `RUNNING`: If the task is in progress<br/>- `COMPLETED`: When the task is complete<br/>- `REGISTERED`: If the task is registered<br/>- `WAIT_TO_REGISTER`: If the job is waiting to be registered<br/>- `INTERRUPTED`: If an interrupt occurred while the operation was in progress.<br/>- `CANCELED`: If the task is canceled<br/>- `FAILED`: If the operation failed<br/>- `ERROR`: If an error occurred while the operation was in progress<br/>- `DELETED`: If the task has been deleted<br/>- `FAIL_TO_READY`: The job failed to be ready. |
-| resourceRelations              | Body | Array    | Relevant resource list                                                                                                                                                                                                                                                                                                                                                                                                       |
-| resourceRelations.resourceType | Body | Enum     | Relevant resource type<br/>- `DB_INSTANCE`: DB instance<br/>- `DB_INSTANCE_GROUP`: DB instance group<br/>- `DB_SECURITY_GROUP`: DB security group<br/>- `PARAMETER_GROUP`: Parameter Group<br/>- `BACKUP`: Backup<br/>- `TENANT`: Tenant                                                                                                                                                                                                                        |
-| resourceRelations.resourceId   | Body | UUID     | Relevant resource identifier                                                                                                                                                                                                                                                                                                                                                                                                     |
-| createdYmdt                    | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                                                                                                                                                                                                                                               |
-| updatedYmdt                    | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                                                                                                                                                                                                                                               |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Task identifier |
+| jobStatus | Body | Enum | Current task status<br/>- DELETED<br/>- CANNOT_PROGRESS<br/>- FAILED<br/>- ERROR<br/>- CANCELED<br/>- INTERRUPTED<br/>- COMPLETED<br/>- COMPLETED_WITH_ERROR<br/>- RUNNING<br/>- PREPARING<br/>- READY<br/>- CREATED<br/>- FAIL_TO_READY<br/>- REGISTERED<br/>- FAIL_TO_REGISTER<br/>- WAIT_TO_REGISTER |
+| resourceRelations | Body | Array | Related resource list |
+| resourceRelations.resourceType | Body | String | Related resource type |
+| resourceRelations.resourceId | Body | String | Related resource identifier |
+| createdYmdt | Body | DateTime | Created date and time |
+| updatedYmdt | Body | DateTime | Modified date and time |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -393,23 +429,26 @@ This API does not require a request body.
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c",
-    "jobStatus": "RUNNING",
+    "jobId": "550e8400-e29b-41d4-a716-446655440000",
+    "jobStatus": "DELETED",
     "resourceRelations": [
         {
-            "resourceType": "DB_INSTANCE",
-            "resourceId": "56b39dcf-65eb-47ec-9d4f-09f160ba2266"
+            "resourceType": "resourceType-example",
+            "resourceId": "resourceId-example"
         }
     ],
-    "createdYmdt": "2023-02-22T20:47:12+09:00",
-    "updatedYmdt": "2023-02-22T20:49:46+09:00"
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
+
+</p>
 </details>
 
+---
 ## DB Instance Group
 
-### List DB Instances
+### List DB Instance Groups
 
 ```http
 GET /v1.0/db-instance-groups
@@ -417,9 +456,9 @@ GET /v1.0/db-instance-groups
 
 #### Required permissions
 
-| Permission Name                                   | Description               |
-|---------------------------------------|------------------|
-| RDSforPostgreSQL:DbInstanceGroup.List | List DB Instances |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceGroup.List | List DB Instance Groups |
 
 #### Request
 
@@ -427,16 +466,17 @@ This API does not require a request body.
 
 #### Response
 
-| Name                                     | Type   | Format       | Description                                                          |
-|----------------------------------------|------|----------|-------------------------------------------------------------|
-| dbInstanceGroups                       | Body | Array    | DB instance groups                                               |
-| dbInstanceGroups.dbInstanceGroupId     | Body | UUID     | DB instance group identifier                                             |
-| dbInstanceGroups.dbInstanceGroupStatus | Body | Enum     | Current status of DB instance groups<br/>- `CREATED: Created`<br/>- `DELETED`: Deleted |
-| dbInstanceGroups.replicationType       | Body | Enum     | DB instance group replication type<br/>- `STANDALONE`: Standalone                    |
-| dbInstanceGroups.createdYmdt           | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                           |
-| dbInstanceGroups.updatedYmdt           | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                           |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| dbInstanceGroups | Body | Array | DB instance group information |
+| dbInstanceGroups.dbInstanceGroupId | Body | UUID | DB instance group identifier |
+| dbInstanceGroups.dbInstanceGroupStatus | Body | Enum | Current status of the DB instance group<br/>- CREATED: `Created`<br/>- DELETED: `Deleted` |
+| dbInstanceGroups.replicationType | Body | Enum | DB instance group replication type<br/>- STANDALONE: `High availability not used`<br/>- HIGH_AVAILABILITY: `High availability used` |
+| dbInstanceGroups.createdYmdt | Body | DateTime | Created date and time |
+| dbInstanceGroups.updatedYmdt | Body | DateTime | Modified date and time |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -447,17 +487,20 @@ This API does not require a request body.
     },
     "dbInstanceGroups": [
         {
-            "dbInstanceGroupId": "05de0746-89fd-49c8-94f9-9c5b1df97009",
+            "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
             "dbInstanceGroupStatus": "CREATED",
             "replicationType": "STANDALONE",
-            "createdYmdt": "2023-02-13T17:35:20+09:00",
-            "updatedYmdt": "2023-02-13T17:35:20+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
+
+</p>
 </details>
 
+---
 
 ### List DB Instance Group Details
 
@@ -467,33 +510,34 @@ GET /v1.0/db-instance-groups/{dbInstanceGroupId}
 
 #### Required permissions
 
-| Permission Name                                  | Description               |
-|--------------------------------------|------------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforPostgreSQL:DbInstanceGroup.Get | List DB Instance Group Details |
 
 #### Request
 
 This API does not require a request body.
 
-| Name                | Type  | Format   | Required | Description              |
-|-------------------|-----|------|----|-----------------|
-| dbInstanceGroupId | URL | UUID | O  | DB instance group identifier |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | O |  |
 
 #### Response
 
-| Name                           | Type   | Format       | Description                                                                                                                                    |
-|------------------------------|------|----------|---------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceGroupId            | Body | UUID     | DB instance group identifier                                                                                                                       |
-| dbInstanceGroupStatus        | Body | Enum     | Current status of DB instance groups<br/>- `CREATED: Created`<br/>- `DELETED`: Deleted                                                                           |
-| replicationType              | Body | Enum     | DB instance group replication type<br/>- `STANDALONE`: Standalone<br/>- `HIGH_AVAILABILITY`: High availability                                                              |
-| dbInstances                  | Body | Array    | DB instances belong to DB instance group                                                                                                             |
-| dbInstances.dbInstanceId     | Body | UUID     | DB instance identifier                                                                                                                          |
-| dbInstances.dbInstanceType   | Body | Enum     | DB instance role type<br/>- `MASTER`: Master<br/>- `FAILED_MASTER`: Failed over master<br/>- `CANDIDATE_MASTER`: Candidate master<br/>- `READ_ONLY_SLAVE`: Read replica |
-| dbInstances.dbInstanceStatus | Body | Enum     | DB instance current status                                                                                                                        |
-| createdYmdt                  | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-| updatedYmdt                  | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| dbInstanceGroupId | Body | UUID | DB instance group identifier |
+| dbInstanceGroupStatus | Body | Enum | Current status of the DB instance group<br/>- CREATED: `Created`<br/>- DELETED: `Deleted` |
+| replicationType | Body | Enum | DB instance group replication type<br/>- STANDALONE: `High availability not used`<br/>- HIGH_AVAILABILITY: `High availability used` |
+| dbInstances | Body | Array | List of DB instances belonging to the DB instance group |
+| dbInstances.dbInstanceId | Body | UUID | DB instance identifier |
+| dbInstances.dbInstanceType | Body | Enum | DB instance role type<br/>- MASTER: `Master`<br/>- FAILED_MASTER: `Failed over master`<br/>- CANDIDATE_MASTER: `Candidate master`<br/>- READ_ONLY_SLAVE: `Read replica` |
+| dbInstances.dbInstanceStatus | Body | Enum | Current status of the DB instance<br/>- BEFORE_CREATE: `Before creation (gray)`<br/>- AVAILABLE: `Available (green)`<br/>- STORAGE_FULL: `Insufficient storage (red)`<br/>- FAIL_TO_CREATE: `Failed to create (red)`<br/>- FAIL_TO_CONNECT: `Failed to connect (red)`<br/>- REPLICATION_STOP: `Replication stopped (red)`<br/>- REPLICATION_DELAY: `Replication delayed (yellow)`<br/>- FAILOVER: `Failover complete (red)`<br/>- SHUTDOWN: `Stopped (gray)`<br/>- DELETED: `Deleted (gray)` |
+| createdYmdt | Body | DateTime | Created date and time |
+| updatedYmdt | Body | DateTime | Modified date and time |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -502,24 +546,25 @@ This API does not require a request body.
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "dbInstanceGroupId": "36617a8e-0df8-4b16-b6ea-6306019e95da",
+    "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
     "dbInstanceGroupStatus": "CREATED",
     "replicationType": "STANDALONE",
     "dbInstances": [
         {
-            "dbInstanceId": "6d2db0ef-fe9b-4ed4-97b1-d97fcb4cf1b8",
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
             "dbInstanceType": "MASTER",
-            "dbInstanceStatus": "AVAILABLE"
+            "dbInstanceStatus": "BEFORE_CREATE"
         }
     ],
-    "createdYmdt": "2023-03-03T17:38:14+09:00",
-    "updatedYmdt": "2023-03-03T17:38:14+09:00"
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
+
+</p>
 </details>
 
-
-## DB Instance Group > Manage Extensions
+---
 
 ### View Extension List
 
@@ -527,38 +572,39 @@ This API does not require a request body.
 GET /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions
 ```
 
-#### Required Permission
+#### Required permissions
 
-| Permission name                                            | Description       |
-|------------------------------------------------|----------|
-| RDSforPostgreSQL:DbInstanceGroupExtension.List | View extension lists |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceGroupExtension.List | View Extension List |
 
 #### Request
 
 This API does not require a request body.
 
-| Name                | Type  | Format   | Required | Description              |
-|-------------------|-----|------|----|-----------------|
-| dbInstanceGroupId | URL | UUID | O  | Identifier of DB instance group |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | O | DB instance group ID |
 
 #### Response
 
-| Name                                                  | Type   | Format      | Description                                                                                                                                                                                              |
-|-----------------------------------------------------|------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| extensions                                          | Body | Array   | Extension list                                                                                                                                                                                           |
-| extensions.extensionId                              | Body | UUID    | Identifier of the extension                                                                                                                                                                                         |
-| extensions.extensionName                            | Body | String  | Extension name                                                                                                                                                                                           |
-| extensions.extensionStatus                          | Body | ENUM    | Extension status<br/>- `AVAILABLE`: available<br/>- `NEED_TO_APPLY`: need to apply<br/>- `APPLYING`: applying                                                                                                               |
-| extensions.databases                                | Body | Array   | Database information with installed extensions                                                                                                                                                                               |
-| extensions.databases.dbInstanceGroupExtensionId     | Body | UUID    | Identifier of an extension within a DB instance group                                                                                                                                                                            |
-| extensions.databases.dbInstanceGroupExtensionStatus | Body | ENUM    | Extension status within a DB instance group<br/>- `CREATED`: created<br/>- `INSTALLED`: installed<br/>- `INSTALLING`: installing<br/>- `INSTALL_ERROR`: installation error<br/>- `DELETED`: deleted<br/>- `DELETING`: deleting<br/>- `DELETE_ERROR`: deletion error |
-| extensions.databases.databaseId                     | Body | UUID    | Identifier of the database                                                                                                                                                                                     |
-| extensions.databases.databaseName                   | Body | String  | Database name                                                                                                                                                                                       |
-| extensions.databases.reservedAction                 | Body | ENUM    | Scheduled Task<br/>- `NONE`: none<br/>- `INSTALL`: scheduled installation (need to apply)<br/>- `INSTALL_WITH_CASCADE`: scheduled forced installation (need to apply)<br/>- `DELETE`: scheduled deletion (need to apply)<br/>- `DELETE_WITH_CASCADE`: scheduled forced deletion (need to apply)                |
-| extensions.databases.errorReason                    | Body | String  | Reason for Error                                                                                                                                                                                           |
-| isNeedToApply                                       | Body | Boolean | Whether to apply changes                                                                                                                                                                                  |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| extensions | Body | Array | Extension information |
+| extensions.extensionId | Body | UUID | Extension identifier |
+| extensions.extensionName | Body | String | Extension name |
+| extensions.extensionStatus | Body | Enum | Extension status<br/>- AVAILABLE: `Available`<br/>- NEED_TO_APPLY: `Need to apply`<br/>- APPLYING: `Applying` |
+| extensions.databases | Body | Array | Database information |
+| extensions.databases.dbInstanceGroupExtensionId | Body | UUID | Identifier of an extension within a DB instance group |
+| extensions.databases.databaseId | Body | UUID | Database identifier |
+| extensions.databases.databaseName | Body | String | Database name |
+| extensions.databases.dbInstanceGroupExtensionStatus | Body | Enum | Extension installation status within the database<br/>- CREATED: `Created`<br/>- INSTALLED: `Installed`<br/>- INSTALLING: `Installing`<br/>- INSTALL_ERROR: `Installation error`<br/>- DELETED: `Deleted`<br/>- DELETING: `Deleting`<br/>- DELETE_ERROR: `Deletion error` |
+| extensions.databases.reservedAction | Body | Enum | Scheduled task<br/>- NONE: `None`<br/>- INSTALL: `Scheduled installation (need to apply)`<br/>- INSTALL_WITH_CASCADE: `Scheduled forced installation (need to apply)`<br/>- DELETE: `Scheduled deletion (need to apply)`<br/>- DELETE_WITH_CASCADE: `Scheduled forced deletion (need to apply)` |
+| extensions.databases.errorReason | Body | String | Reason for error |
+| isNeedToApply | Body | Boolean | Whether changes need to be applied |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -569,108 +615,29 @@ This API does not require a request body.
     },
     "extensions": [
         {
-            "extensionId": "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4",
-            "extensionName": "address_standardizer",
+            "extensionId": "550e8400-e29b-41d4-a716-446655440000",
+            "extensionName": "extensionName-example",
             "extensionStatus": "AVAILABLE",
             "databases": [
                 {
-                    "dbInstanceGroupExtensionId": "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4",
-                    "databaseId": "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4",
-                    "databaseName": "database-1",
-                    "dbInstanceGroupExtensionStatus": "INSTALLED",
+                    "dbInstanceGroupExtensionId": "550e8400-e29b-41d4-a716-446655440000",
+                    "databaseId": "550e8400-e29b-41d4-a716-446655440000",
+                    "databaseName": "databaseName-example",
+                    "dbInstanceGroupExtensionStatus": "CREATED",
                     "reservedAction": "NONE",
-                    "errorReason": null
+                    "errorReason": "errorReason-example"
                 }
             ]
         }
     ],
-    "isNeedToApply": true
+    "isNeedToApply": false
 }
 ```
+
+</p>
 </details>
 
-
-### Install Extensions
-
-```http
-POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{extensionId}
-```
-
-#### Required Permission
-
-| Permission name                                               | Description    |
-|---------------------------------------------------|-------|
-| RDSforPostgreSQL:DbInstanceGroupExtension.Install | Install extensions |
-
-#### Request
-
-This API does not require a request body.
-
-| Name                | Type   | Format      | Required | Description                |
-|-------------------|------|---------|----|-------------------|
-| dbInstanceGroupId | URL  | UUID    | O  | Identifier of DB instance group   |
-| extensionId       | URL  | UUID    | O  | Identifier of the extension           |
-| databaseId        | Body | UUID    | O  | Identifier of the database to be installed |
-| schemaName        | Body | String  | O  | Name of the schema to be installed      |
-| withCascade       | Body | Boolean | X  | Whether to force installation of dependency information    |
-
-#### Response
-
-This API does not return a response body.
-
-<details><summary>Example</summary>
-
-```json
-{
-  "header": {
-    "resultCode": 0,
-    "resultMessage": "SUCCESS",
-    "isSuccessful": true
-  }
-}
-```
-</details>
-
-
-### Delete Extensions (Cancel)
-
-```http
-DELETE /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{dbInstanceGroupExtensionId}
-```
-
-#### Required Permission
-
-| Permission name                                              | Description        |
-|--------------------------------------------------|-----------|
-| RDSforPostgreSQL:DbInstanceGroupExtension.Delete | Delete extensions (cancel) |
-
-#### Request
-
-This API does not require a request body.
-
-| Name                         | Type    | Format      | Required | Description                   |
-|----------------------------|-------|---------|----|----------------------|
-| dbInstanceGroupId          | URL   | UUID    | O  | Identifier of DB instance group      |
-| dbInstanceGroupExtensionId | URL   | UUID    | O  | Identifier of the extension within the DB instance group |
-| withCascade                | Query | Boolean | O  | Whether to force installation of dependency information       |
-
-#### Response
-
-This API does not return a response body.
-
-<details><summary>Example</summary>
-
-```json
-{
-  "header": {
-    "resultCode": 0,
-    "resultMessage": "SUCCESS",
-    "isSuccessful": true
-  }
-}
-```
-</details>
-
+---
 
 ### Apply Extension Changes
 
@@ -678,40 +645,44 @@ This API does not return a response body.
 POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/apply
 ```
 
-#### Required Permission
+#### Required permissions
 
-| Permission name                                             | Description         |
-|-------------------------------------------------|------------|
-| RDSforPostgreSQL:DbInstanceGroupExtension.Apply | Apply extension changes |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceGroupExtension.Apply | Apply Extension Changes |
 
 #### Request
 
 This API does not require a request body.
 
-| Name                         | Type    | Format      | Required | Description                   |
-|----------------------------|-------|---------|----|----------------------|
-| dbInstanceGroupId          | URL   | UUID    | O  | Identifier of DB instance group      |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | O | DB instance group ID |
 
 #### Response
 
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | Identifier of the requested task |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
-  "header": {
-    "resultCode": 0,
-    "resultMessage": "SUCCESS",
-    "isSuccessful": true
-  },
-  "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
+---
 
 ### Synchronize Extensions
 
@@ -719,97 +690,162 @@ This API does not require a request body.
 POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/sync
 ```
 
-#### Required Permission
+#### Required permissions
 
-| Permission name                                            | Description     |
-|------------------------------------------------|--------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforPostgreSQL:DbInstanceGroupExtension.Sync | Synchronize Extensions |
 
 #### Request
 
 This API does not require a request body.
 
-| Name                         | Type    | Format      | Required | Description                   |
-|----------------------------|-------|---------|----|----------------------|
-| dbInstanceGroupId          | URL   | UUID    | O  | Identifier of DB instance group      |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | O | DB instance group ID |
 
 #### Response
 
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | Identifier of the requested task |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
-  "header": {
-    "resultCode": 0,
-    "resultMessage": "SUCCESS",
-    "isSuccessful": true
-  },
-  "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
+---
 
+### Delete Extension (Cancel)
+
+```http
+DELETE /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{dbInstanceGroupExtensionId}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceGroupExtension.Delete | Delete Extension (Cancel) |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | O | DB instance group ID |
+| dbInstanceGroupExtensionId | URL | UUID | O | Identifier of the extension within the DB instance group |
+| withCascade | Query | Boolean | O | Whether to force deletion |
+
+#### Response
+
+This API does not return a response body.
+
+---
+
+### Install Extension
+
+```http
+POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{extensionId}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceGroupExtension.Install | Install Extension |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | O | DB instance group ID |
+| extensionId | URL | UUID | O | Extension identifier |
+| databaseId | Body | UUID | O | Database identifier |
+| schemaName | Body | String | O | Schema name |
+| withCascade | Body | Boolean | X | Whether to automatically install dependencies<br/>- Default: `false` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "databaseId": "550e8400-e29b-41d4-a716-446655440000",
+    "schemaName": "schemaName-example",
+    "withCascade": false
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+This API does not return a response body.
+
+---
 ## DB Instance
 
 ### DB Instance Status
 
-| Status                  | Description                          |
-|---------------------|-----------------------------|
-| `AVAILABLE`         | DB instance is available          |
-| `BEFORE_CREATE`     | Before creating a DB instance           |
-| `STORAGE_FULL`      | Insufficient DB instance storage         |
-| `FAIL_TO_CREATE`    | Failed to create DB instance          |
-| `FAIL_TO_CONNECT`   | Failed to connect DB instance          |
-| `REPLICATION_STOP`  | Replication of DB instance is stopped         |
-| `REPLICATION_DELAY` | When replication of a DB instance is delayed       |
-| `FAILOVER`          | When failover of a highly available DB instance is complete |
-| `SHUTDOWN`          | DB instance is stopped             |
-| `DELETED`           | DB instance is deleted             |
+| Status                  | Description                           |
+|---------------------|-------------------------------|
+| `AVAILABLE`         | DB instance is available           |
+| `BEFORE_CREATE`     | Before creating a DB instance            |
+| `STORAGE_FULL`      | Insufficient DB instance storage          |
+| `FAIL_TO_CREATE`    | Failed to create DB instance           |
+| `FAIL_TO_CONNECT`   | Failed to connect DB instance           |
+| `REPLICATION_STOP`  | Replication of DB instance is stopped          |
+| `FAILOVER`          | When failover of a highly available DB instance is complete       |
+| `SHUTDOWN`          | DB instance is stopped               |
+| `DELETED`           | DB instance is deleted               |
 
 ### DB Instance Progress Status
 
-| Status                              | Description             |
-|---------------------------------|----------------|
-| `APPLYING_DB_INSTANCE_HBA_RULE` | Applying an access control rule  |
-| `APPLYING_PARAMETER_GROUP`      | Parameter group is being applied   |
-| `APPLYING_EXTENSION`            | Applying an extension        |
-| `BACKING_UP`                    | Backing up           |
-| `CANCELING`                     | Canceling           |
-| `CREATING`                      | Creating           |
-| `CREATING_DATABASE`             | Creating a database	   |
-| `CREATING_USER`                 | Creating user	      |
-| `DELETING`                      | Deleting           |
-| `DELETING_DATABASE`             | Deleting a database    |
-| `DELETING_USER`                 | Deleting user       |
-| `EXPORTING_BACKUP`              | Exporting a backup     |
-| `FAILING_OVER`                  | Under failover        |
-| `MIGRATING`                     | Under migration       |
-| `MODIFYING`                     | Under modification           |
-| `OCCUPIED`                      | Occupied           |
-| `PREPARING`                     | In preparation           |
-| `PROMOTING`                     | Promoting           |
-| `PROMOTING_FORCIBLY`            | Force Promoting        |
-| `REBUILDING`                    | Rebuilding          |
-| `REPAIRING`                     | Recovering           |
-| `REPLICATING`                   | Replicating           |
-| `RESTARTING`                    | Restarting          |
-| `RESTARTING_FORCIBLY`           | Force restarting       |
-| `RESTORING`                     | Restoring           |
-| `STARTING`                      | Starting           |
-| `STOPPING`                      | Stopping           |
-| `SYNCING_DATABASE`              | Synchronizing the database   |
-| `SYNCING_USER`                  | Synchronizing user	     |
-| `SYNCING_EXTENSION`             | Synchronizing extensions	      |
-| `UPDATING_USER`                 | Modifying user	      |
-| `UPDATING_DATABASE`             | Modifying the database	   |
-| `WAIT_MANUAL_CONTROL`           | Waiting for manual failover	 |
+| Status                       | Description            |
+|----------------------------|--------------|
+| `APPLYING_PARAMETER_GROUP` | Parameter group is being applied |
+| `BACKING_UP`               | Backing up          |
+| `CANCELING`                | Canceling          |
+| `CREATING`                 | Creating          |
+| `CREATING_SCHEMA`          | Creating a schema  |
+| `CREATING_USER`            | Creating user      |
+| `DELETING`                 | Deleting          |
+| `DELETING_SCHEMA`          | Deleting a schema  |
+| `DELETING_USER`            | Deleting user      |
+| `EXPORTING_BACKUP`         | Exporting a backup   |
+| `FAILING_OVER`             | Under failover      |
+| `MIGRATING`                | Under migration       |
+| `MODIFYING`                | Under modification           |
+| `PREPARING`                | In preparation           |
+| `PROMOTING`                | Promoting           |
+| `REBUILDING`               | Rebuilding          |
+| `REPAIRING`                | Recovering           |
+| `REPLICATING`              | Replicating           |
+| `RESTARTING`               | Restarting          |
+| `RESTARTING_FORCIBLY`      | Force restarting       |
+| `RESTORING`                | Restoring           |
+| `STARTING`                 | Starting           |
+| `STOPPING`                 | Stopping           |
+| `SYNCING_SCHEMA`           | Synchronizing the schema   |
+| `SYNCING_USER`             | Synchronizing user     |
+| `UPDATING_USER`            | Modifying user      |
 
-### List DB instances
+### List DB Instances
 
 ```http
 GET /v1.0/db-instances
@@ -817,8 +853,8 @@ GET /v1.0/db-instances
 
 #### Required permissions
 
-| Permission Name                              | Description            |
-|----------------------------------|---------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforPostgreSQL:DbInstance.List | List DB instances |
 
 #### Request
@@ -827,22 +863,23 @@ This API does not require a request body.
 
 #### Response
 
-| Name                            | Type   | Format       | Description                                                                                                                                    |
-|-------------------------------|------|----------|---------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstances                   | Body | Array    | DB instances                                                                                                                            |
-| dbInstances.dbInstanceId      | Body | UUID     | DB instance identifier                                                                                                                          |
-| dbInstances.dbInstanceGroupId | Body | UUID     | DB instance group identifier                                                                                                                       |
-| dbInstances.dbInstanceName    | Body | String   | Name to identify DB instances                                                                                                                  |
-| dbInstances.description       | Body | String   | Additional information on DB instances                                                                                                                     |
-| dbInstances.dbVersion         | Body | Enum     | DB version information                                                                                                                              |
-| dbInstances.dbPort            | Body | Number   | DB port                                                                                                                                 |
-| dbInstances.dbInstanceType    | Body | Enum     | DB instance role type<br/>- `MASTER`: Master<br/>- `FAILED_MASTER`: Failed over master<br/>- `CANDIDATE_MASTER`: Candidate master<br/>- `READ_ONLY_SLAVE`: Read replica |
-| dbInstances.dbInstanceStatus  | Body | Enum     | DB instance current status                                                                                                                        |
-| dbInstances.progressStatus    | Body | Enum     | DB instance current status                                                                                                                     |
-| dbInstances.createdYmdt       | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-| dbInstances.updatedYmdt       | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| dbInstances | Body | Array | DB instances |
+| dbInstances.dbInstanceId | Body | UUID | DB instance identifier |
+| dbInstances.dbInstanceGroupId | Body | UUID | DB instance group identifier |
+| dbInstances.dbInstanceName | Body | String | Name to identify DB instances |
+| dbInstances.description | Body | String | Additional information on DB instances |
+| dbInstances.dbVersion | Body | Enum | DB version information |
+| dbInstances.dbPort | Body | Number | DB port |
+| dbInstances.dbInstanceType | Body | Enum | DB instance role type<br/>- MASTER: `Master`<br/>- FAILED_MASTER: `Failed over master`<br/>- CANDIDATE_MASTER: `Candidate master`<br/>- READ_ONLY_SLAVE: `Read replica` |
+| dbInstances.dbInstanceStatus | Body | Enum | DB instance current status<br/>- BEFORE_CREATE: `Before creating (gray)`<br/>- AVAILABLE: `Available (green)`<br/>- STORAGE_FULL: `Insufficient storage (red)`<br/>- FAIL_TO_CREATE: `Failed to create (red)`<br/>- FAIL_TO_CONNECT: `Failed to connect (red)`<br/>- REPLICATION_STOP: `Replication stopped (red)`<br/>- REPLICATION_DELAY: `Replication delayed (yellow)`<br/>- FAILOVER: `Failover complete (red)`<br/>- SHUTDOWN: `Stopped (gray)`<br/>- DELETED: `Deleted (gray)` |
+| dbInstances.progressStatus | Body | String | DB instance current progress status |
+| dbInstances.createdYmdt | Body | DateTime | Created date and time |
+| dbInstances.updatedYmdt | Body | DateTime | Modified date and time |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -853,98 +890,26 @@ This API does not require a request body.
     },
     "dbInstances": [
         {
-            "dbInstanceId": "d067593b-1acc-4ccc-9e8a-cc72d6d79ec3",
-            "dbInstanceGroupId": "51c7d080-ff36-4025-84b1-9d9d0b4fe9e0",
-            "dbInstanceName": "db-instance",
-            "description": null,
-            "dbVersion": "POSTGRESQL_V17_6",
-            "dbPort": 15432,
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbInstanceName": "dbInstanceName-example",
+            "description": "description-example",
+            "dbVersion": "POSTGRESQL_V14_17",
+            "dbPort": 1,
             "dbInstanceType": "MASTER",
-            "dbInstanceStatus": "AVAILABLE",
-            "progressStatus": "NONE",
-            "createdYmdt": "2023-01-23T12:03:13+09:00",
-            "updatedYmdt": "2023-02-02T17:20:17+09:00"
+            "dbInstanceStatus": "BEFORE_CREATE",
+            "progressStatus": "progressStatus-example",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
+
+</p>
 </details>
 
-
-### List DB Instance Details
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}
-```
-
-#### Required permissions
-
-| Permission Name                             | Description            |
-|---------------------------------|---------------|
-| RDSforPostgreSQL:DbInstance.Get | List DB Instance Details |
-
-#### Request
-
-This API does not require a request body.
-
-| Name           | Type  | Format   | Required | Description           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB instance identifier |
-
-#### Response
-
-| Name                        | Type   | Format       | Description                                                                                                                                    |
-|---------------------------|------|----------|---------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId              | Body | UUID     | DB instance identifier                                                                                                                          |
-| dbInstanceGroupId         | Body | UUID     | DB instance group identifier                                                                                                                       |
-| dbInstanceName            | Body | String   | Name to identify DB instances                                                                                                                  |
-| description               | Body | String   | Additional information on DB instances                                                                                                                     |
-| dbVersion                 | Body | Enum     | DB version information                                                                                                                              |
-| dbPort                    | Body | Number   | DB port                                                                                                                                 |
-| dbInstanceType            | Body | Enum     | DB instance role type<br/>- `MASTER`: Master<br/>- `FAILED_MASTER`: Failed over master<br/>- `CANDIDATE_MASTER`: Candidate master<br/>- `READ_ONLY_SLAVE`: Read replica |
-| dbInstanceStatus          | Body | Enum     | DB instance current status                                                                                                                        |
-| progressStatus            | Body | Enum     | Current task status of DB instance                                                                                                                  |
-| dbFlavorId                | Body | UUID     | Identifier of DB instance specifications                                                                                                                       |
-| parameterGroupId          | Body | UUID     | Parameter group identifier applied to DB instance                                                                                                             |
-| dbSecurityGroupIds        | Body | Array    | DB security group identifiers applied to DB instance                                                                                                         |
-| notificationGroupIds      | Body | Array    | List of identifiers of notification groups applied to the DB instance                                                                                                            |
-| useDeletionProtection     | Body | Boolean  | Whether to protect DB instance against deletion                                                                                                                      |
-| needToApplyParameterGroup | Body | Boolean  | Need to apply the latest parameter group                                                                                                                   |
-| needMigration             | Body | Boolean  | Need to migrate                                                                                                                          |
-| osVersion                 | Body | String   | OS Version                                                                                                                               |
-| createdYmdt               | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-| updatedYmdt               | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceId": "d067593b-1acc-4ccc-9e8a-cc72d6d79ec3",
-    "dbInstanceGroupId": "51c7d080-ff36-4025-84b1-9d9d0b4fe9e0",
-    "dbInstanceName": "db-instance",
-    "description": null,
-    "dbVersion": "POSTGRESQL_V17_6",
-    "dbPort": 15432,
-    "dbInstanceType": "MASTER",
-    "dbInstanceStatus": "AVAILABLE",
-    "progressStatus": "NONE",
-    "dbFlavorId": "e9ed4ef6-78d7-46fa-ace9-32481e97f3b7",
-    "parameterGroupId": "b03e8b13-de27-4d04-a488-ff5689589372",
-    "dbSecurityGroupIds": ["01908c35-d2c9-4852-baf0-17f06ec42c03"],
-    "notificationGroupIds": ["83a62a33-ddbf-4a04-8653-e54463d5b1ac"],
-    "useDeletionProtection": false,
-    "needToApplyParameterGroup": false,
-    "needMigration": false,
-    "createdYmdt": "2022-11-23T12:03:13+09:00",
-    "updatedYmdt": "2022-12-02T17:20:17+09:00"
-}
-```
-</details>
+---
 
 ### Create DB Instance
 
@@ -954,62 +919,70 @@ POST /v1.0/db-instances
 
 #### Required permissions
 
-| Permission Name                                | Description           |
-|------------------------------------|--------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforPostgreSQL:DbInstance.Create | Create DB Instance |
 
 #### Request
 
-| Name                                       | Type   | Format      | Required | Description                                                                                                                                                                                                                   |
-|------------------------------------------|------|---------|----|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceName                           | Body | String  | O  | Name to identify DB instances                                                                                                                                                                                                 |
-| description                              | Body | String  | X  | Additional information on DB instances                                                                                                                                                                                                    |
-| dbFlavorId                               | Body | UUID    | O  | Identifier of DB instance specifications                                                                                                                                                                                                      |
-| dbVersion                                | Body | Enum    | O  | DB version information                                                                                                                                                                                                             |
-| dbPort                                   | Body | Number  | O  | DB port<br/>- Minimum value: `0`<br/>- Maximum value: 65535                                                                                                                                                                           |
-| databaseName                             | Body | String  | O  | Name of the new database to create in the DB Engine                                                                                                                                                                                               |
-| dbUserName                               | Body | String  | O  | New user account name to create in DB Engine                                                                                                                                                                                               |
-| dbPassword                               | Body | String  | O  | Password for the new user account to be created in the DB Engine<br/>- Minimum length: `4`<br/>- Maximum length: `16`                                                                                                                                                          |
-| parameterGroupId                         | Body | UUID    | O  | Parameter group identifier                                                                                                                                                                                                         |
-| dbSecurityGroupIds                       | Body | Array   | X  | DB security group identifiers                                                                                                                                                                                                     |
-| useDeletionProtection                    | Body | Boolean | X  | Whether to protect against deletion<br/>Default: `false`                                                                                                                                                                                          |
-| useDefaultNotification                   | Body | Boolean | X  | Whether to use default notification<br/>Default: `false`                                                                                                                                                                                       |
-| useHighAvailability                      | Body | Boolean | X  | Whether to use high availability                                                                                                                                                                                                           |
-| pingInterval                             | Body | Number  | X  | Ping interval (sec) when using high availability<br/>- Minimum value: `1`<br/>- Maximum value: `600`                                                                                                                                                                 |
-| failoverReplWaitingTime                  | Body | Number  | X  | Failover latency when using high availability<br/>- Minimum value: `0`<br/>- If set to -1, it will continue to wait for the replication delay to resolve.                                                                                                                                         |                                                                                                                                                                                                                      | userGroupIds                             | Body | Array   | X  | List of identifiers for user groups that receive default notifications                                                                                                                                                                                             |
-| network                                  | Body | Object  | O  | Network information objects                                                                                                                                                                                                           |
-| network.subnetId                         | Body | UUID    | O  | Subnet identifier                                                                                                                                                                                                             |
-| network.usePublicAccess                  | Body | Boolean | X  | External access is available or not<br/>Default: `false`                                                                                                                                                                                      |
-| network.availabilityZone                 | Body | Enum    | X  | Availability zone where DB instance will be created<br/>- Example: `kr-pub-a`<br/>- Default: `Any availability` zone                                                                                                                                                     |
-| storage                                  | Body | Object  | O  | Storage information objects                                                                                                                                                                                                           |    
-| storage.storageType                      | Body | Enum    | O  | Data storage types<br/>- Example: `General SSD`                                                                                                                                                                                  |
-| storage.storageSize                      | Body | Number  | O  | Block Storage Size (GB)<br/>- Minimum value: `20`<br/>- Maximum value: `2048`                                                                                                                                                                    |
-| backup                                   | Body | Object  | O  | Backup information objects                                                                                                                                                                                                             |
-| backup.backupPeriod                      | Body | Number  | O  | Backup retention period<br/>- Minimum value: `0`<br/>- Maximum value: `730`                                                                                                                                                                          |
-| backup.backupRetryCount                  | Body | Number  | X  | Number of backup retries<br/>Default: `6`<br/>- Minimum value: `0`<br/>- Maximum value: `10`                                                                                                                                                              |
-| backup.backupSchedules                   | Body | Array   | X  | Backup schedules                                                                                                                                                                                                            |
-| backup.backupSchedules.backupWndBgnTime  | Body | String  | O  | Backup Start Time<br/>- Example: `00:00:00`                                                                                                                                                                                        |
-| backup.backupSchedules.backupWndDuration | Body | Enum    | O  | Backup Window<br/>Auto backup is executed within the set duration from the backup start time.<br/>- `HALF_AN_HOUR`: 30 minutes<br/>- `ONE_HOUR`: 1 hour<br/>- `ONE_HOUR_AND_HALF`: 1.5 hour<br/>- `TWO_HOURS`: 2 hour<br/>- `TWO_HOURS_AND_HALF`: 2.5 hour<br/>- `THREE_HOURS`: 3 hour |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceName | Body | String | O | Name to identify DB instances |
+| dbInstanceCandidateName | Body | String | X | Name to identify the candidate master of the DB instance |
+| description | Body | String | X | Additional information on DB instances |
+| dbFlavorId | Body | UUID | O | Identifier of DB instance specifications |
+| dbVersion | Body | Enum | O | DB version information |
+| dbPort | Body | Number | O | DB port<br/>- Minimum value: 5432, Maximum value: 45432 |
+| databaseName | Body | String | O | Database name |
+| dbUserName | Body | String | O | DB user account name |
+| dbPassword | Body | String | O | DB user account password |
+| parameterGroupId | Body | UUID | O | Parameter group identifier |
+| dbSecurityGroupIds | Body | Array | X | List of DB security group identifiers |
+| userGroupIds | Body | Array | X | List of user group identifiers |
+| useHighAvailability | Body | Boolean | X | Whether to use high availability<br/>- Default: `false` |
+| useDefaultNotification | Body | Boolean | X | Whether to use default notification<br/>- Default: `false` |
+| useDeletionProtection | Body | Boolean | X | Whether to enable deletion protection<br/>- Default: `false` |
+| pingInterval | Body | Number | X | Ping interval (sec)<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
+| failoverReplWaitingTime | Body | Number | X | Failover replication delay waiting time (sec)<br/>- Minimum value: `-1` |
+| network | Body | Object | O | Network information objects |
+| network.subnetId | Body | UUID | O | Subnet identifier |
+| network.usePublicAccess | Body | Boolean | X | External access is available or not<br/>- Default: `false` |
+| network.availabilityZone | Body | Enum | X | Availability zone where DB instance will be created |
+| storage | Body | Object | O | Storage information objects |
+| storage.storageType | Body | Enum | O | Data storage type |
+| storage.storageSize | Body | Number | O | Block storage size (GB)<br/>- Minimum value: `20` |
+| backup | Body | Object | O | Backup information objects |
+| backup.backupPeriod | Body | Number | O | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| backup.backupRetryCount | Body | Number | X | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| backup.backupSchedules | Body | Array | O | Backup schedule information |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | O | Backup start time |
+| backup.backupSchedules.backupWndDuration | Body | Enum | O | Backup window<br/>Auto backup is executed within the set duration from the backup start time.<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hours`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2.5 hours`<br/>- THREE_HOURS: `3 hours` |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbVersion": "POSTGRESQL_V17_6",
-    "dbPort": 15432,
-    "databaseName": "database",
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
+    "dbInstanceName": "dbInstanceName-example",
+    "dbInstanceCandidateName": "dbInstanceCandidateName-example",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbVersion": "POSTGRESQL_V14_17",
+    "dbPort": 1,
+    "databaseName": "databaseName-example",
+    "dbUserName": "dbUserName-example",
+    "dbPassword": "dbPassword-example",
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
     "userGroupIds": [],
+    "useHighAvailability": false,
+    "useDefaultNotification": false,
+    "useDeletionProtection": false,
+    "pingInterval": 1,
+    "failoverReplWaitingTime": 1,
     "network": {
-        "subnetId": "e721a9dd-dad0-4cf0-a53b-dd654ebfc683",
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
         "availabilityZone": "kr-pub-a"
     },
     "storage": {
@@ -1017,26 +990,29 @@ POST /v1.0/db-instances
         "storageSize": 20
     },
     "backup": {
-        "backupPeriod": 1,
+        "backupPeriod": 0,
+        "backupRetryCount": 0,
         "backupSchedules": [
             {
                 "backupWndBgnTime": "00:00:00",
-                "backupWndDuration": "ONE_HOUR_AND_HALF",
-                "backupRetryExpireTime": "01:30:00"
+                "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
     }
 }
 ```
+
+</p>
 </details>
 
 #### Response
 
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | Identifier of requested task |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -1045,10 +1021,273 @@ POST /v1.0/db-instances
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
+
+---
+### Restore DB Instance from Backup in Object Storage
+
+```http
+POST /v1.0/db-instances/restore-from-obs
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.RestoreFromObs | Restore DB Instance from Backup in Object Storage |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceName | Body | String | X | Name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| dbInstanceCandidateName | Body | String | X | Candidate master name to identify the DB instance |
+| description | Body | String | X | Additional information on DB instances<br/>- Maximum length: `100` |
+| dbFlavorId | Body | UUID | O | Identifier of DB instance specifications |
+| dbPort | Body | Number | X | DB port<br/>- Minimum value: 5432, Maximum value: 45432 |
+| dbVersion | Body | Enum | O | DB engine type |
+| useHighAvailability | Body | Boolean | X | Whether to use high availability<br/>- Default: `false` |
+| imageId | Body | UUID | X | Image identifier |
+| pingInterval | Body | Number | X | Ping interval (sec) when using high availability<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
+| failoverReplWaitingTime | Body | Number | X | Failover replication delay waiting time (sec)<br/>- Minimum value: `-1` |
+| storage | Body | Object | O | Storage information object |
+| storage.storageType | Body | Enum | O | Storage type |
+| storage.storageSize | Body | Number | O | Data storage size (GB)<br/>- Minimum value: `20` |
+| network | Body | Object | O | Network information object |
+| network.subnetId | Body | UUID | O | Subnet identifier |
+| network.usePublicAccess | Body | Boolean | X | External access availability<br/>- Default: `false` |
+| network.availabilityZone | Body | Enum | X | Availability zone where DB instance will be created |
+| backup | Body | Object | O | Backup information object |
+| backup.backupPeriod | Body | Number | O | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| backup.backupRetryCount | Body | Number | X | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| backup.replicationRegion | Body | Enum | X | Backup replication region<br/>- KR1: `Korea (Pangyo)`<br/>- KR2: `Korea (Pyeongchon)` |
+| backup.backupSchedules | Body | Array | O | Backup schedule list |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | O | Backup start time |
+| backup.backupSchedules.backupWndDuration | Body | Enum | O | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1 hour 30 minutes`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2 hours 30 minutes`<br/>- THREE_HOURS: `3 hours` |
+| restore | Body | Object | O | Restoration information object |
+| restore.tenantId | Body | String | O | Tenant ID of the object storage where the backup is stored |
+| restore.username | Body | String | O | NHN Cloud account or IAM member ID |
+| restore.password | Body | String | O | API password for the object storage where the backup is stored |
+| restore.targetContainer | Body | String | O | Container of the object storage where the backup is stored |
+| restore.objectPath | Body | String | O | Path of the backup stored in the container |
+| useDefaultNotification | Body | Boolean | X | Whether to use default notifications<br/>- Default: `false` |
+| parameterGroupId | Body | UUID | O | Parameter group identifier |
+| dbSecurityGroupIds | Body | Array | X | List of DB security group identifiers |
+| userGroupIds | Body | Array | X | List of user group identifiers |
+| useDeletionProtection | Body | Boolean | X | Whether deletion protection is enabled<br/>- Default: `false` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName",
+    "dbInstanceCandidateName": "dbInstanceCandidateName-example",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "dbVersion": "POSTGRESQL_V14_17",
+    "useHighAvailability": false,
+    "imageId": "550e8400-e29b-41d4-a716-446655440000",
+    "pingInterval": 3,
+    "failoverReplWaitingTime": 60,
+    "storage": {
+        "storageType": "General SSD",
+        "storageSize": 20
+    },
+    "network": {
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
+        "availabilityZone": "kr-pub-a"
+    },
+    "backup": {
+        "backupPeriod": 0,
+        "backupRetryCount": 0,
+        "replicationRegion": "KR1",
+        "backupSchedules": [
+            {
+                "backupWndBgnTime": "00:00:00",
+                "backupWndDuration": "HALF_AN_HOUR"
+            }
+        ]
+    },
+    "restore": {
+        "tenantId": "0123456789abcdef0123456789abcdef",
+        "username": "username-example",
+        "password": "password-example",
+        "targetContainer": "targetContainer-example",
+        "objectPath": "objectPath-example"
+    },
+    "useDefaultNotification": false,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useDeletionProtection": false
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Delete DB Instance
+
+```http
+DELETE /v1.0/db-instances/{dbInstanceId}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Delete | Delete DB Instance |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### List DB Instance Details
+
+```http
+GET /v1.0/db-instances/{dbInstanceId}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Get | List DB Instance Details |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| dbInstanceId | Body | UUID | DB instance identifier |
+| dbInstanceGroupId | Body | UUID | DB instance group identifier |
+| dbInstanceName | Body | String | Name to identify DB instances |
+| description | Body | String | Additional information on DB instances |
+| dbVersion | Body | Enum | DB engine type |
+| dbPort | Body | Number | DB port |
+| dbInstanceType | Body | Enum | DB instance role type<br/>- MASTER: `Master`<br/>- FAILED_MASTER: `Failed over master`<br/>- CANDIDATE_MASTER: `Candidate master`<br/>- READ_ONLY_SLAVE: `Read replica` |
+| dbInstanceStatus | Body | Enum | DB instance current status<br/>- BEFORE_CREATE: `Before creation (gray)`<br/>- AVAILABLE: `Available (green)`<br/>- STORAGE_FULL: `Storage full (red)`<br/>- FAIL_TO_CREATE: `Failed to create (red)`<br/>- FAIL_TO_CONNECT: `Failed to connect (red)`<br/>- REPLICATION_STOP: `Replication stopped (red)`<br/>- REPLICATION_DELAY: `Replication delayed (yellow)`<br/>- FAILOVER: `Failover completed (red)`<br/>- SHUTDOWN: `Stopped (gray)`<br/>- DELETED: `Deleted (gray)` |
+| progressStatus | Body | String | Current task status of DB instance |
+| dbFlavorId | Body | UUID | Identifier of DB instance specifications |
+| parameterGroupId | Body | UUID | Identifier of the parameter group applied to the DB instance |
+| dbSecurityGroupIds | Body | Array | List of DB security group identifiers applied to the DB instance |
+| notificationGroupIds | Body | Array | List of identifiers of notification groups applied to the DB instance |
+| useDeletionProtection | Body | Boolean | Whether deletion protection is enabled for the DB instance |
+| needToApplyParameterGroup | Body | Boolean | Whether the latest parameter group needs to be applied |
+| needMigration | Body | Boolean | Whether migration is required |
+| osVersion | Body | String | OS version |
+| createdYmdt | Body | DateTime | Created date and time |
+| updatedYmdt | Body | DateTime | Modified date and time |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbInstanceName": "dbInstanceName-example",
+    "description": "description-example",
+    "dbVersion": "POSTGRESQL_V14_17",
+    "dbPort": 1,
+    "dbInstanceType": "MASTER",
+    "dbInstanceStatus": "BEFORE_CREATE",
+    "progressStatus": "progressStatus-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [
+        "550e8400-e29b-41d4-a716-446655440000"
+    ],
+    "notificationGroupIds": [
+        "550e8400-e29b-41d4-a716-446655440000"
+    ],
+    "useDeletionProtection": false,
+    "needToApplyParameterGroup": false,
+    "needMigration": false,
+    "osVersion": "osVersion-example",
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+```
+
+</p>
+</details>
+
+---
 
 ### Modify DB Instance
 
@@ -1058,43 +1297,59 @@ PUT /v1.0/db-instances/{dbInstanceId}
 
 #### Required permissions
 
-| Permission Name                                | Description           |
-|------------------------------------|--------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforPostgreSQL:DbInstance.Modify | Modify DB Instance |
 
 #### Request
 
-| Name                 | Type   | Format      | Required | Description                                                                        |
-|--------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId       | URL  | UUID    | O  | DB instance identifier                                                              |
-| dbInstanceName     | Body | String  | X  | Name to identify DB instances                                                      |
-| description        | Body | String  | X  | Additional information on DB instances                                                         |
-| dbPort             | Body | Number  | X  | DB port<br/>- Minimum value: `0`<br/>- Maximum value: 65535                                |
-| dbFlavorId         | Body | UUID    | X  | Identifier of DB instance specifications                                                           |
-| parameterGroupId   | Body | UUID    | X  | Parameter group identifier                                                              |
-| dbSecurityGroupIds | Body | Array   | X  | DB security group identifiers                                                          |
-| executeBackup      | Body | Boolean | X  | Whether to execute backup at this time<br/>Default: `false`                                         |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceName | Body | String | X | Name to identify DB instances |
+| dbInstanceCandidateName | Body | String | X | Candidate master name to identify the DB instance |
+| description | Body | String | X | Additional information on DB instances<br/>- Maximum length: `100` |
+| dbPort | Body | Number | X | DB port<br/>- Minimum value: 5432, Maximum value: 45432 |
+| dbFlavorId | Body | UUID | X | Identifier of DB instance specifications |
+| parameterGroupId | Body | UUID | X | Parameter group identifier |
+| dbVersion | Body | Enum | X | DB engine version code |
+| dbSecurityGroupIds | Body | Array | X | List of DB security group identifiers |
+| executeBackup | Body | Boolean | X | Whether to execute backup at this time<br/>- Default: `false` |
+| useOnlineFailover | Body | Boolean | X | Whether to restart using failover<br/>- Default: `false` |
+| waitReplicationDelay | Body | Boolean | X | Whether to wait for replication delay to resolve<br/>- Default: `false` |
+| useReadOnly | Body | Boolean | X | Whether to block write workloads<br/>- Default: `false` |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
-    "dbInstanceName": "db-instance2",
-    "description": "description2",
-    "dbPort": 10001,
+    "dbInstanceName": "dbInstanceName-example",
+    "dbInstanceCandidateName": "dbInstanceCandidateName-example",
+    "description": "description-example",
+    "dbPort": 1,
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbVersion": "POSTGRESQL_V14_17",
     "dbSecurityGroupIds": [],
-    "executeBackup": true
+    "executeBackup": false,
+    "useOnlineFailover": false,
+    "waitReplicationDelay": false,
+    "useReadOnly": false
 }
 ```
+
+</p>
 </details>
 
 #### Response
 
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | Identifier of requested task |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -1103,124 +1358,43 @@ PUT /v1.0/db-instances/{dbInstanceId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
+---
 
-### Get high availability information
+### Apply Latest Parameter Group to DB Instance
 
 ```http
-GET /v1.0/db-instances/{dbInstanceId}/high-availability
+POST /v1.0/db-instances/{dbInstanceId}/apply-recent-parameter-group
 ```
 
 #### Required permissions
 
-| Permission Name                                   | Description         |
-|---------------------------------------|------------|
-| RDSforPostgreSQL:HighAvailability.Get | Get high availability information |
-
-#### Request
-
-| Name                  | Type   | Format      | Required | Description                                                   |
-|---------------------|------|---------|----|------------------------------------------------------|
-| dbInstanceId        | URL  | UUID    | O  | DB instance identifier                                         |
-
-#### Response
-
-| Name                      | Type   | Format      | Description                                                                                                                                                                                                                                                                                                                             |
-|-------------------------|------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| haStatus                | Body | Boolean | High Availability Status<br/>- `CREATED: Created`<br/>- `STABLE`: Normal<br/>- `DISABLE_REPLICATION_DELAY`: Failover stops due to replication delay<br/>- `PAUSING`: Pausing<br/>- `PAUSED`: Paused<br/>- `PAUSED_DUE_TO_TASK`: Paused `due to task`<br/>- `FAILOVER_STARTED`: Failover started<br/>- `FAILOVER_FAILED`: Failover failed<br/>- `FAILOVER_COMPLETED`: Failover complete<br/>- `DELETED`: Deleted |
-| pingInterval            | Body | Number  | Ping interval (sec) when using high availability<br/>- Minimum value: `1`<br/>- Maximum value: `600`                                                                                                                                                                                                                                                                           |
-| failoverReplWaitingTime | Body | Number  | Failover latency when using high availability<br/>- Minimum value: `0`<br/>- If set to -1, it will continue to wait for the replication delay to resolve.                                                                                                                                                                                                                                                   |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "useHighAvailability": true,
-    "haStatus": "STABLE",
-    "pingInterval": 3,
-    "failoverReplWaitingTime": 60
-}
-```
-</details>
-
-
-### Modify High Availability
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/high-availability
-```
-
-#### Required permissions
-
-| Permission Name                                      | Description        |
-|------------------------------------------|-----------|
-| RDSforPostgreSQL:HighAvailability.Modify | Modify High Availability |
-
-#### Request
-
-| Name                      | Type   | Format      | Required | Description                                                                           |
-|-------------------------|------|---------|----|------------------------------------------------------------------------------|
-| dbInstanceId            | URL  | UUID    | O  | DB instance identifier                                                                 |
-| useHighAvailability     | Body | Boolean | O  | Whether to use high availability                                                                   |
-| pingInterval            | Body | Number  | X  | Ping interval (sec) when using high availability<br/>- Minimum value: `1`<br/>- Maximum value: `600`                         |
-| failoverReplWaitingTime | Body | Number  | X  | Failover latency when using high availability<br/>- Minimum value: `0`<br/>- If set to -1, it will continue to wait for the replication delay to resolve. |
-
-#### Response
-
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### Restart High Availability
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/high-availability/resume
-```
-
-#### Required permissions
-
-| Permission Name                                      | Description           |
-|------------------------------------------|--------------|
-| RDSforPostgreSQL:HighAvailability.Resume | Restart High Availability |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Modify | Apply Latest Parameter Group to DB Instance |
 
 #### Request
 
 This API does not require a request body.
 
-| Name           | Type  | Format   | Required | Description           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB instance identifier |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
 
 #### Response
 
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | Identifier of requested task |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -1229,754 +1403,14 @@ This API does not require a request body.
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-
-### Pause High Availability
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/high-availability/pause
-```
-
-#### Required permissions
-
-| Permission Name                                     | Description           |
-|-----------------------------------------|--------------|
-| RDSforPostgreSQL:HighAvailability.Pause | Pause High Availability |
-
-#### Request
-
-This API does not require a request body.
-
-| Name           | Type  | Format   | Required | Description           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB instance identifier |
-
-#### Response
-
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-
-### Recover High Availability
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/high-availability/repair
-```
-
-#### Required permissions
-
-| Permission Name                                      | Description        |
-|------------------------------------------|-----------|
-| RDSforPostgreSQL:HighAvailability.Repair | Recover High Availability |
-
-#### Request
-
-This API does not require a request body.
-
-| Name           | Type  | Format   | Required | Description           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB instance identifier |
-
-#### Response
-
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-
-### Separate High Availability
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/high-availability/split
-```
-
-#### Required permissions
-
-| Permission Name                                     | Description        |
-|-----------------------------------------|-----------|
-| RDSforPostgreSQL:HighAvailability.Split | Separate High Availability |
-
-#### Request
-
-This API does not require a request body.
-
-| Name           | Type  | Format   | Required | Description           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB instance identifier |
-
-#### Response
-
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-
-### Get DB instance storage information
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}/storage-info
-```
-
-#### Required permissions
-
-| Permission Name                             | Description            |
-|---------------------------------|---------------|
-| RDSforPostgreSQL:DbInstance.Get | List DB Instance Details |
-
-#### Request
-
-This API does not require a request body.
-
-| Name           | Type  | Format   | Required | Description           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB instance identifier |
-
-#### Response
-
-| Name               | Type   | Format      | Description                                                                                   |
-|------------------|------|---------|--------------------------------------------------------------------------------------|
-| storageType      | Body | Enum    | Data storage types                                                                          |
-| storageSize      | Body | Number  | Block Storage Size (GB)                                                                      |
-| storageStatus    | Body | Enum    | Data Storage Current Status<br/>- `DETACHED`: Detached<br/>- `ATTACHED`: Attached<br/>- `DELETED`: Deleted |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "storageType": "General SSD",
-    "storageSize": 20,
-    "storageStatus": "ATTACHED"
-}
-```
-</details>
-
-
-### Modifying DB instance storage information
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/storage-info
-```
-
-#### Required permissions
-
-| Permission Name                                | Description           |
-|------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Modify | Modify DB Instance |
-
-#### Request
-
-| Name                | Type   | Format      | Required | Description                                                                        |
-|-------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID    | O  | DB instance identifier                                                              |
-| storageSize       | Body | Number  | O  | Block Storage Size (GB)<br/>- Minimum value: Current value<br/>- Maximum value: `2048`                          |
-
-#### Response
-
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### Get DB instance network information
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}/network-info
-```
-
-#### Required permissions
-
-| Permission Name                             | Description            |
-|---------------------------------|---------------|
-| RDSforPostgreSQL:DbInstance.Get | List DB Instance Details |
-
-#### Request
-
-This API does not require a request body.
-
-| Name           | Type  | Format   | Required | Description           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB instance identifier |
-
-#### Response
-
-| Name                      | Type   | Format      | Description                                                                                                                                      |
-|-------------------------|------|---------|-----------------------------------------------------------------------------------------------------------------------------------------|
-| availabilityZone        | Body | Enum    | Availability zone where DB instance will be created                                                                                                                     |
-| subnet                  | Body | Object  | Subnet object                                                                                                                                  |
-| subnet.subnetId         | Body | UUID    | Subnet identifier                                                                                                                                |
-| subnet.subnetName       | Body | UUID    | Name to identify subnets                                                                                                                        |
-| subnet.subnetCidr       | Body | UUID    | CIDR of subnet                                                                                                                               |
-| subnet.publicAccessible | Body | Boolean | External access is available or not                                                                                                                             |
-| endPoints               | Body | Array   | List of access information                                                                                                                                |
-| endPoints.domain        | Body | String  | Domain                                                                                                                                     |
-| endPoints.ipAddress     | Body | String  | IP address                                                                                                                                   |
-| endPoints.endPointType  | Body | Enum    | Types of access information<br>-`EXTERNAL`: External access domain<br>-`INTERNAL`: Internal access domain<br>-`PUBLIC`: (Deprecated) External access domain<br>-`PRIVATE`: (Deprecated) Internal access domain |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "availabilityZone": "kr-pub-a",
-    "subnet": {
-        "subnetId": "bd453789-34ae-416c-9f78-05b9e43a46be",
-        "subnetName": "Default Network",
-        "subnetCidr": "192.168.0.0/16",
-        "publicAccessible": true
-    },
-    "endPoints": [
-        {
-            "domain": "ea548a78-d85f-43b4-8ddf-c88d999b9905.internal.kr1.postgres.rds.nhncloudservice.com",
-            "ipAddress": "192.168.0.2",
-            "endPointType": "INTERNAL"
-        }
-    ]
-}
-```
-</details>
-
-### Modifying DB instance network information
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/network-info
-```
-
-#### Required permissions
-
-| Permission Name                                | Description           |
-|------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Modify | Modify DB Instance |
-
-#### Request
-
-| Name              | Type   | Format      | Required | Description           |
-|-----------------|------|---------|----|--------------|
-| dbInstanceId    | URL  | UUID    | O  | DB instance identifier |
-| usePublicAccess | Body | Boolean | O  | External access is available or not  |
-
-#### Response
-
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### Get DB instance backup information
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}/backup-info
-```
-
-#### Required permissions
-
-| Permission Name                             | Description            |
-|---------------------------------|---------------|
-| RDSforPostgreSQL:DbInstance.Get | List DB Instance Details |
-
-#### Request
-
-This API does not require a request body.
-
-| Name           | Type  | Format   | Required | Description           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB instance identifier |
-
-#### Response
-
-| Name                                    | Type   | Format     | Description                                                                                                                                                                                                                   |
-|---------------------------------------|------|--------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| backupPeriod                          | Body | Number | Backup retention period                                                                                                                                                                                                          |
-| backupRetryCount                      | Body | Number | Number of backup retries                                                                                                                                                                                                            |
-| backupSchedules                       | Body | Array  | Backup schedules                                                                                                                                                                                                            |
-| backupSchedules.backupWndBgnTime      | Body | String | Backup Start Time                                                                                                                                                                                                             |
-| backupSchedules.backupWndDuration     | Body | Enum   | Backup Window<br/>Auto backup is executed within the set duration from the backup start time.<br/>- `HALF_AN_HOUR`: 30 minutes<br/>- `ONE_HOUR`: 1 hour<br/>- `ONE_HOUR_AND_HALF`: 1.5 hour<br/>- `TWO_HOURS`: 2 hour<br/>- `TWO_HOURS_AND_HALF`: 2.5 hour<br/>- `THREE_HOURS`: 3 hour |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "backupPeriod": 1,
-    "backupRetryCount": 0,
-    "backupSchedules": [
-        {
-            "backupWndBgnTime": "00:00:00",
-            "backupWndDuration": "ONE_HOUR_AND_HALF",
-            "backupRetryExpireTime": "01:30:00"
-        }
-    ]
-}
-```
-</details>
-
-### Modifying DB instance backup information
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/backup-info
-```
-
-#### Required permissions
-
-| Permission Name                                | Description           |
-|------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Modify | Modify DB Instance |
-
-#### Request
-
-| Name                                    | Type   | Format     | Required | Description                                                                                                                                                                                                                   |
-|---------------------------------------|------|--------|----|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                          | URL  | UUID   | O  | DB instance identifier                                                                                                                                                                                                         |
-| backupPeriod                          | Body | Number | X  | Backup retention period<br/>- Minimum value: `0`<br/>- Maximum value: `730`                                                                                                                                                                          |
-| backupRetryCount                      | Body | Number | X  | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10`                                                                                                                                                                             |
-| backupSchedules                       | Body | Array  | X  | Backup schedules                                                                                                                                                                                                            |
-| backupSchedules.backupWndBgnTime      | Body | String | O  | Backup Start Time<br/>- Example: `00:00:00`                                                                                                                                                                                        |
-| backupSchedules.backupWndDuration     | Body | Enum   | O  | Backup Window<br/>Auto backup is executed within the set duration from the backup start time.<br/>- `HALF_AN_HOUR`: 30 minutes<br/>- `ONE_HOUR`: 1 hour<br/>- `ONE_HOUR_AND_HALF`: 1.5 hour<br/>- `TWO_HOURS`: 2 hour<br/>- `TWO_HOURS_AND_HALF`: 2.5 hour<br/>- `THREE_HOURS`: 3 hour |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "backupPeriod": 5,
-    "backupSchedules": [
-        {
-            "backupWndBgnTime": "01:00:00",
-            "backupWndDuration": "TWO_HOURS",
-            "backupRetryExpireTime": "03:00:00"
-        }
-    ]
-}
-```
-</details>
-
-#### Response
-
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### Get DB instance restore information
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}/restoration-info
-```
-
-#### Required permissions
-
-| Permission Name                             | Description            |
-|---------------------------------|---------------|
-| RDSforPostgreSQL:DbInstance.Get | List DB Instance Details |
-
-#### Request
-
-| Name           | Type  | Format   | Required | Description           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB instance identifier |
-
-#### Response
-
-| Name                                      | Type   | Format       | Description                                                                                                                                                    |
-|-----------------------------------------|------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
-| oldestRestorableYmdt                    | Body | DateTime | Oldest restoreable time                                                                                                                                      |
-| latestRestorableYmdt                    | Body | DateTime | Most recent restoreable time                                                                                                                                      |
-| restorableBackups                       | Body | Array    | List of restoreable backups                                                                                                                                          |
-| restorableBackups.backup                | Body | Object   | Backup information objects                                                                                                                                              |
-| restorableBackups.backup.backupId       | Body | UUID     | Backup identifier                                                                                                                                               |
-| restorableBackups.backup.backupName     | Body | String   | Backup name                                                                                                                                                 |
-| restorableBackups.backup.backupSize     | Body | Number   | Backup size                                                                                                                                                 |
-| restorableBackups.backup.backupType     | Body | Enum     | Backup type<br/>- `AUTO`: Automatic<br/>`MANUAL: Manual`                                                                                                             |
-| restorableBackups.backup.backupStatus   | Body | Enum     | Backup Status<br/>`BACKING_UP`: Backup in progress<br/>`COMPLETED`: Backup completed<br/>`DELETING`: Backup being deleted<br/>`DELETED`: Backup deleted<br/>`ERROR`: Error occurred |
-| restorableBackups.backup.dbInstanceId   | Body | UUID     | Original DB instance identifier                                                                                                                                       |
-| restorableBackups.backup.dbInstanceName | Body | String   | Original DB instance name                                                                                                                                        |
-| restorableBackups.backup.dbVersion      | Body | String   | DB version information                                                                                                                                              |
-| restorableBackups.backup.failoverCount  | Body | Number   | Number of failovers                                                                                                                                              |
-| restorableBackups.backup.walFileName    | Body | String   | WAL log file name                                                                                                                                          |
-| restorableBackups.backup.createdYmdt    | Body | DateTime | Date and time of backup creation                                                                                                                                              |
-| restorableBackups.backup.updatedYmdt    | Body | DateTime | Date and time of backup renewal                                                                                                                                              |
-| restorableBackups.backup.startYmdt      | Body | DateTime | When backups start                                                                                                                                              |
-| restorableBackups.backup.completedYmdt  | Body | DateTime | Backup completion date                                                                                                                                              |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "oldestRestorableYmdt": "2023-07-09T16:33:33+09:00",
-    "latestRestorableYmdt": "2023-07-10T15:44:44+09:00",
-    "restorableBackups": [
-        {
-            "backup": {
-                "backupId": "145d889a-fe08-474f-8f58-bde576ff96a9",
-                "backupName": "example-backup-name",
-                "backupStatus": "COMPLETED",
-                "dbInstanceId": "dba1be25-9429-4589-9716-7fb6daad7cb9",
-                "dbInstanceName": "original-db-instance-name",
-                "dbVersion": "POSTGRESQL_V17_6",
-                "backupType": "MANUAL",
-                "backupSize": 8299904,
-                "walFileName": "000000010000000000000005",
-                "createdYmdt": "2023-07-10T15:44:44+09:00",
-                "updatedYmdt": "2023-07-10T15:46:07+09:00"
-            }
-        }
-    ]
-}
-```
-</details>
-
-### Restore DB Instance
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/restore
-```
-
-#### Required permissions
-
-| Permission Name                                 | Description           |
-|-------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Restore | Restore DB Instance |
-
-#### Common Request
-
-| Name                                       | Type   | Format      | Required | Description                                                                                                                                                                                                                                                  |
-|------------------------------------------|------|---------|----|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                             | URL  | UUID    | O  | DB instance identifier                                                                                                                                                                                                                                        |
-| restore                                  | Body | Object  | O  | Restoration information object                                                                                                                                                                                                                                            |
-| restore.restoreType                      | Body | Enum    | O  | Restoration type<br/>`TIMESTAMP`: A point-in-time restoration type using the time within the restorable time<br/>- `BACKUP`: Restore type using a previously created backup                                                                                                                                                    |
-| dbInstanceName                           | Body | String  | O  | Name to identify DB instances                                                                                                                                                                                                                                |
-| description                              | Body | String  | X  | Additional information on DB instances                                                                                                                                                                                                                                   |
-| dbFlavorId                               | Body | UUID    | O  | Identifier of DB instance specifications                                                                                                                                                                                                                                     |
-| dbPort                                   | Body | Number  | O  | DB port<br/>- Minimum value: `3306`<br/>- Maximum value: `43306`                                                                                                                                                                                                          |
-| parameterGroupId                         | Body | UUID    | O  | Parameter group identifier                                                                                                                                                                                                                                        |
-| dbSecurityGroupIds                       | Body | Array   | X  | DB security group identifiers                                                                                                                                                                                                                                    |
-| userGroupIds                             | Body | Array   | X  | User group identifiers                                                                                                                                                                                                                                      |
-| useDefaultNotification                   | Body | Boolean | X  | Whether to use default notification<br/>Default: `false`                                                                                                                                                                                                                      |
-| useDeletionProtection                    | Body | Boolean | X  | Whether to protect against deletion<br>Default: `false`                                                                                                                                                                                                                            |                                                                                                                                                                                                                                                                                                                                                                                                                                        |
-| useHighAvailability                      | Body | Boolean | X  | Whether to use high availability<br/>Default: `false`                                                                                                                                                                                                                       |
-| pingInterval                             | Body | Number  | X  | Ping interval (sec) when using high availability<br/>- Default: `3Minimum` `:` 1<br/>- Maximum value: `600`                                                                                                                                                                                        |
-| failoverReplWaitingTime                  | Body | Number  | X  | Failover latency when using high availability<br/>- Minimum value: `0`<br/>- If set to -1, it will continue to wait for the replication delay to resolve.                                                                                                                                                                        |                                                                                                                                                                                                                      | userGroupIds                             | Body | Array   | X  | List of identifiers for user groups that receive default notifications                                                                                                                                                                                             |
-| network                                  | Body | Object  | O  | Network information objects                                                                                                                                                                                                                                          |
-| network.subnetId                         | Body | UUID    | O  | Subnet identifier                                                                                                                                                                                                                                            |
-| network.usePublicAccess                  | Body | Boolean | X  | External access is available or not<br/>Default: `false`</li></ul>                                                                                                                                                                                                            |
-| network.availabilityZone                 | Body | Enum    | X  | Availability zone where DB instance will be created<br/>- Example: `kr-pub-a`<br/>- Default: `Any availability` zone                                                                                                                                                                                    |
-| storage                                  | Body | Object  | O  | Storage information objects                                                                                                                                                                                                                                          |
-| storage.storageType                      | Body | Enum    | O  | Block Storage Type<br/>- Example: `General SSD`                                                                                                                                                                                                                 |
-| storage.storageSize                      | Body | Number  | O  | Block Storage Size (GB)<br/>- Minimum value: `20`<br/>- Maximum value: `2048`                                                                                                                                                                                                   |
-| backup                                   | Body | Object  | O  | Backup information objects                                                                                                                                                                                                                                            |
-| backup.backupPeriod                      | Body | Number  | O  | Backup retention period<br/>- Minimum value: `0`<br/>- Maximum value: `730`                                                                                                                                                                                                         |
-| backup.backupRetryCount                  | Body | Number  | X  | Number of backup retries<br/>Default: `6`<br/>- Minimum value: `0`<br/>- Maximum value: `10`                                                                                                                                                                                             |
-| backup.backupSchedules                   | Body | Array   | O  | Backup schedules                                                                                                                                                                                                                                           |
-| backup.backupSchedules.backupWndBgnTime  | Body | String  | X  | Backup started time<br/>- Example: `00:00:00`<br/>- Default: Original DB instance value                                                                                                                                                                                               |
-| backup.backupSchedules.backupWndDuration | Body | Enum    | X  | Backup duration<br/>Auto backup proceeds within duration from backup start time.<br/>- `HALF_AN_HOUR`: 30 minutes<br/>- `ONE_HOUR`: 1 hour<br/>- `ONE_HOUR_AND_HALF`: 1.5 hour<br/>- `TWO_HOURS`: 2 hour<br/>- `TWO_HOURS_AND_HALF`: 2.5 hour<br/>- `THREE_HOURS`: 3 hour<br/>- Default: Original DB instance value |
-
-#### Request when restoring a point in time restoration using Timestamp (if restoreType is `TIMESTAMP`)
-
-| Name                  | Type   | Format       | Required | Description                                                                                              |
-|---------------------|------|----------|----|-------------------------------------------------------------------------------------------------|
-| restore.restoreYmdt | Body | DateTime | O  | DB instance restore time. (YYYY-MM-DDThh:mm:ss.SSSTZD)<br>Restoration is possible only before the most recent restorable time, which is queried through restoration information inquiry. |
-
-<details><summary>Example</summary>
-
-```json
-{
-  "dbInstanceName": "db-instance",
-  "description": "description",
-  "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-  "dbPort": 10000,
-  "dbUserName": "db-user",
-  "dbPassword": "password",
-  "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-  "dbSecurityGroupIds": [
-    "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-  ],
-  "userGroupIds": [],
-  "network": {
-    "subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36"
-  },
-  "storage": {
-    "storageType": "General SSD",
-    "storageSize": 20
-  },
-  "restore": {
-    "restoreType": "TIMESTAMP",
-    "restoreYmdt": "2023-07-10T15:44:44+09:00"
-  },
-  "backup": {
-    "backupPeriod": 1,
-    "backupSchedules": [
-      {
-        "backupWndBgnTime": "00:00:00",
-        "backupWndDuration": "ONE_HOUR_AND_HALF"
-      }
-    ]
-  }
-}
-```
-</details>
-
-#### Response
-
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-
-### Change DB Instance Deletion Protection Settings
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/deletion-protection
-```
-
-#### Required permissions
-
-| Permission Name                                | Description           |
-|------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Modify | Modify DB Instance |
-
-#### Request
-
-| Name                    | Type   | Format      | Required | Description           |
-|-----------------------|------|---------|----|--------------|
-| dbInstanceId          | URL  | UUID    | O  | DB instance identifier |
-| useDeletionProtection | Body | Boolean | O  | Whether to protect against deletion     |
-
-#### Response
-
-This API does not return a response body.
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
-
-
-### Get DB instance maintenance information
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}/maintenance-info
-```
-
-#### Required permissions
-
-| Permission Name                                | Description           |
-|------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Get | List DB Instance Details |
-
-#### Request
-
-| Name                    | Type   | Format      | Required | Description           |
-|-----------------------|------|---------|----|--------------|
-| dbInstanceId          | URL  | UUID    | O  | DB instance identifier |
-
-#### Response
-
-| Name                  | Type | Format  | Description                                                                                                                          |
-|-----------------------|------|---------|--------------------------------------------------------------------------------------------------------------------------------------|
-| allowAutoMaintenance  | Body | Boolean | Whether to allow automatic maintenance                                                                                               |
-| useAutoStorageCleanup | Body | Boolean | Whether to enable automatic storage cleanup                                                                                          |
-| maintWndBgnTime       | Body | String  | Automatic maintenance start time <br/>- Example: `00:00:00`                                                                          |
-| maintWndDuration      | Body | ENUM    | Maintenance window <br/> Examples: `half_an_hour`, `one_hour`, `one_hour_and_half`, `two_hours`, `two_hours_and_half`, `three_hours` |
-| logRetentionPeriod    | Body | Number  | Log retention period (days)                                                                                                                          |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "allowAutoMaintenance": true,
-    "useAutoStorageCleanup": true,
-    "maintWndBgnTime": "00:00:00",
-    "maintWndDuration": "HALF_AN_HOUR",
-    "logRetentionPeriod": 7
-}
-```
-</details>
-
-
-### Modify DB instance maintenance information
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/maintenance-info
-```
-
-#### Required permissions
-
-| Permission Name                                | Description           |
-|------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Modify | Modify DB Instance |
-
-#### Request
-
-| Name                  | Type | Format  | Required | Description                                                                                                                          |
-|-----------------------|------|---------|----------|--------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId          | URL  | UUID    | O        | DB instance identifier                                                                                                               |
-| allowAutoMaintenance  | Body | Boolean | O        | Whether to allow automatic maintenance                                                                                               |
-| useAutoStorageCleanup | Body | Boolean | O        | Whether to enable automatic storage cleanup                                                                                          |
-| maintWndBgnTime       | Body | String  | O        | Automatic maintenance start time <br/>- Example: `00:00:00`                                                                          |
-| maintWndDuration      | Body | ENUM    | O        | Maintenance window <br/> Examples: `half_an_hour`, `one_hour`, `one_hour_and_half`, `two_hours`, `two_hours_and_half`, `three_hours` |
-| logRetentionPeriod    | Body | Number  | X        | Log retention period (days)                                                                                                                          |
-
-<details><summary>Example</summary>
-
-```json
-{
-  "allowAutoMaintenance": true,
-  "useAutoStorageCleanup": true,
-  "logRetentionPeriod": 7
-}
-```
-</details>
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
-<details><summary>Example</summary>
-
-```json
-{
-  "header": {
-    "resultCode": 0,
-    "resultMessage": "SUCCESS",
-    "isSuccessful": true
-  },
-  "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-
+---
 ### Get selectable DB versions in the current DB instance
 
 ```http
@@ -1985,26 +1419,30 @@ GET /v1.0/db-instances/{dbInstanceId}/available-db-versions
 
 #### Required permissions
 
-| Permission Name                                | Description           |
-|------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Get | List DB Instance Details |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Get | Get selectable DB versions in the current DB instance |
 
 #### Request
 
-| Name                    | Type   | Format      | Required | Description           |
-|-----------------------|------|---------|----|--------------|
-| dbInstanceId          | URL  | UUID    | O  | DB instance identifier |
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
 
 #### Response
 
-| Name                           | Type   | Format      | Description                    |
-|------------------------------|------|---------|-----------------------|
-| dbVersions                   | Body | Array   | DB version list              |
-| dbVersions.dbVersion         | Body | String  | DB version                 |
-| dbVersions.dbVersionName     | Body | String  | DB version name                |
-| dbVersions.restorableFromObs | Body | Boolean | Restoring backup from object storage available or not |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| availableDbVersions | Body | Array | DB version information |
+| availableDbVersions.dbVersionCode | Body | Enum | DB version code<br/>- MYSQL_V5633<br/>- MYSQL_V5715<br/>- MYSQL_V5719<br/>- MYSQL_V5726<br/>- MYSQL_V5731<br/>- MYSQL_V5733<br/>- MYSQL_V5737<br/>- MYSQL_V8018<br/>- MYSQL_V8023<br/>- MYSQL_V8028<br/>- MYSQL_V8032<br/>- MYSQL_V8033<br/>- MYSQL_V8034<br/>- MYSQL_V8035<br/>- MYSQL_V8036<br/>- MYSQL_V8040<br/>- MYSQL_V8041<br/>- MYSQL_V8042<br/>- MYSQL_V8043<br/>- MYSQL_V8044<br/>- MYSQL_V8045<br/>- MYSQL_V8405<br/>- MYSQL_V8406<br/>- MYSQL_V8407<br/>- MYSQL_V8408<br/>- MYSQL_V8409<br/>- MARIADB_V10330<br/>- MARIADB_V10611<br/>- MARIADB_V10612<br/>- MARIADB_V10616<br/>- MARIADB_V10622<br/>- MARIADB_V10625<br/>- MARIADB_V101107<br/>- MARIADB_V101108<br/>- MARIADB_V101113<br/>- MARIADB_V101116<br/>- MARIADB_V11407<br/>- MARIADB_V11410<br/>- MARIADB_V11806<br/>- POSTGRESQL_V14_6<br/>- POSTGRESQL_V14_15<br/>- POSTGRESQL_V14_17<br/>- POSTGRESQL_V14_19<br/>- POSTGRESQL_V17_2<br/>- POSTGRESQL_V17_4<br/>- POSTGRESQL_V17_6 |
+| availableDbVersions.dbMajorVersionCode | Body | Enum | DB major version code<br/>- MYSQL_V56<br/>- MYSQL_V57<br/>- MYSQL_V80<br/>- MYSQL_V84<br/>- MARIADB_V103<br/>- MARIADB_V106<br/>- MARIADB_V1011<br/>- MARIADB_V114<br/>- MARIADB_V118<br/>- POSTGRES_V14<br/>- POSTGRES_V17 |
+| availableDbVersions.name | Body | String | DB version name |
+| availableDbVersions.canCreate | Body | Boolean | Whether creation is available |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -2013,222 +1451,21 @@ GET /v1.0/db-instances/{dbInstanceId}/available-db-versions
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "dbVersions": [
+    "availableDbVersions": [
         {
-            "dbVersion": "POSTGRESQL_V17_6",
-            "dbVersionName": "PostgreSQL V17.6",
-            "restorableFromObs": true
+            "dbVersionCode": "MYSQL_V5633",
+            "dbMajorVersionCode": "MYSQL_V56",
+            "name": "PostgreSQL V14.6",
+            "canCreate": false
         }
     ]
 }
 ```
+
+</p>
 </details>
 
-
-### Delete DB instance
-
-```http
-DELETE /v1.0/db-instances/{dbInstanceId}
-```
-
-#### Required permissions
-
-| Permission Name                                | Description           |
-|------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Delete | Delete DB instance |
-
-#### Request
-
-This API does not require a request body.
-
-| Name           | Type  | Format   | Required | Description           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB instance identifier |
-
-#### Response
-
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### Restart DB Instance
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/restart
-```
-
-#### Required permissions
-
-| Permission Name                                 | Description            |
-|-------------------------------------|---------------|
-| RDSforPostgreSQL:DbInstance.Restart | Restart DB Instance |
-
-#### Request
-
-| Name                | Type   | Format      | Required | Description                                                                        |
-|-------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID    | O  | DB instance identifier                                                              |
-| useOnlineFailover | Body | Boolean | X  | Whether to restart using failover<br/>Available only for DB instance using high availability<br/>Default: `false` |
-| executeBackup     | Body | Boolean | X  | Whether to execute backup at this time<br/>Default: `false`                                         |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "executeBackup": true
-}
-```
-</details>
-
-#### Response
-
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### Force Restart DB instance
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/force-restart
-```
-
-#### Required permissions
-
-| Permission Name                                      | Description               |
-|------------------------------------------|------------------|
-| RDSforPostgreSQL:DbInstance.ForceRestart | Force Restart DB instance |
-
-#### Request
-
-| Name           | Type  | Format   | Required | Description           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB instance identifier |
-
-#### Response
-
-This API does not return a response body.
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
-
-
-### Start DB Instance
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/start
-```
-
-#### Required permissions
-
-| Permission Name                               | Description           |
-|-----------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Start | Start DB Instance |
-
-#### Request
-
-This API does not require a request body.
-
-| Name           | Type  | Format   | Required | Description           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB instance identifier |
-
-#### Response
-
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### Stop DB Instance
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/stop
-```
-
-#### Required permissions
-
-| Permission Name                               | Description           |
-|-----------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Start | Start DB Instance |
-
-#### Request
-
-This API does not require a request body.
-
-| Name           | Type  | Format   | Required | Description           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB instance identifier |
-
-#### Response
-
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
+---
 
 ### Backup DB Instance
 
@@ -2238,33 +1475,37 @@ POST /v1.0/db-instances/{dbInstanceId}/backup
 
 #### Required permissions
 
-| Permission Name                                | Description           |
-|------------------------------------|--------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforPostgreSQL:DbInstance.Backup | Backup DB Instance |
 
 #### Request
 
-| Name           | Type   | Format     | Required | Description              |
-|--------------|------|--------|----|-----------------|
-| dbInstanceId | URL  | UUID   | O  | DB instance identifier    |
-| backupName   | Body | String | O  | Name to identify backups |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| backupName | Body | String | O | Name to identify backups |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
-    "backupName": "backup"
+    "backupName": "backupName-example"
 }
 ```
+
+</p>
 </details>
 
 #### Response
 
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | Identifier of requested task |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -2273,12 +1514,147 @@ POST /v1.0/db-instances/{dbInstanceId}/backup
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-### Export after Backing up DB Instance
+---
+
+### Get DB Instance Backup Information
+
+```http
+GET /v1.0/db-instances/{dbInstanceId}/backup-info
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Get | Get DB Instance Backup Information |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| allowAutoBackup | Body | Boolean | Whether automatic backup is allowed |
+| usePeriodicAutoBackup | Body | Boolean | Whether scheduled automatic backup is used |
+| backupPeriod | Body | Number | Backup retention period (days) |
+| backupRetryCount | Body | Number | Number of backup retries |
+| backupSchedules | Body | Array | Backup schedules |
+| backupSchedules.backupWndBgnTime | Body | Time | Backup start time |
+| backupSchedules.backupWndDuration | Body | Enum | Backup Window<br/>Auto backup is executed within the set duration from the backup start time.<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hour`<br/>- TWO_HOURS: `2 hour`<br/>- TWO_HOURS_AND_HALF: `2.5 hour`<br/>- THREE_HOURS: `3 hour` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "allowAutoBackup": false,
+    "usePeriodicAutoBackup": false,
+    "backupPeriod": 1,
+    "backupRetryCount": 1,
+    "backupSchedules": [
+        {
+            "backupWndBgnTime": "00:00:00",
+            "backupWndDuration": "HALF_AN_HOUR"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### Modify DB Instance Backup Information
+
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/backup-info
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Modify | Modify DB Instance Backup Information |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| allowAutoBackup | Body | Boolean | X | Whether automatic backup is allowed |
+| usePeriodicAutoBackup | Body | Boolean | X | Whether scheduled automatic backup is used |
+| backupPeriod | Body | Number | X | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| backupRetryCount | Body | Number | X | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| backupSchedules | Body | Array | X | Backup schedules |
+| backupSchedules.backupWndBgnTime | Body | Time | O | Backup start time |
+| backupSchedules.backupWndDuration | Body | Enum | O | Backup Window<br/>Auto backup is executed within the set duration from the backup start time.<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hour`<br/>- TWO_HOURS: `2 hour`<br/>- TWO_HOURS_AND_HALF: `2.5 hour`<br/>- THREE_HOURS: `3 hour` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "allowAutoBackup": false,
+    "usePeriodicAutoBackup": false,
+    "backupPeriod": 0,
+    "backupRetryCount": 0,
+    "backupSchedules": [
+        {
+            "backupWndBgnTime": "00:00:00",
+            "backupWndDuration": "HALF_AN_HOUR"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Export after Backing up DB Instance to Object Storage
 
 ```http
 POST /v1.0/db-instances/{dbInstanceId}/backup-to-object-storage
@@ -2286,41 +1662,45 @@ POST /v1.0/db-instances/{dbInstanceId}/backup-to-object-storage
 
 #### Required permissions
 
-| Permission Name                                               | Description                         |
-|---------------------------------------------------|----------------------------|
-| RDSforPostgreSQL:DbInstance.BackupToObjectStorage | Export Backup Files to Object Storage After Backup |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.BackupToObjectStorage | Export after Backing up DB Instance to Object Storage |
 
 #### Request
 
-| Name              | Type   | Format     | Required | Description                          |
-|-----------------|------|--------|----|-----------------------------|
-| dbInstanceId    | URL  | UUID   | O  | DB instance identifier                |
-| tenantId        | Body | String | O  | Tenant ID of object storage to store backup   |
-| username        | Body | String | O  | ID of NHN Cloud Account or IAM Account   |
-| password        | Body | String | O  | API password for object storage where backup is stored |
-| targetContainer | Body | String | O  | Object storage container where backup is stored     |
-| objectPath      | Body | String | O  | Backup path to be stored in container            |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| tenantId | Body | String | O | Tenant ID of object storage to store backup<br/>- Minimum length: `32`<br/>- Maximum length: `32` |
+| username | Body | String | O | ID of NHN Cloud Account or IAM Account |
+| password | Body | String | O | API password for object storage where backup is stored |
+| targetContainer | Body | String | O | Object storage container where backup is stored |
+| objectPath | Body | String | O | Backup path to be stored in container |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
-    "tenantId": "399631c404744dbbb18ce4fa2dc71a5a",
-    "username": "gildong.hong@nhn.com",
-    "password": "password",
-    "targetContainer": "/container",
-    "objectPath": "/backups/backup_file"
+    "tenantId": "0123456789abcdef0123456789abcdef",
+    "username": "username-example",
+    "password": "password-example",
+    "targetContainer": "targetContainer-example",
+    "objectPath": "objectPath-example"
 }
 ```
+
+</p>
 </details>
 
 #### Response
 
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | Identifier of requested task |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -2329,172 +1709,14 @@ POST /v1.0/db-instances/{dbInstanceId}/backup-to-object-storage
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-### Applying DB instance latest parameter groups
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/apply-recent-parameter-group
-```
-
-#### Required permissions
-
-| Permission Name                                | Description           |
-|------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Modify | Modify DB Instance |
-
-#### Request
-
-| Name                | Type   | Format      | Required | Description                                                                        |
-|-------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID    | O  | DB instance identifier                                                              |
-| executeBackup     | Body | Boolean | X  | Whether to execute backup at this time<br/>Default: `false`                                         |
-
-<details><summary>Example</summary>
-
-```json
-{
-  "executeBackup": true
-}
-```
-</details>
-
-#### Response
-
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### Replicate DB Instance
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/replicate
-```
-
-#### Required permissions
-
-| Permission Name                                   | Description           |
-|---------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Replicate | Replicate DB Instance |
-
-#### Request
-
-| Name                                           | Type   | Format      | Required | Description                                                                                                                                                                                                                                                  |
-|----------------------------------------------|------|---------|----|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                                 | URL  | UUID    | O  | DB instance identifier                                                                                                                                                                                                                                        |
-| dbInstanceName                               | Body | String  | O  | Name to identify DB instances                                                                                                                                                                                                                                |
-| description                                  | Body | String  | X  | Additional information on DB instances                                                                                                                                                                                                                                   |
-| dbFlavorId                                   | Body | UUID    | X  | Identifier of DB instance specifications<br/>- Default: Original DB instance value                                                                                                                                                                                                             |
-| dbPort                                       | Body | Number  | X  | DB port<br/>- Default: Original DB instance value<br/>- Minimum value: `0`<br/>- Maximum value: 65535                                                                                                                                                                                  |
-| parameterGroupId                             | Body | UUID    | X  | Parameter group identifier<br/>- Default: Original DB instance value                                                                                                                                                                                                                |
-| dbSecurityGroupIds                           | Body | Array   | X  | DB security group identifiers<br/>- Default: Original DB instance value                                                                                                                                                                                                            |
-| userGroupIds                                 | Body | Array   | X  | User group identifiers                                                                                                                                                                                                                                      |
-| useDefaultNotification                       | Body | Boolean | X  | Whether to use default notification<br/>Default: `false`                                                                                                                                                                                                                      |
-| useDeletionProtection                        | Body | Boolean | X  | Whether to protect against deletion<br/>Default: `false`                                                                                                                                                                                                                         |
-| network                                      | Body | Object  | X  | Network information objects                                                                                                                                                                                                                                          |
-| network.usePublicAccess                      | Body | Boolean | X  | External access is available or not<br/>Default: `false`                                                                                                                                                                                                                      |
-| network.availabilityZone                     | Body | Enum    | X  | Availability zone where DB instance will be created<br/>- Example: `kr-pub-a`<br/>- Default: `Any availability` zone                                                                                                                                                                                    |  
-| storage                                      | Body | Object  | X  | Storage information objects                                                                                                                                                                                                                                          |    
-| storage.storageType                          | Body | Enum    | X  | Data storage types<br>- Example: `General SSD`                                                                                                                                                                                                                  |
-| storage.storageSize                          | Body | Number  | X  | Block Storage Size (GB)<br/>- Default: Original DB instance value<br/>- Minimum value: `20`<br/>- Maximum value: `2048`                                                                                                                                                                           |
-| backup                                       | Body | Object  | X  | Backup information objects                                                                                                                                                                                                                                            |
-| backup.backupPeriod                          | Body | Number  | X  | Backup retention period<br/>- Default: Original DB instance value<br/>- Minimum value: `0`<br/>- Maximum value: `730`                                                                                                                                                                                 |
-| backup.backupRetryCount                      | Body | Number  | X  | Number of backup retries<br/>- Default: Original DB instance value<br/>- Minimum value: `0`<br/>- Maximum value: `10`                                                                                                                                                                                    |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "dbInstanceName": "db-instance-replicate",
-    "description": "description",
-    "dbPort": 15432,
-    "storage": {
-        "storageSize": 100
-    }
-}
-```
-</details>
-
-#### Response
-
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### Promote DB Instance
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/promote
-```
-
-#### Required permissions
-
-| Permission Name                                 | Description           |
-|-------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Promote | Promote DB Instance |
-
-#### Request
-
-This API does not require a request body.
-
-| Name           | Type  | Format   | Required | Description           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB instance identifier |
-
-#### Response
-
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-
-## DB Instances > Databases
-
+---
 ### View the list of databases
 
 ```http
@@ -2503,32 +1725,34 @@ GET /v1.0/db-instances/{dbInstanceId}/databases
 
 #### Required permissions
 
-| Permission Name                                      | Description                     |
-|------------------------------------------|------------------------|
-| RDSforPostgreSQL:DbInstanceDatabase.List | View a list of databases in a DB instance |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceDatabase.List | View the list of databases |
 
 #### Request
 
 This API does not require a request body.
 
-| Name           | Type  | Format   | Required | Description           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB instance identifier |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
 
 #### Response
 
-| Name                           | Type   | Format       | Description                                                                                                                                                  |
-|------------------------------|------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| databases                    | Body | Array    | List of databases                                                                                                                                           |
-| databases.databaseId         | Body | UUID     | Identifiers in the database                                                                                                                                         |
-| databases.databaseName       | Body | String   | Database Name                                                                                                                                           |
-| databases.databaseStatus     | Body | Enum     | Current state of the database<br/>- `STABLE`: Created<br/>(CREATING: Creating,<br/>- `MODIFYING`: Modifying<br/>- `SYNCING`: Synchronizing<br/>DELETING: Deleting,<br/>- `DELETED`: Deleted |
-| databases.createdYmdt        | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                   |
-| databases.updatedYmdt        | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                   |
-| databases.schemas            | Body | Array    | List of schemas in the database                                                                                                                                     |
-| databases.schemas.schemaName | Body | String   | Schema name                                                                                                                                              |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| databases | Body | Array | Database information |
+| databases.databaseId | Body | UUID | Database identifier |
+| databases.databaseName | Body | String | Database name |
+| databases.databaseStatus | Body | Enum | Current state of the database<br/>- STABLE: `Available`<br/>- CREATING: `Creating`<br/>- MODIFYING: `Modifying`<br/>- DELETING: `Deleting`<br/>- DELETED: `Deleted`<br/>- SYNCING: `Synchronizing`<br/>- DELETE_ERROR: `Deletion failed` |
+| databases.createdYmdt | Body | DateTime | Created date and time |
+| databases.updatedYmdt | Body | DateTime | Modified date and time |
+| databases.schemas | Body | Array | Schema information |
+| databases.schemas.schemaName | Body | String | Schema name |
+| databases.errorReason | Body | String | Reason for deletion failure |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -2539,21 +1763,26 @@ This API does not require a request body.
     },
     "databases": [
         {
-            "databaseId": "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4",
-            "databaseName": "database",
+            "databaseId": "550e8400-e29b-41d4-a716-446655440000",
+            "databaseName": "databaseName-example",
             "databaseStatus": "STABLE",
-            "createdYmdt": "2023-03-20T13:37:45+09:00",
-            "updatedYmdt": "2023-03-20T13:37:45+09:00",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00",
             "schemas": [
                 {
-                    "schemaName": "rds"
+                    "schemaName": "schemaName-example"
                 }
-            ]
+            ],
+            "errorReason": "errorReason-example"
         }
     ]
 }
 ```
+
+</p>
 </details>
+
+---
 
 ### Create a database
 
@@ -2563,33 +1792,37 @@ POST /v1.0/db-instances/{dbInstanceId}/databases
 
 #### Required permissions
 
-| Permission Name                                        | Description                    |
-|--------------------------------------------|-----------------------|
-| RDSforPostgreSQL:DbInstanceDatabase.Create | Creating a database within a DB instance |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceDatabase.Create | Create a database |
 
 #### Request
 
-| Name           | Type   | Format     | Required | Description           |
-|--------------|------|--------|----|--------------|
-| dbInstanceId | URL  | UUID   | O  | DB instance identifier |
-| databaseName | Body | String | O  | Database Name    |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| databaseName | Body | String | O | Database name |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
-    "databaseName": "database"
+    "databaseName": "databaseName-example"
 }
 ```
+
+</p>
 </details>
 
 #### Response
 
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of the requested task |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -2598,62 +1831,16 @@ POST /v1.0/db-instances/{dbInstanceId}/databases
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-### Modifying the database
+---
 
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/databases/{databaseId}
-```
-
-#### Required permissions
-
-| Permission Name                                        | Description                    |
-|--------------------------------------------|-----------------------|
-| RDSforPostgreSQL:DbInstanceDatabase.Modify | Modifying databases within a DB instance |
-
-#### Request
-
-| Name                       | Type   | Format      | Required | Description                                                                                          |
-|--------------------------|------|---------|----|---------------------------------------------------------------------------------------------|
-| dbInstanceId             | URL  | UUID    | O  | DB instance identifier                                                                                |
-| databaseId               | URL  | UUID    | O  | Identifiers in the database                                                                                 |
-| databaseName             | Body | String  | O  | Database Name                                                                                   |
-| applyHbaRulesImmediately | Body | Boolean | X  | Whether to apply associated access control rules immediately<br/>- When you change the database name, any access control rules set under the old database name are reflected with the changed name. |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "databaseName": "database-1"
-}
-```
-</details>
-
-#### Response
-
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### Deleting a database
+### Delete a database
 
 ```http
 DELETE /v1.0/db-instances/{dbInstanceId}/databases/{databaseId}
@@ -2661,26 +1848,27 @@ DELETE /v1.0/db-instances/{dbInstanceId}/databases/{databaseId}
 
 #### Required permissions
 
-| Permission Name                                        | Description                    |
-|--------------------------------------------|-----------------------|
-| RDSforPostgreSQL:DbInstanceDatabase.Delete | Deleting a database within a DB instance |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceDatabase.Delete | Delete a database |
 
 #### Request
 
 This API does not require a request body.
 
-| Name           | Type  | Format   | Required | Description           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB instance identifier |
-| databaseId   | URL | UUID | O  | Identifiers in the database  |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| databaseId | URL | UUID | O | Database identifier |
 
 #### Response
 
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of the requested task |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -2689,13 +1877,73 @@ This API does not require a request body.
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-## DB Instances > Users
+---
 
+### Modify a database
+
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/databases/{databaseId}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceDatabase.Modify | Modify a database |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| databaseId | URL | UUID | O | Database identifier |
+| applyHbaRulesImmediately | Body | Boolean | X | Whether to apply associated access control rules immediately<br/>- Default: `false` |
+| databaseName | Body | String | O | Database name |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "applyHbaRulesImmediately": false,
+    "databaseName": "databaseName-example"
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of the requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
 ### View the list of users
 
 ```http
@@ -2704,31 +1952,32 @@ GET /v1.0/db-instances/{dbInstanceId}/db-users
 
 #### Required permissions
 
-| Permission Name                                  | Description                  |
-|--------------------------------------|---------------------|
-| RDSforPostgreSQL:DbInstanceUser.List | Viewing a list of users in a DB instance |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceUser.List | View the list of users |
 
 #### Request
 
 This API does not require a request body.
 
-| Name           | Type  | Format   | Required | Description           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB instance identifier |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
 
 #### Response
 
-| Name                    | Type   | Format       | Description                                                                                                                                                  |
-|-----------------------|------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbUsers               | Body | Array    | DB users                                                                                                                                           |
-| dbUsers.dbUserId      | Body | UUID     | DB user identifier                                                                                                                                         |
-| dbUsers.dbUserName    | Body | String   | DB user account name                                                                                                                                        |
-| dbUsers.authorityType | Body | Enum     | DB user permission types<br/>- `CRUD`: Permission to execute DML query<br/>- `DDL`: Permission to execute DDL query                                                                           |
-| dbUsers.dbUserStatus  | Body | Enum     | DB user current status<br/>- `STABLE`: Created<br/>(CREATING: Creating,<br/>- `MODIFYING`: Modifying<br/>- `SYNCING`: Synchronizing<br/>DELETING: Deleting,<br/>- `DELETED`: Deleted |
-| dbUsers.createdYmdt   | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                   |
-| dbUsers.updatedYmdt   | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                   |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| dbUsers | Body | Array | DB user list |
+| dbUsers.dbUserId | Body | UUID | DB user identifier |
+| dbUsers.dbUserName | Body | String | DB user account name |
+| dbUsers.authorityType | Body | Enum | DB user permission types<br/>- CUSTOM: `Custom permission`<br/>- READ: `READ permission (read-only permission)`<br/>- CRUD: `CRUD permission (includes read permission)`<br/>- DDL: `DDL permission (includes CRUD permission)` |
+| dbUsers.dbUserStatus | Body | Enum | DB user current status<br/>- STABLE: `Available`<br/>- CREATING: `Creating`<br/>- MODIFYING: `Modifying`<br/>- DELETING: `Deleting`<br/>- DELETED: `Deleted`<br/>- SYNCING: `Synchronizing`<br/>- DELETE_ERROR: `Deletion failed` |
+| dbUsers.createdYmdt | Body | DateTime | Created date and time |
+| dbUsers.updatedYmdt | Body | DateTime | Modified date and time |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -2737,17 +1986,23 @@ This API does not require a request body.
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "databases": [
+    "dbUsers": [
         {
-            "databaseId": "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4",
-            "databaseName": "database",
-            "databaseStatus": "STABLE",
-            "createdYmdt": "2023-03-20T13:37:45+09:00"
+            "dbUserId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbUserName": "dbUserName-example",
+            "authorityType": "CUSTOM",
+            "dbUserStatus": "STABLE",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
+
+</p>
 </details>
+
+---
 
 ### Create a user
 
@@ -2757,39 +2012,45 @@ POST /v1.0/db-instances/{dbInstanceId}/db-users
 
 #### Required permissions
 
-| Permission Name                                    | Description                 |
-|----------------------------------------|--------------------|
-| RDSforPostgreSQL:DbInstanceUser.Create | Creating a user in a DB instance |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceUser.Create | Create a user |
 
 #### Request
 
-| Name                    | Type   | Format      | Required | Description                                                                        |
-|-----------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId          | URL  | UUID    | O  | DB instance identifier                                                              |
-| dbUserName            | Body | String  | O  | DB user account name<br/>- Minimum length: `1`<br/>- Maximum length: `32`                           |
-| dbPassword            | Body | String  | O  | DB user account password<br/>- Minimum length: `1`<br/>- Maximum length: `32`                          |
-| authorityType         | Body | Enum    | O  | DB user permission types<br/>- `CRUD`: Permission to execute DML query<br/>- `DDL`: Permission to execute DDL query |
-| createDefaultHbaRules | Body | Boolean | X  | Whether to create default access control rules                                                         |
-| address               | Body | String  | X  | Connection address to use when creating default access control rules                                                |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbUserName | Body | String | O | DB user account name |
+| dbPassword | Body | String | O | DB user account password |
+| authorityType | Body | Enum | O | DB user permission types<br/>- CUSTOM: `Custom permission`<br/>- READ: `Read permission`<br/>- CRUD: `CRUD permission`<br/>- DDL: `DDL permission` |
+| createDefaultHbaRules | Body | Boolean | X | Whether to create default access control rules<br/>- Default: `false` |
+| address | Body | String | X | Connection address |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "authorityType": "CRUD"
+    "dbUserName": "dbUserName-example",
+    "dbPassword": "dbPassword-example",
+    "authorityType": "CUSTOM",
+    "createDefaultHbaRules": false,
+    "address": "address-example"
 }
 ```
+
+</p>
 </details>
 
 #### Response
 
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | Identifier of requested task |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -2798,10 +2059,60 @@ POST /v1.0/db-instances/{dbInstanceId}/db-users
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
+
+---
+
+### Delete a user
+
+```http
+DELETE /v1.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceUser.Delete | Delete a user |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbUserId | URL | UUID | O | DB user identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
 
 ### Edit a user
 
@@ -2811,38 +2122,44 @@ PUT /v1.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
 
 #### Required permissions
 
-| Permission Name                                    | Description                 |
-|----------------------------------------|--------------------|
-| RDSforPostgreSQL:DbInstanceUser.Modify | Modifying users in a DB instance |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceUser.Modify | Edit a user |
 
 #### Request
 
-| Name                       | Type   | Format      | Required | Description                                                                                          |
-|--------------------------|------|---------|----|---------------------------------------------------------------------------------------------|
-| dbInstanceId             | URL  | UUID    | O  | DB instance identifier                                                                                |
-| dbUserId                 | URL  | UUID    | O  | DB user identifier                                                                                 |
-| dbUserName               | Body | String  | X  | DB user account name<br/>- Minimum length: `1`<br/>- Maximum length: `32`                                             |
-| dbPassword               | Body | String  | X  | DB user account password<br/>- Minimum length: `1`<br/>- Maximum length: `32`                                            |
-| authorityType            | Body | Enum    | X  | DB user permission types<br/>- `CRUD`: Permission to execute DML query<br/>- `DDL`: Permission to execute DDL query                   |
-| applyHbaRulesImmediately | Body | Boolean | X  | Whether to apply associated access control rules immediately<br/>- When you change a user account name, any access control rules set under the old user account name are reflected with the changed name. |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbUserId | URL | UUID | O | DB user identifier |
+| dbUserName | Body | String | X | DB user account name |
+| dbPassword | Body | String | X | DB user account password |
+| authorityType | Body | Enum | X | DB user permission<br/>- CUSTOM: `Custom permission`<br/>- READ: `Read permission`<br/>- CRUD: `CRUD permission`<br/>- DDL: `DDL permission` |
+| applyHbaRulesImmediately | Body | Boolean | X | Whether to apply access control changes immediately<br/>- Default: `false` |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
-    "dbUserName": "db-user-1",
-    "dbPassword": "new-password"
+    "dbUserName": "dbUserName-example",
+    "dbPassword": "dbPassword-example",
+    "authorityType": "CUSTOM",
+    "applyHbaRulesImmediately": false
 }
 ```
+
+</p>
 </details>
 
 #### Response
 
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | Identifier of requested task |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -2851,54 +2168,77 @@ PUT /v1.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-### Deleting a user
+---
+
+### Change DB Instance Deletion Protection Settings
 
 ```http
-DELETE /v1.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
+PUT /v1.0/db-instances/{dbInstanceId}/deletion-protection
 ```
 
 #### Required permissions
 
-| Permission Name                                    | Description                 |
-|----------------------------------------|--------------------|
-| RDSforPostgreSQL:DbInstanceUser.Delete | Deleting a user in a DB instance |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Modify | Change DB instance deletion protection settings |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| useDeletionProtection | Body | Boolean | O | Whether to enable deletion protection |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "useDeletionProtection": false
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+This API does not return a response body.
+
+---
+
+### Force Restart DB Instance
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/force-restart
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.ForceRestart | Force Restart DB Instance |
 
 #### Request
 
 This API does not require a request body.
 
-| Name           | Type  | Format   | Required | Description           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB instance identifier |
-| dbUserId     | URL | UUID | O  | DB user identifier  |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
 
 #### Response
 
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
+This API does not return a response body.
 
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-## DB Instances > Access Control
-
+---
 ### View a list of access control rules
 
 ```http
@@ -2907,41 +2247,42 @@ GET /v1.0/db-instances/{dbInstanceId}/hba-rules
 
 #### Required permissions
 
-| Permission Name                                 | Description                       |
-|-------------------------------------|--------------------------|
-| RDSforPostgreSQL:DbInstanceHba.List | View a list of access control rules in a DB instance |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceHba.List | View a list of access control rules |
 
 #### Request
 
 This API does not require a request body.
 
-| Name           | Type  | Format   | Required | Description           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB instance identifier |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
 
 #### Response
 
-| Name                              | Type   | Format      | Description                                                                                                                                                   |
-|---------------------------------|------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------|
-| hbaRules                        | Body | Array   | List of access control rules                                                                                                                                          |
-| hbaRules.hbaRuleId              | Body | UUID    | Identifiers for access control rules                                                                                                                                        |
-| hbaRules.hbaRuleStatus          | Body | Enum    | Current status of access control rules<br/>- `CREATED: Created`<br/>- `APPLIED`: Applied<br/>(CREATING: Creating,<br/>- `MODIFYING`: Modifying<br/>DELETING: Deleting,<br/>- `DELETED`: Deleted |
-| hbaRules.databaseApplyType      | Body | String  | How database rules are applied<br/>- `ENTIRE`: All<br/>- `USER_CUSTOM`: Customize                                                                                       |
-| hbaRules.dbUserApplyType        | Body | Enum    | How DB user rules are applied<br/>- `ENTIRE`: All<br/>- `USER_CUSTOM`: Customize                                                                                       |
-| hbaRules.databases              | Body | Array   | List of custom databases                                                                                                                                     |
-| hbaRules.databases.databaseId   | Body | UUID    | Identifiers for custom databases                                                                                                                                   |
-| hbaRules.databases.databaseName | Body | String  | Custom database name                                                                                                                                     |
-| hbaRules.dbUsers                | Body | Array   | Custom DB user list                                                                                                                                     |
-| hbaRules.dbUsers.dbUserId       | Body | UUID    | Identifier of the custom DB user                                                                                                                                   |
-| hbaRules.dbUsers.dbUserName     | Body | String  | Custom DB user account name                                                                                                                                  |
-| hbaRules.address                | Body | String  | Access Address                                                                                                                                                |
-| hbaRules.authMethod             | Body | Enum    | Authentication Method<br/>- `TRUST`: Trust (no password required)<br/>- `REJECT`: Block access<br/>- `SCRAM_SHA_256`: Password (SCRAM-SHA-256)                                                 |
-| hbaRules.reservedAction         | Body | Enum    | Preliminaries<br/>- `NONE`: None<br/>- `CREATE`: Schedule a creation (requires application)<br/>- `MODIFY`: Schedule a modification (requires application)<br/>- `DELETE`: Schedule a delete (requires enforcement)                                        |
-| hbaRules.order                  | Body | Number  | Application order                                                                                                                                                |
-| hbaRules.applicable             | Body | Boolean | Applicability<br/>- Rules with an inapplicable status are ignored                                                                                                                     |
-| needToApply                     | Body | Boolean | Whether changes need to be made                                                                                                                                       |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| hbaRules | Body | Array | List of access control rules |
+| hbaRules.hbaRuleId | Body | UUID | Identifier of the access control rule |
+| hbaRules.hbaRuleStatus | Body | Enum | Current status of the access control rule<br/>- CREATED: `Created`<br/>- APPLIED: `Applied`<br/>- CREATING: `Creating`<br/>- MODIFYING: `Modifying`<br/>- DELETING: `Deleting`<br/>- DELETED: `Deleted` |
+| hbaRules.databaseApplyType | Body | Enum | Database apply type<br/>- ENTIRE: `All`<br/>- USER_CUSTOM: `Customize` |
+| hbaRules.dbUserApplyTypeCode | Body | Enum | DB user apply type<br/>- ENTIRE: `All`<br/>- USER_CUSTOM: `Customize` |
+| hbaRules.databases | Body | Array | List of custom databases |
+| hbaRules.databases.databaseId | Body | UUID | Database identifier |
+| hbaRules.databases.databaseName | Body | String | Database name |
+| hbaRules.dbUsers | Body | Array | Custom DB user list |
+| hbaRules.dbUsers.dbUserId | Body | UUID | DB user identifier |
+| hbaRules.dbUsers.dbUserName | Body | String | DB user account name |
+| hbaRules.address | Body | String | Connection address |
+| hbaRules.authMethod | Body | Enum | Authentication method<br/>- TRUST: `Trust (no password required)`<br/>- REJECT: `Block access`<br/>- SCRAM_SHA_256: `Password (SCRAM-SHA-256)` |
+| hbaRules.reservedAction | Body | Enum | Scheduled task<br/>- NONE: `None`<br/>- CREATE: `Schedule a creation (requires application)`<br/>- MODIFY: `Schedule a modification (requires application)`<br/>- DELETE: `Schedule a deletion (requires application)` |
+| hbaRules.order | Body | Number | Application order |
+| hbaRules.applicable | Body | Boolean | Whether the rule is applicable |
+| needToApply | Body | Boolean | Whether changes need to be applied |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -2952,27 +2293,37 @@ This API does not require a request body.
     },
     "hbaRules": [
         {
-            "hbaRuleId": "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4",
-            "hbaRuleStatus": "APPLIED",
-            "databaseApplyType": "USER_CUSTOM",
-            "dbUserApplyType": "ENTIRE",
+            "hbaRuleId": "550e8400-e29b-41d4-a716-446655440000",
+            "hbaRuleStatus": "CREATED",
+            "databaseApplyType": "ENTIRE",
+            "dbUserApplyTypeCode": "ENTIRE",
             "databases": [
                 {
-                    "databaseId": "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4",
-                    "databaseName": "database"
+                    "databaseId": "550e8400-e29b-41d4-a716-446655440000",
+                    "databaseName": "databaseName-example"
                 }
             ],
-            "dbUsers": [],
-            "address": "0.0.0.0/0",
+            "dbUsers": [
+                {
+                    "dbUserId": "550e8400-e29b-41d4-a716-446655440000",
+                    "dbUserName": "dbUserName-example"
+                }
+            ],
+            "address": "address-example",
             "authMethod": "TRUST",
             "reservedAction": "NONE",
-            "order": 0,
-            "applicable": true
+            "order": 1,
+            "applicable": false
         }
-    ]
+    ],
+    "needToApply": false
 }
 ```
+
+</p>
 </details>
+
+---
 
 ### Add an access control rule
 
@@ -2982,45 +2333,49 @@ POST /v1.0/db-instances/{dbInstanceId}/hba-rules
 
 #### Required permissions
 
-| Permission Name                                   | Description                      |
-|---------------------------------------|-------------------------|
-| RDSforPostgreSQL:DbInstanceHba.Create | Adding access control rules within a DB instance |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceHba.Create | Add an access control rule to a DB instance |
 
 #### Request
 
-| Name                | Type   | Format     | Required | Description                                                                                                   |
-|-------------------|------|--------|----|------------------------------------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID   | O  | DB instance identifier                                                                                         |
-| databaseApplyType | Body | String | O  | How database rules are applied<br/>- `ENTIRE`: All<br/>- `USER_CUSTOM`: Customize                                       |
-| dbUserApplyType   | Body | Enum   | O  | How DB user rules are applied<br/>- `ENTIRE`: All<br/>- `USER_CUSTOM`: Customize                                       |
-| databaseIds       | Body | Array  | X  | List of identifiers for a custom database                                                                                |
-| dbUserIds         | Body | Array  | X  | List of identifiers for custom DB users                                                                                |
-| address           | Body | String | O  | Access Address<br/>- Enter in CIDR format, hostname, or domain format                                                             |
-| authMethod        | Body | Enum   | O  | Authentication Method<br/>- `TRUST`: Trust (no password required)<br/>- `REJECT`: Block access<br/>- `SCRAM_SHA_256`: Password (SCRAM-SHA-256) |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| connectionTypeCode | Body | Enum | X | Access control record type<br/>- HOST: `Valid for TCP/IP connections`<br/>- HOST_NO_SSL: `Valid only for connections without SSL encryption` |
+| databaseApplyType | Body | Enum | O | Database apply type<br/>- ENTIRE: `All`<br/>- USER_CUSTOM: `Customize` |
+| dbUserApplyType | Body | Enum | O | DB user apply type<br/>- ENTIRE: `All`<br/>- USER_CUSTOM: `Customize` |
+| databaseIds | Body | Array | X | List of database identifiers |
+| dbUserIds | Body | Array | X | List of DB user identifiers |
+| address | Body | String | O | Connection address |
+| authMethod | Body | Enum | O | Authentication method<br/>- TRUST: `Trust (no password required)`<br/>- REJECT: `Block access`<br/>- SCRAM_SHA_256: `Password (SCRAM-SHA-256)` |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
+    "connectionTypeCode": "HOST",
     "databaseApplyType": "ENTIRE",
-    "dbUserApplyType": "USER_CUSTOM",
-    "databaseIds": [], 
-    "dbUserIds": [
-        "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4"
-    ],
-    "address": "0.0.0.0/0",
+    "dbUserApplyType": "ENTIRE",
+    "databaseIds": [],
+    "dbUserIds": [],
+    "address": "address-example",
     "authMethod": "TRUST"
 }
 ```
+
+</p>
 </details>
 
 #### Response
 
-| Name        | Type   | Format   | Description            |
-|-----------|------|------|---------------|
-| hbaRuleId | Body | UUID | Identifiers for access control rules |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| hbaRuleId | Body | UUID | Identifier of the access control rule |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -3029,93 +2384,43 @@ POST /v1.0/db-instances/{dbInstanceId}/hba-rules
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "hbaRuleId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "hbaRuleId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-### Modify an access control rule
+---
+
+### Apply access control rules
 
 ```http
-PUT /v1.0/db-instances/{dbInstanceId}/hba-rules/{hbaRuleId}
+POST /v1.0/db-instances/{dbInstanceId}/hba-rules/apply
 ```
 
 #### Required permissions
 
-| Permission Name                                   | Description                      |
-|---------------------------------------|-------------------------|
-| RDSforPostgreSQL:DbInstanceHba.Modify | Modifying access control rules within a DB instance |
-
-#### Request
-
-| Name                | Type   | Format     | Required | Description                                                                                                   |
-|-------------------|------|--------|----|------------------------------------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID   | O  | DB instance identifier                                                                                         |
-| hbaRuleId         | URL  | UUID   | O  | Identifiers for access control rules                                                                                        |
-| databaseApplyType | Body | String | O  | How database rules are applied<br/>- `ENTIRE`: All<br/>- `USER_CUSTOM`: Customize                                       |
-| dbUserApplyType   | Body | Enum   | O  | How DB user rules are applied<br/>- `ENTIRE`: All<br/>- `USER_CUSTOM`: Customize                                       |
-| databaseIds       | Body | Array  | X  | List of identifiers for a custom database                                                                                |
-| dbUserIds         | Body | Array  | X  | List of identifiers for custom DB users                                                                                |
-| address           | Body | String | O  | Access Address<br/>- Enter in CIDR format, hostname, or domain format                                                             |
-| authMethod        | Body | Enum   | O  | Authentication Method<br/>- `TRUST`: Trust (no password required)<br/>- `REJECT`: Block access<br/>- `SCRAM_SHA_256`: Password (SCRAM-SHA-256) |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "databaseApplyType": "ENTIRE",
-    "dbUserApplyType": "ENTIRE",
-    "databaseIds": [], 
-    "dbUserIds": [],
-    "address": "0.0.0.0/0",
-    "authMethod": "REJECT"
-}
-```
-</details>
-
-#### Response
-
-This API does not return a response body.
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
-
-### Deleting an access control rule
-
-```http
-DELETE /v1.0/db-instances/{dbInstanceId}/hba-rules/{hbaRuleId}
-```
-
-#### Required permissions
-
-| Permission Name                                   | Description                      |
-|---------------------------------------|-------------------------|
-| RDSforPostgreSQL:DbInstanceHba.Delete | Deleting an access control rule in a DB instance |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Modify | Modify DB Instance |
 
 #### Request
 
 This API does not require a request body.
 
-| Name           | Type  | Format   | Required | Description            |
-|--------------|-----|------|----|---------------|
-| dbInstanceId | URL | UUID | O  | DB instance identifier  |
-| hbaRuleId    | URL | UUID | O  | Identifiers for access control rules |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
 
 #### Response
 
-This API does not return a response body.
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of the requested task |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -3123,10 +2428,15 @@ This API does not return a response body.
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
+
+---
 
 ### Reorder access control rules
 
@@ -3136,72 +2446,141 @@ PUT /v1.0/db-instances/{dbInstanceId}/hba-rules/orders
 
 #### Required permissions
 
-| Permission Name                                   | Description                      |
-|---------------------------------------|-------------------------|
-| RDSforPostgreSQL:DbInstanceHba.Modify | Modifying access control rules within a DB instance |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceHba.Modify | Modify access control rules in a DB instance |
 
 #### Request
 
-| Name           | Type  | Format   | Required | Description                                  |
-|--------------|-----|------|----|-------------------------------------|
-| dbInstanceId | URL | UUID | O  | DB instance identifier                        |
-| hbaRuleIds   | URL | Body | O  | List of identifiers for access control rules<br/>- Adjusted in the order you requested |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| hbaRuleIds | Body | Array | O | Sorted list of access control rule identifiers (saved in the order requested) |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
-    "hbaRuleIds": [
-        "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4"
-    ]
+    "hbaRuleIds": []
 }
 ```
+
+</p>
 </details>
 
 #### Response
 
 This API does not return a response body.
 
-<details><summary>Example</summary>
+---
 
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
-
-### Applying access control rules
+### Delete an access control rule
 
 ```http
-POST /v1.0/db-instances/{dbInstanceId}/hba-rules/apply
+DELETE /v1.0/db-instances/{dbInstanceId}/hba-rules/{hbaRuleId}
 ```
 
 #### Required permissions
 
-| Permission Name                                   | Description           |
-|---------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Modify    | Modify DB Instance |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceHba.Delete | Delete an access control rule from a DB instance |
 
 #### Request
 
 This API does not require a request body.
 
-| Name           | Type  | Format   | Required | Description           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB instance identifier |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| hbaRuleId | URL | UUID | O | Identifier of the access control rule |
 
 #### Response
 
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
+This API does not return a response body.
+
+---
+
+### Modify an access control rule
+
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/hba-rules/{hbaRuleId}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceHba.Modify | Modify access control rules in a DB instance |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| hbaRuleId | URL | UUID | O | Identifier of the access control rule |
+| connectionTypeCode | Body | Enum | X | Access control record type<br/>- HOST: `Valid for TCP/IP connections`<br/>- HOST_NO_SSL: `Valid only for connections without SSL encryption` |
+| databaseApplyType | Body | Enum | O | Database apply type<br/>- ENTIRE: `All`<br/>- USER_CUSTOM: `Customize` |
+| dbUserApplyType | Body | Enum | O | DB user apply type<br/>- ENTIRE: `All`<br/>- USER_CUSTOM: `Customize` |
+| databaseIds | Body | Array | X | List of database identifiers |
+| dbUserIds | Body | Array | X | List of DB user identifiers |
+| address | Body | String | O | Connection address |
+| authMethod | Body | Enum | O | Authentication method<br/>- TRUST: `Trust (no password required)`<br/>- REJECT: `Block access`<br/>- SCRAM_SHA_256: `Password (SCRAM-SHA-256)` |
 
 <details><summary>Example</summary>
+<p>
+
+```json
+{
+    "connectionTypeCode": "HOST",
+    "databaseApplyType": "ENTIRE",
+    "dbUserApplyType": "ENTIRE",
+    "databaseIds": [],
+    "dbUserIds": [],
+    "address": "address-example",
+    "authMethod": "TRUST"
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+This API does not return a response body.
+
+---
+### Get high availability information
+
+```http
+GET /v1.0/db-instances/{dbInstanceId}/high-availability
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:HighAvailability.Get | Get high availability information |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| haStatus | Body | Enum | High availability status<br/>- CREATED: `Created`<br/>- STABLE: `Normal`<br/>- PAUSING: `Pausing`<br/>- DISABLE: `Stopped`<br/>- DISABLE_MASTER_IN_REPLICATION: `High availability stopped due to abnormal master replication detected`<br/>- DISABLE_MHA_PROCESS: `High availability process stopped`<br/>- DISABLE_REPLICATION_STOP: `High availability stopped due to replication stop`<br/>- DISABLE_REPLICATION_DELAY: `High availability stopped due to replication delay`<br/>- FAILOVER_STARTED: `Failover started`<br/>- FAILOVER_FAILED: `Failover failed`<br/>- FAILOVER_COMPLETED: `Failover completed`<br/>- DELETED: `Deleted`<br/>- PAUSED: `Paused`<br/>- PAUSED_DUE_TO_TASK: `Paused due to task`<br/>- MASTER_FAILURE_DETECTION: `Master failure detected` |
+| pingInterval | Body | Number | Ping interval (sec) when using high availability |
+| failoverReplWaitingTime | Body | Number | Failover replication delay waiting time (sec) when using high availability |
+
+<details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -3210,12 +2589,1079 @@ This API does not require a request body.
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "haStatus": "CREATED",
+    "pingInterval": 1,
+    "failoverReplWaitingTime": 1
 }
 ```
+
+</p>
 </details>
 
+---
+
+### Modify High Availability
+
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/high-availability
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:HighAvailability.Modify | Modify High Availability |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| useHighAvailability | Body | Boolean | O | Whether to use high availability |
+| pingInterval | Body | Number | X | Ping interval (sec)<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
+| failoverReplWaitingTime | Body | Number | X | Failover replication delay waiting time (sec)<br/>- Minimum value: `-1` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "useHighAvailability": false,
+    "pingInterval": 1,
+    "failoverReplWaitingTime": 1
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Pause High Availability
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/high-availability/pause
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:HighAvailability.Pause | Pause High Availability |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Recover High Availability
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/high-availability/repair
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:HighAvailability.Repair | Recover High Availability |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Restart High Availability
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/high-availability/resume
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:HighAvailability.Resume | Restart High Availability |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Separate High Availability
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/high-availability/split
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:HighAvailability.Split | Separate High Availability |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+### Get DB instance maintenance information
+
+```http
+GET /v1.0/db-instances/{dbInstanceId}/maintenance-info
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Get | Get DB instance maintenance information |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| allowAutoMaintenance | Body | Boolean | Whether to allow automatic maintenance |
+| useAutoStorageCleanup | Body | Boolean | Whether to enable automatic storage cleanup |
+| maintWndBgnTime | Body | Time | Automatic maintenance start time |
+| maintWndDuration | Body | Enum | Maintenance window<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1 hour 30 minutes`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2 hours 30 minutes`<br/>- THREE_HOURS: `3 hours` |
+| logRetentionPeriod | Body | Number | Log retention period (days) |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "allowAutoMaintenance": false,
+    "useAutoStorageCleanup": false,
+    "maintWndBgnTime": "00:00:00",
+    "maintWndDuration": "HALF_AN_HOUR",
+    "logRetentionPeriod": 1
+}
+```
+
+</p>
+</details>
+
+---
+
+### Modify DB instance maintenance information
+
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/maintenance-info
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Modify | Modify DB instance maintenance information |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| allowAutoMaintenance | Body | Boolean | X | Whether to allow automatic maintenance |
+| useAutoStorageCleanup | Body | Boolean | X | Whether to enable automatic storage cleanup |
+| maintWndBgnTime | Body | Time | X | Automatic maintenance start time |
+| maintWndDuration | Body | Enum | X | Maintenance window<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1 hour 30 minutes`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2 hours 30 minutes`<br/>- THREE_HOURS: `3 hours` |
+| logRetentionPeriod | Body | Number | X | Log retention period (days)<br/>- Minimum: `1`<br/>- Maximum: `30` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "allowAutoMaintenance": false,
+    "useAutoStorageCleanup": false,
+    "maintWndBgnTime": "00:00:00",
+    "maintWndDuration": "HALF_AN_HOUR",
+    "logRetentionPeriod": 1
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+### Get DB instance network information
+
+```http
+GET /v1.0/db-instances/{dbInstanceId}/network-info
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Get | Get DB instance network information |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| availabilityZone | Body | Enum | Availability zone where DB instance will be created |
+| subnet | Body | Object | Subnet object |
+| subnet.subnetId | Body | UUID | Subnet identifier |
+| subnet.subnetName | Body | String | Name to identify subnets |
+| subnet.subnetCidr | Body | String | CIDR of subnet |
+| subnet.publicAccessible | Body | Boolean | External access is available or not |
+| endPoints | Body | Array | List of access information |
+| endPoints.domain | Body | String | Domain |
+| endPoints.ipAddress | Body | String | IP address |
+| endPoints.endPointType | Body | String | Types of access information |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "availabilityZone": "kr-pub-a",
+    "subnet": {
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "subnetName": "subnetName-example",
+        "subnetCidr": "192.168.0.0/24",
+        "publicAccessible": false
+    },
+    "endPoints": [
+        {
+            "domain": "domain-example",
+            "ipAddress": "192.168.0.1",
+            "endPointType": "https://example.com"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### Modify DB instance network information
+
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/network-info
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Modify | Modify DB instance network information |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| usePublicAccess | Body | Boolean | O | External access is available or not |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "usePublicAccess": false
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Promote DB Instance
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/promote
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Promote | Promote DB Instance |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+### Create Read Replica
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/replicate
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Replicate | Create read replica |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceName | Body | String | O | Name to identify the DB instance |
+| description | Body | String | X | Additional information on the DB instance |
+| dbFlavorId | Body | UUID | X | Identifier of DB instance specifications |
+| dbPort | Body | Number | X | DB port<br/>- Minimum value: 5432, Maximum value: 45432 |
+| parameterGroupId | Body | UUID | X | Parameter group identifier |
+| dbSecurityGroupIds | Body | Array | X | List of DB security group identifiers |
+| userGroupIds | Body | Array | X | List of user group identifiers |
+| useDefaultNotification | Body | Boolean | X | Whether to use default notification<br/>- Default: `false` |
+| useDeletionProtection | Body | Boolean | X | Whether deletion protection is enabled<br/>- Default: `false` |
+| network | Body | Object | X | Network information object |
+| network.usePublicAccess | Body | Boolean | X | Whether external access is available<br/>- Default: `false` |
+| network.availabilityZone | Body | Enum | X | Availability zone where the DB instance will be created |
+| storage | Body | Object | X | Storage information object |
+| storage.storageType | Body | Enum | X | Data storage type |
+| storage.storageSize | Body | Number | X | Data storage size (GB)<br/>- Minimum value: `20`<br/>- Maximum value: `2048` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName-example",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useDefaultNotification": false,
+    "useDeletionProtection": false,
+    "network": {
+        "usePublicAccess": false,
+        "availabilityZone": "kr-pub-a"
+    },
+    "storage": {
+        "storageType": "General SSD",
+        "storageSize": 20
+    }
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of the requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Restart DB Instance
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/restart
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Restart | Restart DB Instance |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of the requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Get DB Instance Restore Information
+
+```http
+GET /v1.0/db-instances/{dbInstanceId}/restoration-info
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Get | Get DB instance restore information |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| oldestRestorableYmdt | Body | DateTime | Oldest restorable time |
+| latestRestorableYmdt | Body | DateTime | Most recent restorable time |
+| restorableBackups | Body | Array | List of restorable backups |
+| restorableBackups.backupId | Body | UUID | Backup identifier |
+| restorableBackups.backupName | Body | String | Backup name |
+| restorableBackups.backupStatus | Body | Enum | Backup status<br/>- BACKING_UP: `Backing up (spinner)`<br/>- VERIFYING: `Verifying (spinner)`<br/>- COMPLETED: `Available (green icon)`<br/>- DELETING: `Deleting (spinner)`<br/>- DELETED: `Deleted (gray icon)`<br/>- ERROR: `Error (red icon)` |
+| restorableBackups.dbInstanceId | Body | UUID | Original DB instance identifier |
+| restorableBackups.dbInstanceName | Body | String | Original DB instance name |
+| restorableBackups.dbVersion | Body | Enum | DB engine type |
+| restorableBackups.backupType | Body | Enum | Backup type<br/>- AUTO<br/>- MANUAL |
+| restorableBackups.backupSize | Body | Number | Backup size |
+| restorableBackups.failoverCount | Body | Number | Number of failovers |
+| restorableBackups.walFileName | Body | String | WAL file name |
+| restorableBackups.createdYmdt | Body | DateTime | Backup creation date and time |
+| restorableBackups.updatedYmdt | Body | DateTime | Backup update date and time |
+| restorableBackups.startYmdt | Body | DateTime | Backup start date and time |
+| restorableBackups.completedYmdt | Body | DateTime | Backup completion date and time |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "oldestRestorableYmdt": "2023-12-31T15:00:00+09:00",
+    "latestRestorableYmdt": "2023-12-31T15:00:00+09:00",
+    "restorableBackups": [
+        {
+            "backupId": "550e8400-e29b-41d4-a716-446655440000",
+            "backupName": "backupName-example",
+            "backupStatus": "BACKING_UP",
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbInstanceName": "dbInstanceName-example",
+            "dbVersion": "POSTGRESQL_V14_17",
+            "backupType": "AUTO",
+            "backupSize": 1,
+            "failoverCount": 1,
+            "walFileName": "walFileName-example",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00",
+            "startYmdt": "2023-12-31T15:00:00+09:00",
+            "completedYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### Restore DB Instance
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/restore
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Restore | Restore DB Instance |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceName | Body | String | X | Name to identify the DB instance |
+| dbInstanceCandidateName | Body | String | X | Candidate master name to identify the DB instance |
+| description | Body | String | X | Additional information on the DB instance<br/>- Maximum length: `100` |
+| dbFlavorId | Body | UUID | O | Identifier of DB instance specifications |
+| dbPort | Body | Number | X | DB port<br/>- Minimum value: 5432, Maximum value: 45432 |
+| useHighAvailability | Body | Boolean | X | Whether to use high availability<br/>- Default: `false` |
+| imageId | Body | UUID | X | Image identifier |
+| pingInterval | Body | Number | X | Ping interval (sec) when using high availability<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
+| failoverReplWaitingTime | Body | Number | X | Failover replication delay wait time (sec)<br/>- Minimum value: `-1` |
+| storage | Body | Object | O | Storage information object |
+| storage.storageType | Body | Enum | O | Storage type |
+| storage.storageSize | Body | Number | O | Data storage size (GB)<br/>- Minimum value: `20` |
+| network | Body | Object | O | Network information object |
+| network.subnetId | Body | UUID | O | Subnet identifier |
+| network.usePublicAccess | Body | Boolean | X | Whether external access is available<br/>- Default: `false` |
+| network.availabilityZone | Body | Enum | X | Availability zone where the DB instance will be created |
+| backup | Body | Object | O | Backup information object |
+| backup.backupPeriod | Body | Number | O | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| backup.backupRetryCount | Body | Number | X | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| backup.replicationRegion | Body | Enum | X | Backup replication region<br/>- KR1: `Korea (Pangyo)`<br/>- KR2: `Korea (Pyeongchon)` |
+| backup.backupSchedules | Body | Array | O | Backup schedule list |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | O | Backup start time |
+| backup.backupSchedules.backupWndDuration | Body | Enum | O | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1 hour 30 minutes`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2 hours 30 minutes`<br/>- THREE_HOURS: `3 hours` |
+| restore | Body | Object | O | Restoration information object |
+| restore.restoreType | Body | Enum | O | Restoration type<br/>- BACKUP: `Restoration using a previously created backup`<br/>- TIMESTAMP: `Point-in-time recovery using a time within the restorable period` |
+| restore.restoreYmdt | Body | DateTime | X | DB instance restore date and time |
+| restore.backupId | Body | UUID | X | Identifier of the backup to use for restoration |
+| useDefaultNotification | Body | Boolean | X | Whether to use default notification<br/>- Default: `false` |
+| parameterGroupId | Body | UUID | O | Parameter group identifier |
+| dbSecurityGroupIds | Body | Array | X | List of DB security group identifiers |
+| userGroupIds | Body | Array | X | List of user group identifiers |
+| useDeletionProtection | Body | Boolean | X | Whether deletion protection is enabled<br/>- Default: `false` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName-example",
+    "dbInstanceCandidateName": "dbInstanceCandidateName-example",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "useHighAvailability": false,
+    "imageId": "550e8400-e29b-41d4-a716-446655440000",
+    "pingInterval": 3,
+    "failoverReplWaitingTime": 60,
+    "storage": {
+        "storageType": "General SSD",
+        "storageSize": 20
+    },
+    "network": {
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
+        "availabilityZone": "kr-pub-a"
+    },
+    "backup": {
+        "backupPeriod": 0,
+        "backupRetryCount": 0,
+        "replicationRegion": "KR1",
+        "backupSchedules": [
+            {
+                "backupWndBgnTime": "00:00:00",
+                "backupWndDuration": "HALF_AN_HOUR"
+            }
+        ]
+    },
+    "restore": {
+        "restoreType": "BACKUP",
+        "restoreYmdt": "2023-12-31T15:00:00+09:00",
+        "backupId": "550e8400-e29b-41d4-a716-446655440000"
+    },
+    "useDefaultNotification": false,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useDeletionProtection": false
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of the requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+### Start DB Instance
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/start
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Start | Start DB Instance |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Stop DB Instance
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/stop
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Stop | Stop DB Instance |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Get DB Instance Storage Information
+
+```http
+GET /v1.0/db-instances/{dbInstanceId}/storage-info
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Get | Get DB Instance Storage Information |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| storageType | Body | Enum | Data storage types |
+| storageSize | Body | Number | Data storage size (GB) |
+| storageStatus | Body | Enum | Data storage current status<br/>- DELETED: `Deleted`<br/>- PENDING_DELETION: `Deletion deferred`<br/>- DELETION_RESERVED: `Deletion reserved (pending snapshot cleanup)`<br/>- DETACHED: `Detached`<br/>- ATTACHED: `Attached` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "storageType": "General SSD",
+    "storageSize": 1,
+    "storageStatus": "DELETED"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Modify DB Instance Storage Information
+
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/storage-info
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Modify | Modify DB Instance Storage Information |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| storageSize | Body | Number | O | Data storage size (GB)<br/>- Maximum value: `2048` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "storageSize": 1
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
 ## Backup
+
+### Backup Status
+
+| Status         | Description                  |
+|--------------|------------------------------|
+| `BACKING_UP` | Backup in progress           |
+| `COMPLETED`  | Backup completed             |
+| `DELETING`   | Backup being deleted         |
+| `DELETED`    | Backup deleted               |
+| `ERROR`      | Error occurred               |
 
 ### Retrieve Backup List
 
@@ -3225,40 +3671,34 @@ GET /v1.0/backups
 
 #### Required permissions
 
-| Permission Name                          | Description       |
-|------------------------------|----------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforPostgreSQL:Backup.List | Retrieve Backup List |
 
 #### Request
 
 This API does not require a request body.
 
-| Name           | Type    | Format     | Required | Description                                                         |
-|--------------|-------|--------|----|------------------------------------------------------------|
-| page         | Query | Number | O  | Page to retrieve<br/>- Minimum value: `1`                                 |
-| size         | Query | Number | O  | Page size to retrieve<br/>- Minimum value: `1`<br/>- Maximum value: `100`             |
-| backupType   | Query | Enum   | X  | Backup type<br/>- `AUTO`: Automatic<br/>- `MANUAL`:  Manual<br/>- Default value: All |
-| dbInstanceId | Query | UUID   | X  | Original DB instance identifier                                            |
-| dbVersion    | Query | Enum   | X  | DB version information                                                   |
-
 #### Response
 
-| Name                   | Type   | Format       | Description                                                                                                                                                        |
-|----------------------|------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| totalCounts          | Body | Number   | Number of all backup lists                                                                                                                                                |
-| backups              | Body | Array    | Backup list                                                                                                                                                     |
-| backups.backupId     | Body | UUID     | Backup identifier                                                                                                                                                   |
-| backups.backupName   | Body | String   | Name to identify backups                                                                                                                                           |
-| backups.backupStatus | Body | Enum     | Backup current status<br/>`BACKING_UP`: Backup in progress<br/>`COMPLETED`: Backup completed<br/>`DELETING`: Backup being deleted<br/>`DELETED`: Backup deleted<br/>`ERROR`: Error occurred |
-| backups.dbInstanceId | Body | UUID     | Original DB instance identifier                                                                                                                                           |
-| backups.dbVersion    | Body | Enum     | DB version information                                                                                                                                                  |
-| backups.backupType   | Body | Enum     | Backup type<br/>- `AUTO`: Automatic<br/>- `MANUAL`:  Manual                                                                                                                |
-| backups.backupSize   | Body | Number   | Size of the backup<br/>- Unit: `Bytes`                                                                                                                                    |
-| createdYmdt          | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                         |
-| updatedYmdt          | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                         |
-| completedYmdt        | Body | DateTime | End date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                         |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | Number of all backup lists |
+| backups | Body | Array | Backup list |
+| backups.backupId | Body | UUID | Backup identifier |
+| backups.backupName | Body | String | Name to identify backups |
+| backups.backupStatus | Body | Enum | Backup current status<br/>- BACKING_UP: `Backup in progress (spinner)`<br/>- VERIFYING: `Verifying (spinner)`<br/>- COMPLETED: `Available (green icon)`<br/>- DELETING: `Deleting (spinner)`<br/>- DELETED: `Deleted (gray icon)`<br/>- ERROR: `Error (red icon)` |
+| backups.dbInstanceId | Body | UUID | Original DB instance identifier |
+| backups.dbVersion | Body | Enum | DB engine version |
+| backups.backupType | Body | Enum | Backup type<br/>- AUTO<br/>- MANUAL |
+| backups.backupSize | Body | Number | Size of the backup (Bytes) |
+| backups.startYmdt | Body | DateTime | Start date and time |
+| backups.createdYmdt | Body | DateTime | Created date and time |
+| backups.updatedYmdt | Body | DateTime | Modified date and time |
+| backups.completedYmdt | Body | DateTime | End date and time |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -3270,170 +3710,26 @@ This API does not require a request body.
     "totalCounts": 1,
     "backups": [
         {
-            "backupId": "0017f136-3e01-4530-94aa-20661afe6632",
-            "backupName": "backup",
-            "backupStatus": "COMPLETED",
-            "dbInstanceId": "142e6ccc-3bfb-4e1e-84f7-38861284fafd",
-            "dbVersion": "POSTGRESQL_V17_6",
+            "backupId": "550e8400-e29b-41d4-a716-446655440000",
+            "backupName": "backupName-example",
+            "backupStatus": "BACKING_UP",
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbVersion": "POSTGRESQL_V14_17",
             "backupType": "AUTO",
-            "backupSize": 4996786,
-            "createdYmdt": "2023-02-21T00:35:00+09:00",
-            "updatedYmdt": "2023-02-22T00:35:32+09:00",
-            "completedYmdt": "2023-02-22T00:35:32+09:00"
+            "backupSize": 1,
+            "startYmdt": "2023-12-31T15:00:00+09:00",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00",
+            "completedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
+
+</p>
 </details>
 
-### Export backup to object storage
-
-```http
-POST /v1.0/backups/{backupId}/export
-```
-
-#### Required permissions
-
-| Permission Name                            | Description                 |
-|--------------------------------|--------------------|
-| RDSforPostgreSQL:Backup.Export | Export backup to object storage |
-
-#### Request
-
-| Name              | Type   | Format     | Required | Description                          |
-|-----------------|------|--------|----|-----------------------------|
-| backupId        | URL  | UUID   | O  | Backup identifier                     |
-| tenantId        | Body | String | O  | Tenant ID of object storage to store backup   |
-| username        | Body | String | O  | ID of NHN Cloud Account or IAM Account   |
-| password        | Body | String | O  | API password for object storage where backup is stored |
-| targetContainer | Body | String | O  | Object storage container where backup is stored     |
-| objectPath      | Body | String | O  | Backup path to be stored in container            |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "tenantId": "399631c404744dbbb18ce4fa2dc71a5a",
-    "username": "gildong.hong@nhn.com",
-    "password": "password",
-    "targetContainer": "/container",
-    "objectPath": "/backups/backup_file"
-}
-```
-</details>
-
-#### Response
-
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### Restore Backup
-
-```http
-POST /v1.0/backups/{backupId}/restore
-```
-
-#### Required permissions
-
-| Permission Name                             | Description      |
-|---------------------------------|---------|
-| RDSforPostgreSQL:Backup.Restore | Restore Backup |
-
-#### Request
-
-| Name                                       | Type   | Format      | Required | Description                                                                                                                                                                                                                        |
-|------------------------------------------|------|---------|----|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| backupId                                 | URL  | UUID    | O  | Backup identifier                                                                                                                                                                                                                   |
-| dbInstanceName                           | Body | String  | O  | Name to identify DB instances                                                                                                                                                                                                      |
-| description                              | Body | String  | X  | Additional information on DB instances                                                                                                                                                                                                         |
-| dbFlavorId                               | Body | UUID    | O  | Identifier of DB instance specifications                                                                                                                                                                                                           |
-| dbPort                                   | Body | Number  | O  | DB port<br/>- Minimum value: `0`<br/>- Maximum value: 65535                                                                                                                                                                                |
-| parameterGroupId                         | Body | UUID    | O  | Parameter group identifier                                                                                                                                                                                                              |
-| dbSecurityGroupIds                       | Body | Array   | X  | DB security group identifiers                                                                                                                                                                                                          ||network|Body|Object|O|Network information objects|
-| userGroupIds                             | Body | Array   | X  | User group identifiers                                                                                                                                                                                                            |
-| useDefaultNotification                   | Body | Boolean | X  | Whether to use default notification<br/>Default: `false`                                                                                                                                                                                            |
-| useDeletionProtection                    | Body | Boolean | X  | Whether to protect against deletion<br/>Default: `false`                                                                                                                                                                                               | 
-| useHighAvailability                      | Body | Boolean | X  | Whether to use high availability                                                                                                                                                                                                                |
-| pingInterval                             | Body | Number  | X  | Ping interval (sec) when using high availability<br/>- Minimum value: `1`<br/>- Maximum value: `600`                                                                                                                                                                      |
-| failoverReplWaitingTime                  | Body | Number  | X  | Failover latency when using high availability<br/>- Minimum value: `0`<br/>- If set to -1, it will continue to wait for the replication delay to resolve.                                                                                                                                              |                                                                                                                                                                                                                      | userGroupIds                             | Body | Array   | X  | List of identifiers for user groups that receive default notifications                                                                                                                                                                                             |
-| network                                  | Body | Object  | O  | Network information objects                                                                                                                                                                                                                |
-| network.subnetId                         | Body | UUID    | O  | Subnet identifier                                                                                                                                                                                                                  |
-| network.usePublicAccess                  | Body | Boolean | X  | External access is available or not<br/>Default: `false`                                                                                                                                                                                            |
-| network.availabilityZone                 | Body | Enum    | X  | Availability zone where DB instance will be created<br/>- Example: `kr-pub-a`<br/>- Default: `Any availability` zone                                                                                                                                                          |
-| storage                                  | Body | Object  | O  | Storage information objects                                                                                                                                                                                                                |    
-| storage.storageType                      | Body | Enum    | O  | Data storage types<br/>- Example: `General SSD`                                                                                                                                                                                       |
-| storage.storageSize                      | Body | Number  | O  | Data storage size<br/>- Unit: `Gigabytes`<br/>- Minimum value: `20`<br/>- Maximum value: `2048`                                                                                                                                                           |
-| backup                                   | Body | Object  | O  | Backup information objects                                                                                                                                                                                                                  |
-| backup.backupPeriod                      | Body | Number  | O  | Backup retention period<br/>- Minimum value: `0`<br/>- Maximum value: `730`                                                                                                                                                                               |
-| backup.backupRetryCount                  | Body | Number  | X  | Number of backup retries<br/>Default: `6`<br/>- Minimum value: `0`<br/>- Maximum value: `10`                                                                                                                                                                   |
-| backup.backupSchedules                   | Body | Array   | X  | Backup schedules                                                                                                                                                                                                                 |
-| backup.backupSchedules.backupWndBgnTime  | Body | String  | O  | Backup Start Time<br/>- Example: `00:00:00`                                                                                                                                                                                             |
-| backup.backupSchedules.backupWndDuration | Body | Enum    | O  | Backup duration<br/>Auto backup is executed within the set duration from the backup start time.<br/>- `HALF_AN_HOUR`: 30 minutes<br/>- `ONE_HOUR`: 1 hour<br/>- `ONE_HOUR_AND_HALF`: 1.5 hour<br/>- `TWO_HOURS`: 2 hour<br/>- `TWO_HOURS_AND_HALF`: 2.5 hour<br/>- `THREE_HOURS`: 3 hour |
-
-<details><summary>Example</summary>
-
-```json
-
-{
-  "dbInstanceName": "db-instance-restore",
-  "dbFlavorId": "50be6d9c-02d6-4594-a2d4-12010eb65ec0",
-  "dbPort": 15432,
-  "parameterGroupId": "132d383c-38e3-468a-a826-5e9a8fff15d0",
-  "network": {
-    "subnetId": "e721a9dd-dad0-4cf0-a53b-dd654ebfc683"
-  },
-  "storage": {
-    "storageType": "General SSD",
-    "storageSize": 20
-  },
-  "backup": {
-    "backupPeriod": 1,
-    "backupSchedules": [
-      {
-        "backupWndBgnTime": "00:00:00",
-        "backupWndDuration": "HALF_AN_HOUR",
-        "backupRetryExpireTime": "00:30:00"
-      }
-    ]
-  }
-}
-```
-</details>
-
-#### Response
-
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
+---
 
 ### Delete Backup
 
@@ -3443,25 +3739,26 @@ DELETE /v1.0/backups/{backupId}
 
 #### Required permissions
 
-| Permission Name                            | Description      |
-|--------------------------------|---------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforPostgreSQL:Backup.Delete | Delete Backup |
 
 #### Request
 
 This API does not require a request body.
 
-| Name       | Type  | Format   | Required | Description      |
-|----------|-----|------|----|---------|
-| backupId | URL | UUID | O  | Backup identifier |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | O | Backup identifier |
 
 #### Response
 
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | Identifier of requested task |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -3470,12 +3767,200 @@ This API does not require a request body.
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
+---
+
+### Export Backup to Object Storage
+
+```http
+POST /v1.0/backups/{backupId}/export
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:Backup.Export | Export Backup to Object Storage |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | O | Backup identifier |
+| tenantId | Body | String | O | Tenant ID of object storage where backup will be stored<br/>- Minimum length: `32`<br/>- Maximum length: `32` |
+| username | Body | String | O | NHN Cloud account or IAM member ID |
+| password | Body | String | O | API password for object storage where backup will be stored |
+| targetContainer | Body | String | O | Object storage container where backup will be stored |
+| objectPath | Body | String | O | Path of the backup to be stored in the container |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "tenantId": "0123456789abcdef0123456789abcdef",
+    "username": "username-example",
+    "password": "password-example",
+    "targetContainer": "targetContainer-example",
+    "objectPath": "objectPath-example"
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Restore Backup
+
+```http
+POST /v1.0/backups/{backupId}/restore
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:Backup.Restore | Restore Backup |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | O | Backup identifier |
+| dbInstanceName | Body | String | O | Name to identify DB instances |
+| dbInstanceCandidateName | Body | String | X | Candidate master name to identify the DB instance |
+| description | Body | String | X | Additional information on DB instances |
+| dbFlavorId | Body | UUID | O | Identifier of DB instance specifications |
+| dbPort | Body | Number | O | DB port<br/>- Minimum value: 5432, Maximum value: 45432 |
+| parameterGroupId | Body | UUID | O | Parameter group identifier |
+| dbSecurityGroupIds | Body | Array | X | List of DB security group identifiers |
+| userGroupIds | Body | Array | X | List of user group identifiers |
+| useHighAvailability | Body | Boolean | X | Whether to use high availability<br/>- Default: `false` |
+| useDefaultNotification | Body | Boolean | X | Whether to use default notification<br/>- Default: `false` |
+| useDeletionProtection | Body | Boolean | X | Whether to use deletion protection<br/>- Default: `false` |
+| pingInterval | Body | Number | X | Ping interval (seconds)<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
+| failoverReplWaitingTime | Body | Number | X | Failover replication delay waiting time (seconds)<br/>- Minimum value: `-1` |
+| network | Body | Object | O | Network information objects |
+| network.subnetId | Body | UUID | O | Subnet identifier |
+| network.usePublicAccess | Body | Boolean | X | Whether external access is available<br/>- Default: `false` |
+| network.availabilityZone | Body | Enum | X | Availability zone where DB instance will be created |
+| storage | Body | Object | O | Storage information objects |
+| storage.storageType | Body | Enum | O | Storage type |
+| storage.storageSize | Body | Number | O | Data storage size (GB)<br/>- Minimum value: `20` |
+| backup | Body | Object | O | Backup information objects |
+| backup.backupPeriod | Body | Number | O | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| backup.backupRetryCount | Body | Number | X | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| backup.backupSchedules | Body | Array | O | Backup schedules |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | O | Backup start time |
+| backup.backupSchedules.backupWndDuration | Body | Enum | O | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hours`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2.5 hours`<br/>- THREE_HOURS: `3 hours` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName-example",
+    "dbInstanceCandidateName": "dbInstanceCandidateName-example",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useHighAvailability": false,
+    "useDefaultNotification": false,
+    "useDeletionProtection": false,
+    "pingInterval": 1,
+    "failoverReplWaitingTime": 1,
+    "network": {
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
+        "availabilityZone": "kr-pub-a"
+    },
+    "storage": {
+        "storageType": "General SSD",
+        "storageSize": 20
+    },
+    "backup": {
+        "backupPeriod": 0,
+        "backupRetryCount": 0,
+        "backupSchedules": [
+            {
+                "backupWndBgnTime": "00:00:00",
+                "backupWndDuration": "HALF_AN_HOUR"
+            }
+        ]
+    }
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
 ## DB Security Group
+
+### DB Security Group Progress Status
+
+| Status          | Description                  |
+|-----------------|------------------------------|
+| `NONE`          | No work in progress          |
+| `CREATING_RULE` | Creating rule policy         |
+| `UPDATING_RULE` | Modifying rule policy        |
+| `DELETING_RULE` | Deleting rule policy         |
 
 ### List DB Security Groups
 
@@ -3485,8 +3970,8 @@ GET /v1.0/db-security-groups
 
 #### Required permissions
 
-| Permission Name                                   | Description             |
-|---------------------------------------|----------------|
+| Permission Name                       | Description             |
+|---------------------------------------|-------------------------|
 | RDSforPostgreSQL:DbSecurityGroup.List | List DB Security Groups |
 
 #### Request
@@ -3495,18 +3980,19 @@ This API does not require a request body.
 
 #### Response
 
-| Name                                     | Type   | Format       | Description                                                                                                                                                                                             |
-|----------------------------------------|------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroups                       | Body | Array    | DB security groups                                                                                                                                                                                    |
-| dbSecurityGroups.dbSecurityGroupId     | Body | UUID     | DB security group identifier                                                                                                                                                                                  |
-| dbSecurityGroups.dbSecurityGroupName   | Body | String   | Name to identify DB instances                                                                                                                                                                          |
-| dbSecurityGroups.dbSecurityGroupStatus | Body | Enum     | Current status of DB security groups<br/>- `CREATED: Created`<br/>- `DELETED`: Deleted                                                                                                                                      |
-| dbSecurityGroups.description           | Body | String   | Additional information on DB security group                                                                                                                                                                             |
-| dbSecurityGroups.progressStatus        | Body | Enum     | Current status of DB security group<br/>- `NONE`: No work in progress<br/>- `CREATING_RULE`: Creating rule policy<br/>- `UPDATING_RULE`: Modifying rule policy<br/>- `DELETING_RULE`: Deleting rule policy<br/>- `APPLYING_DEFAULT_RULE`: Applying default rule  |
-| dbSecurityGroups.createdYmdt           | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                              |
-| dbSecurityGroups.updatedYmdt           | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                              |
+| Name                                   | Type | Format   | Description                                                                                                                                                                                                                                                         |
+|----------------------------------------|------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| dbSecurityGroups                       | Body | Array    | DB security groups                                                                                                                                                                                                                                                  |
+| dbSecurityGroups.dbSecurityGroupId     | Body | UUID     | DB security group identifier                                                                                                                                                                                                                                        |
+| dbSecurityGroups.dbSecurityGroupName   | Body | String   | Name to identify the DB security group                                                                                                                                                                                                                              |
+| dbSecurityGroups.dbSecurityGroupStatus | Body | Enum     | Current status of the DB security group<br/>- CREATED: `Created`<br/>- DELETED: `Deleted`                                                                                                                                                                          |
+| dbSecurityGroups.description           | Body | String   | Additional information on the DB security group                                                                                                                                                                                                                     |
+| dbSecurityGroups.progressStatus        | Body | Enum     | Current progress status of the DB security group<br/>- NONE: `No work in progress`<br/>- CREATING_RULE: `Creating rule policy`<br/>- UPDATING_RULE: `Modifying rule policy`<br/>- DELETING_RULE: `Deleting rule policy`<br/>- APPLYING_DEFAULT_RULE: `Applying default rule` |
+| dbSecurityGroups.createdYmdt           | Body | DateTime | Created date and time                                                                                                                                                                                                                                               |
+| dbSecurityGroups.updatedYmdt           | Body | DateTime | Modified date and time                                                                                                                                                                                                                                              |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -3517,100 +4003,22 @@ This API does not require a request body.
     },
     "dbSecurityGroups": [
         {
-            "dbSecurityGroupId": "fe4f2aee-afbb-4c19-a5e9-eb2eab394708",
-            "dbSecurityGroupName": "dbSecurityGroup",
+            "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbSecurityGroupName": "dbSecurityGroupName-example",
             "dbSecurityGroupStatus": "CREATED",
-            "description": "description",
+            "description": "description-example",
             "progressStatus": "NONE",
-            "createdYmdt": "2023-02-19T19:18:13+09:00",
-            "updatedYmdt": "2022-02-19T19:18:13+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
+
+</p>
 </details>
 
-### List DB Security Group Details
-
-```http
-GET /v1.0/db-security-groups/{dbSecurityGroupId}
-```
-
-#### Required permissions
-
-| Permission Name                                  | Description             |
-|--------------------------------------|----------------|
-| RDSforPostgreSQL:DbSecurityGroup.Get | List DB Security Group Details |
-
-#### Request
-
-This API does not require a request body.
-
-| Name                | Type  | Format   | Required | Description            |
-|-------------------|-----|------|----|---------------|
-| dbSecurityGroupId | URL | UUID | O  | DB security group identifier |
-
-#### Response
-
-| Name                    | Type   | Format       | Description                                                                                                                                                                                            |
-|-----------------------|------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId     | Body | UUID     | DB security group identifier                                                                                                                                                                                 |
-| dbSecurityGroupName   | Body | String   | Name to identify DB instances                                                                                                                                                                         |
-| dbSecurityGroupStatus | Body | Enum     | Current status of DB security groups<br/>- `CREATED: Created`<br/>- `DELETED`: Deleted                                                                                                                                     |
-| description           | Body | String   | Additional information on DB security group                                                                                                                                                                            |
-| progressStatus        | Body | Enum     | Current status of DB security group<br/>- `NONE`: No work in progress<br/>- `CREATING_RULE`: Creating rule policy<br/>- `UPDATING_RULE`: Modifying rule policy<br/>- `DELETING_RULE`: Deleting rule policy<br/>- `APPLYING_DEFAULT_RULE`: Applying default rule |
-| rules                 | Body | Array    | DB security group rules                                                                                                                                                                                |
-| rules.ruleId          | Body | UUID     | DB security group rule identifier                                                                                                                                                                              |
-| rules.description     | Body | String   | Additional information on DB security group rule                                                                                                                                                                         |
-| rules.direction       | Body | Enum     | Communication direction<br/>- `INGRESS`: Inbound<br/>- `EGRESS`: Outbound                                                                                                                                                  |
-| rules.etherType       | Body | Enum     | Ether type<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                                |
-| rules.port            | Body | Object   | Port object                                                                                                                                                                                         |
-| rules.port.portType   | Body | Enum     | Port type<br/>- `DB_PORT`: Sets to DB instance port value.<br/>- `PORT`: Sets to specified port value.<br/>- `PORT_RANGE`: Sets to specified port range.                                                                            |
-| rules.port.minPort    | Body | Number   | Minimum port range                                                                                                                                                                                      |
-| rules.port.maxPort    | Body | Number   | Maximum port range                                                                                                                                                                                      |
-| rules.cidr            | Body | String   | Remote source for traffic to allow                                                                                                                                                                                |
-| rules.createdYmdt     | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                             |
-| rules.updatedYmdt     | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                             |
-| createdYmdt           | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                             |
-| updatedYmdt           | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                             |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbSecurityGroup": {
-        "dbSecurityGroupId": "fe4f2aee-afbb-4c19-a5e9-eb2eab394708",
-        "dbSecurityGroupName": "dbSecurityGroup",
-        "dbSecurityGroupStatus": "CREATED",
-        "description": "description",
-        "progressStatus": "NONE",
-        "rules": [
-            {
-                "ruleId": "17c88ef6-95f1-4678-84f9-fee1b22e250d",
-                "description": "description",
-                "direction": "INGRESS",
-                "etherType": "IPV4",
-                "port": {
-                    "portType": "PORT_RANGE",
-                    "minPort": 10000,
-                    "maxPort": 10005
-                },
-                "cidr": "0.0.0.0/0",
-                "createdYmdt": "2023-02-19T19:18:13+09:00",
-                "updatedYmdt": "2023-02-19T19:18:13+09:00"
-            }
-        ],
-        "createdYmdt": "2023-02-19T19:18:13+09:00",
-        "updatedYmdt": "2023-02-19T19:18:13+09:00"
-    }
-}
-```
-</details>
+---
 
 ### Create DB Security Group
 
@@ -3620,55 +4028,60 @@ POST /v1.0/db-security-groups
 
 #### Required permissions
 
-| Permission Name                                     | Description            |
-|-----------------------------------------|---------------|
+| Permission Name                         | Description              |
+|-----------------------------------------|--------------------------|
 | RDSforPostgreSQL:DbSecurityGroup.Create | Create DB Security Group |
 
 #### Request
 
-| Name                  | Type   | Format     | Required | Description                                                                                                                                                                                       |
-|---------------------|------|--------|----|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupName | Body | String | O  | Name to identify DB instances                                                                                                                                                                    |
-| description         | Body | String | X  | Additional information on DB security group                                                                                                                                                                       |
-| rules               | Body | Array  | O  | DB security group rules                                                                                                                                                                           |
-| rules.description   | Body | String | X  | Additional information on DB security group rule                                                                                                                                                                    |
-| rules.direction     | Body | Enum   | O  | Communication direction<br/>- `INGRESS`: Inbound<br/>- `EGRESS`: Outbound                                                                                                                                             |
-| rules.etherType     | Body | Enum   | O  | Ether type<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                           |
-| rules.cidr          | Body | String | O  | Remote source for traffic to allow<br/>- Example: `1.1.1.1/32`                                                                                                                                                    |
-| rules.port          | Body | Object | O  | Port object                                                                                                                                                                                    |
-| rules.port.portType | Body | Enum   | O  | Port type<br/>- `DB_PORT`: Sets to DB instance port value. Values for `minPort` 값과 `maxPort` are not required.<br/>- `PORT`: 지정된 포트값으로 설정됩니다. `minPort`값과 `maxPort`값이 같아야 합니다.<br/>- `PORT_RANGE`: Sets to specified port range. |
-| rules.port.minPort  | Body | Number | X  | Minimum port range<br/>- Minimum value received: 5432<br/>- Transmit minimum: 1                                                                                                                                              |
-| rules.port.maxPort  | Body | Number | X  | Maximum port range<br/>- Maximum received: 45432<br/>- Send maximum: 65535                                                                                                                                         |
+| Name                | Type | Format | Required | Description                                                                                                                                                                                                                                                                                                                              |
+|---------------------|------|--------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| dbSecurityGroupName | Body | String | O        | Name to identify the DB security group                                                                                                                                                                                                                                                                                                   |
+| description         | Body | String | X        | Additional information on the DB security group                                                                                                                                                                                                                                                                                          |
+| rules               | Body | Array  | O        | DB security group rule information                                                                                                                                                                                                                                                                                                       |
+| rules.direction     | Body | Enum   | O        | Communication direction<br/>- INGRESS: `Inbound`<br/>- EGRESS: `Outbound`                                                                                                                                                                                                                                                               |
+| rules.etherType     | Body | Enum   | O        | Ether type<br/>- IPV4: `IPv4`<br/>- IPV6: `IPv6`                                                                                                                                                                                                                                                                                        |
+| rules.port          | Body | Object | O        | Port object                                                                                                                                                                                                                                                                                                                              |
+| rules.port.portType | Body | Enum   | O        | Port type<br/>- ALL: `All port ranges (not used in the user console)`<br/>- PORT: `Specific port`<br/>- DB_PORT: `DB listening port`<br/>- PORT_RANGE: `Port range`                                                                                                                                                                      |
+| rules.port.minPort  | Body | Number | X        | Minimum port range<br/>- Minimum value: `1`                                                                                                                                                                                                                                                                                              |
+| rules.port.maxPort  | Body | Number | X        | Maximum port range<br/>- Maximum value: `65535`                                                                                                                                                                                                                                                                                          |
+| rules.cidr          | Body | String | O        | CIDR                                                                                                                                                                                                                                                                                                                                     |
+| rules.description   | Body | String | X        | Additional information on the DB security group rule                                                                                                                                                                                                                                                                                     |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
-    "dbSecurityGroupName": "dbSecurityGroup",
-    "description": "description",
+    "dbSecurityGroupName": "dbSecurityGroupName-example",
+    "description": "description-example",
     "rules": [
         {
             "direction": "INGRESS",
             "etherType": "IPV4",
             "port": {
-                "portType": "PORT_RANGE",
-                "minPort": 10000,
-                "maxPort": 10005
+                "portType": "ALL",
+                "minPort": 1,
+                "maxPort": 1
             },
-            "cidr": "0.0.0.0/0"
+            "cidr": "192.168.0.0/24",
+            "description": "description-example"
         }
     ]
 }
 ```
+
+</p>
 </details>
 
 #### Response
 
-| Name                | Type   | Format   | Description            |
-|-------------------|------|------|---------------|
-| dbSecurityGroupId | Body | UUID | DB security group identifier |
+| Name              | Type | Format | Description                  |
+|-------------------|------|--------|------------------------------|
+| dbSecurityGroupId | Body | UUID   | DB security group identifier |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -3677,57 +4090,14 @@ POST /v1.0/db-security-groups
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "dbSecurityGroupId": "fe4f2aee-afbb-4c19-a5e9-eb2eab394708"
+    "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-### Modify DB Security Group
-
-```http
-PUT /v1.0/db-security-groups/{dbSecurityGroupId}
-```
-
-#### Required permissions
-
-| Permission Name                                     | Description            |
-|-----------------------------------------|---------------|
-| RDSforPostgreSQL:DbSecurityGroup.Modify | Modify DB Security Group |
-
-#### Request
-
-| Name                  | Type   | Format     | Required | Description                    |
-|---------------------|------|--------|----|-----------------------|
-| dbSecurityGroupId   | URL  | UUID   | O  | DB security group identifier         |
-| dbSecurityGroupName | Body | String | X  | Name to identify DB instances |
-| description         | Body | String | X  | Additional information on DB security group    |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "dbSecurityGroupName": "dbSecurityGroup",
-    "description": "description"
-}
-```
-</details>
-
-#### Response
-
-This API does not return a response body.
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
+---
 
 ### Delete DB Security Group
 
@@ -3737,23 +4107,71 @@ DELETE /v1.0/db-security-groups/{dbSecurityGroupId}
 
 #### Required permissions
 
-| Permission Name                                     | Description            |
-|-----------------------------------------|---------------|
+| Permission Name                         | Description              |
+|-----------------------------------------|--------------------------|
 | RDSforPostgreSQL:DbSecurityGroup.Delete | Delete DB Security Group |
 
 #### Request
 
 This API does not require a request body.
 
-| Name                | Type  | Format   | Required | Description            |
-|-------------------|-----|------|----|---------------|
-| dbSecurityGroupId | URL | UUID | O  | DB security group identifier |
+| Name              | Type | Format | Required | Description |
+|-------------------|------|--------|----------|-------------|
+| dbSecurityGroupId | URL  | UUID   | O        |             |
 
 #### Response
 
 This API does not return a response body.
 
+---
+
+### List DB Security Group Details
+
+```http
+GET /v1.0/db-security-groups/{dbSecurityGroupId}
+```
+
+#### Required permissions
+
+| Permission Name                      | Description                    |
+|--------------------------------------|--------------------------------|
+| RDSforPostgreSQL:DbSecurityGroup.Get | List DB Security Group Details |
+
+#### Request
+
+This API does not require a request body.
+
+| Name              | Type | Format | Required | Description                  |
+|-------------------|------|--------|----------|------------------------------|
+| dbSecurityGroupId | URL  | UUID   | O        |                              |
+
+#### Response
+
+| Name                          | Type | Format   | Description                                                                                                                                                                                                                                                              |
+|-------------------------------|------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| dbSecurityGroup               | Body | Object   | DB security group                                                                                                                                                                                                                                                        |
+| dbSecurityGroup.dbSecurityGroupId     | Body | UUID     | DB security group identifier                                                                                                                                                                                                                                             |
+| dbSecurityGroup.dbSecurityGroupName   | Body | String   | Name to identify the DB security group                                                                                                                                                                                                                                   |
+| dbSecurityGroup.dbSecurityGroupStatus | Body | Enum     | Current status of the DB security group<br/>- CREATED: `Created`<br/>- DELETED: `Deleted`                                                                                                                                                                               |
+| dbSecurityGroup.description           | Body | String   | Additional information on the DB security group                                                                                                                                                                                                                          |
+| dbSecurityGroup.progressStatus        | Body | Enum     | Current progress status of the DB security group<br/>- NONE: `No work in progress`<br/>- CREATING_RULE: `Creating rule policy`<br/>- UPDATING_RULE: `Modifying rule policy`<br/>- DELETING_RULE: `Deleting rule policy`<br/>- APPLYING_DEFAULT_RULE: `Applying default rule` |
+| dbSecurityGroup.rules                 | Body | Array    | DB security group rule list                                                                                                                                                                                                                                              |
+| dbSecurityGroup.rules.ruleId          | Body | UUID     | DB security group rule identifier                                                                                                                                                                                                                                        |
+| dbSecurityGroup.rules.description     | Body | String   | Additional information on the DB security group rule                                                                                                                                                                                                                     |
+| dbSecurityGroup.rules.direction       | Body | Enum     | Communication direction<br/>- INGRESS: `Inbound`<br/>- EGRESS: `Outbound`                                                                                                                                                                                               |
+| dbSecurityGroup.rules.etherType       | Body | Enum     | Ether type<br/>- IPV4: `IPv4`<br/>- IPV6: `IPv6`                                                                                                                                                                                                                        |
+| dbSecurityGroup.rules.port            | Body | Object   | Port object                                                                                                                                                                                                                                                              |
+| dbSecurityGroup.rules.port.portType   | Body | Enum     | Port type<br/>- ALL: `All port ranges (not used in the user console)`<br/>- PORT: `Specific port`<br/>- DB_PORT: `DB listening port`<br/>- PORT_RANGE: `Port range`                                                                                                      |
+| dbSecurityGroup.rules.port.minPort    | Body | Number   | Minimum port range                                                                                                                                                                                                                                                       |
+| dbSecurityGroup.rules.port.maxPort    | Body | Number   | Maximum port range                                                                                                                                                                                                                                                       |
+| dbSecurityGroup.rules.cidr            | Body | String   | CIDR                                                                                                                                                                                                                                                                     |
+| dbSecurityGroup.rules.createdYmdt     | Body | DateTime | Created date and time                                                                                                                                                                                                                                                    |
+| dbSecurityGroup.rules.updatedYmdt     | Body | DateTime | Modified date and time                                                                                                                                                                                                                                                   |
+| dbSecurityGroup.createdYmdt           | Body | DateTime | Created date and time                                                                                                                                                                                                                                                    |
+| dbSecurityGroup.updatedYmdt           | Body | DateTime | Modified date and time                                                                                                                                                                                                                                                   |
+
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -3761,133 +4179,78 @@ This API does not return a response body.
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
+    },
+    "dbSecurityGroup": {
+        "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
+        "dbSecurityGroupName": "dbSecurityGroupName-example",
+        "dbSecurityGroupStatus": "CREATED",
+        "description": "description-example",
+        "progressStatus": "NONE",
+        "rules": [
+            {
+                "ruleId": "550e8400-e29b-41d4-a716-446655440000",
+                "description": "description-example",
+                "direction": "INGRESS",
+                "etherType": "IPV4",
+                "port": {
+                    "portType": "ALL",
+                    "minPort": 1,
+                    "maxPort": 1
+                },
+                "cidr": "192.168.0.0/24",
+                "createdYmdt": "2023-12-31T15:00:00+09:00",
+                "updatedYmdt": "2023-12-31T15:00:00+09:00"
+            }
+        ],
+        "createdYmdt": "2023-12-31T15:00:00+09:00",
+        "updatedYmdt": "2023-12-31T15:00:00+09:00"
     }
 }
 ```
+
+</p>
 </details>
 
-### Create DB Security Group
+---
+
+### Modify DB Security Group
 
 ```http
-POST /v1.0/db-security-groups/{dbSecurityGroupId}/rules
+PUT /v1.0/db-security-groups/{dbSecurityGroupId}
 ```
 
 #### Required permissions
 
-| Permission Name                                         | Description               |
-|---------------------------------------------|------------------|
-| RDSforPostgreSQL:DbSecurityGroupRule.Create | Create DB Security Group |
+| Permission Name                         | Description              |
+|-----------------------------------------|--------------------------|
+| RDSforPostgreSQL:DbSecurityGroup.Modify | Modify DB Security Group |
 
 #### Request
 
-| Name                | Type   | Format     | Required | Description                                                                                                                                                                                       |
-|-------------------|------|--------|----|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId | URL  | UUID   | O  | DB security group identifier                                                                                                                                                                            |
-| description       | Body | String | X  | Additional information on DB security group rule                                                                                                                                                                    |
-| direction         | Body | Enum   | O  | Communication direction<br/>- `INGRESS`: Inbound<br/>- `EGRESS`: Outbound                                                                                                                                             |
-| etherType         | Body | Enum   | O  | Ether type<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                           |
-| port              | Body | Object | O  | Port object                                                                                                                                                                                    |
-| port.portType     | Body | Enum   | O  | Port type<br/>- `DB_PORT`: Sets to DB instance port value. Values for `minPort` 값과 `maxPort` are not required.<br/>- `PORT`: 지정된 포트값으로 설정됩니다. `minPort`값과 `maxPort`값이 같아야 합니다.<br/>- `PORT_RANGE`: Sets to specified port range. |
-| port.minPort      | Body | Number | X  | Minimum port range<br/>- Minimum value received: 5432<br/>- Transmit minimum: 1                                                                                                                                              |
-| port.maxPort      | Body | Number | X  | Maximum port range<br/>- Maximum received: 45432<br/>- Send maximum: 65535                                                                                                                                         |
-| cidr              | Body | String | O  | Remote source for traffic to allow<br/>- Example: `1.1.1.1/32`                                                                                                                                                    |
+| Name                | Type | Format | Required | Description                                     |
+|---------------------|------|--------|----------|-------------------------------------------------|
+| dbSecurityGroupId   | URL  | UUID   | O        |                                                 |
+| dbSecurityGroupName | Body | String | O        | Name to identify the DB security group          |
+| description         | Body | String | X        | Additional information on the DB security group |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
-    "direction": "INGRESS",
-    "etherType": "IPV4",
-    "port": {
-        "portType": "PORT",
-        "minPort": 10000,
-        "maxPort": 10000
-    },
-    "cidr": "0.0.0.0/0"
+    "dbSecurityGroupName": "dbSecurityGroupName-example",
+    "description": "description-example"
 }
 ```
+
+</p>
 </details>
 
 #### Response
 
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
+This API does not return a response body.
 
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### Modify DB Security Group Rule
-
-```http
-PUT /v1.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
-```
-
-#### Required permissions
-
-| Permission Name                                         | Description               |
-|---------------------------------------------|------------------|
-| RDSforPostgreSQL:DbSecurityGroupRule.Modify | Modify DB Security Group Rule |
-
-#### Request
-
-| Name                | Type   | Format     | Required | Description                                                                                                                                                                                       |
-|-------------------|------|--------|----|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId | URL  | UUID   | O  | DB security group identifier                                                                                                                                                                            |
-| ruleId            | URL  | UUID   | O  | DB security group rule identifier                                                                                                                                                                         |
-| description       | Body | String | X  | Additional information on DB security group rule                                                                                                                                                                    |
-| direction         | Body | Enum   | O  | Communication direction<br/>- `INGRESS`: Inbound<br/>- `EGRESS`: Outbound                                                                                                                                             |
-| etherType         | Body | Enum   | O  | Ether type<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                           |
-| port              | Body | Object | O  | Port object                                                                                                                                                                                    |
-| port.portType     | Body | Enum   | O  | Port type<br/>- `DB_PORT`: Sets to DB instance port value. Values for `minPort` 값과 `maxPort` are not required.<br/>- `PORT`: 지정된 포트값으로 설정됩니다. `minPort`값과 `maxPort`값이 같아야 합니다.<br/>- `PORT_RANGE`: Sets to specified port range. |
-| port.minPort      | Body | Number | X  | Minimum port range<br/>- Minimum value received: 5432<br/>- Transmit minimum: 1                                                                                                                                              |
-| port.maxPort      | Body | Number | X  | Maximum port range<br/>- Maximum received: 45432<br/>- Send maximum: 65535                                                                                                                                         |
-| cidr              | Body | String | O  | Remote source for traffic to allow<br/>- Example: `1.1.1.1/32`                                                                                                                                                    |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "direction": "INGRESS",
-    "etherType": "IPV4",
-    "port": {
-        "portType": "DB_PORT"
-    },
-    "cidr": "0.0.0.0/0"
-}
-```
-</details>
-
-#### Response
-
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
+---
 
 ### Delete DB Security Group Rule
 
@@ -3897,26 +4260,27 @@ DELETE /v1.0/db-security-groups/{dbSecurityGroupId}/rules
 
 #### Required permissions
 
-| Permission Name                                         | Description               |
-|---------------------------------------------|------------------|
-| RDSforPostgreSQL:DbSecurityGroupRule.Create | Delete DB Security Group Rule |
+| Permission Name                             | Description                  |
+|---------------------------------------------|------------------------------|
+| RDSforPostgreSQL:DbSecurityGroupRule.Delete | Delete DB Security Group Rule |
 
 #### Request
 
 This API does not require a request body.
 
-| Name                | Type    | Format    | Required | Description                  |
-|-------------------|-------|-------|----|---------------------|
-| dbSecurityGroupId | URL   | UUID  | O  | DB security group identifier       |
-| ruleIds           | Query | Array | O  | DB security group rule identifiers |
+| Name              | Type  | Format | Required | Description                        |
+|-------------------|-------|--------|----------|------------------------------------|
+| dbSecurityGroupId | URL   | UUID   | O        |                                    |
+| ruleIds           | Query | String | O        | DB security group rule ID list     |
 
 #### Response
 
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
+| Name  | Type | Format | Description                  |
+|-------|------|--------|------------------------------|
+| jobId | Body | UUID   | Identifier of requested task |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -3925,11 +4289,157 @@ This API does not require a request body.
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
+---
+
+### Create DB Security Group Rule
+
+```http
+POST /v1.0/db-security-groups/{dbSecurityGroupId}/rules
+```
+
+#### Required permissions
+
+| Permission Name                             | Description                  |
+|---------------------------------------------|------------------------------|
+| RDSforPostgreSQL:DbSecurityGroupRule.Create | Create DB Security Group Rule |
+
+#### Request
+
+| Name              | Type | Format | Required | Description                                                                                                                                                                                                          |
+|-------------------|------|--------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| dbSecurityGroupId | URL  | UUID   | O        |                                                                                                                                                                                                                      |
+| direction         | Body | Enum   | O        | Communication direction<br/>- INGRESS: `Inbound`<br/>- EGRESS: `Outbound`                                                                                                                                            |
+| etherType         | Body | Enum   | O        | Ether type<br/>- IPV4: `IPv4`<br/>- IPV6: `IPv6`                                                                                                                                                                     |
+| port              | Body | Object | O        | Port information                                                                                                                                                                                                     |
+| port.portType     | Body | Enum   | O        | Port type<br/>- ALL: `All port ranges (not used in the user console)`<br/>- PORT: `Specific port`<br/>- DB_PORT: `DB listening port`<br/>- PORT_RANGE: `Port range`                                                   |
+| port.minPort      | Body | Number | X        | Minimum port range<br/>- Minimum value: `1`                                                                                                                                                                          |
+| port.maxPort      | Body | Number | X        | Maximum port range<br/>- Maximum value: `65535`                                                                                                                                                                      |
+| cidr              | Body | String | O        | CIDR                                                                                                                                                                                                                 |
+| description       | Body | String | X        | Additional information on the DB security group rule                                                                                                                                                                 |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "direction": "INGRESS",
+    "etherType": "IPV4",
+    "port": {
+        "portType": "ALL",
+        "minPort": 1,
+        "maxPort": 1
+    },
+    "cidr": "192.168.0.0/24",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name  | Type | Format | Description                  |
+|-------|------|--------|------------------------------|
+| jobId | Body | UUID   | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Modify DB Security Group Rule
+
+```http
+PUT /v1.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
+```
+
+#### Required permissions
+
+| Permission Name                             | Description                  |
+|---------------------------------------------|------------------------------|
+| RDSforPostgreSQL:DbSecurityGroupRule.Modify | Modify DB Security Group Rule |
+
+#### Request
+
+| Name              | Type | Format | Required | Description                                                                                                                                                                                                          |
+|-------------------|------|--------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| dbSecurityGroupId | URL  | UUID   | O        |                                                                                                                                                                                                                      |
+| ruleId            | URL  | UUID   | O        |                                                                                                                                                                                                                      |
+| direction         | Body | Enum   | O        | Communication direction<br/>- INGRESS: `Inbound`<br/>- EGRESS: `Outbound`                                                                                                                                            |
+| etherType         | Body | Enum   | O        | Ether type<br/>- IPV4: `IPv4`<br/>- IPV6: `IPv6`                                                                                                                                                                     |
+| port              | Body | Object | O        | Port information                                                                                                                                                                                                     |
+| port.portType     | Body | Enum   | O        | Port type<br/>- ALL: `All port ranges (not used in the user console)`<br/>- PORT: `Specific port`<br/>- DB_PORT: `DB listening port`<br/>- PORT_RANGE: `Port range`                                                   |
+| port.minPort      | Body | Number | X        | Minimum port range<br/>- Minimum value: `1`                                                                                                                                                                          |
+| port.maxPort      | Body | Number | X        | Maximum port range<br/>- Maximum value: `65535`                                                                                                                                                                      |
+| cidr              | Body | String | O        | CIDR                                                                                                                                                                                                                 |
+| description       | Body | String | X        | Additional information on the DB security group rule                                                                                                                                                                 |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "direction": "INGRESS",
+    "etherType": "IPV4",
+    "port": {
+        "portType": "ALL",
+        "minPort": 1,
+        "maxPort": 1
+    },
+    "cidr": "192.168.0.0/24",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name  | Type | Format | Description                  |
+|-------|------|--------|------------------------------|
+| jobId | Body | UUID   | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
 ## Parameter group
 
 ### List Parameter Groups
@@ -3940,32 +4450,29 @@ GET /v1.0/parameter-groups
 
 #### Required permissions
 
-| Permission Name                                  | Description            |
-|--------------------------------------|---------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforPostgreSQL:ParameterGroup.List | List Parameter Groups |
 
 #### Request
 
 This API does not require a request body.
 
-| Name        | Type    | Format   | Required | Description       |
-|-----------|-------|------|----|----------|
-| dbVersion | Query | Enum | X  | DB version information |
-
 #### Response
 
-| Name                                   | Type   | Format       | Description                                                                |
-|--------------------------------------|------|----------|-------------------------------------------------------------------|
-| parameterGroups                      | Body | Array    | Parameter groups                                                        |
-| parameterGroups.parameterGroupId     | Body | UUID     | Parameter group identifier                                                      |
-| parameterGroups.parameterGroupName   | Body | String   | Name to identify parameter groups                                              |
-| parameterGroups.parameterGroupStatus | Body | Enum     | Parameter group current status<br/>- `STABLE`: Applied<br/>- `NEED_TO_APPLY`: Need to apply |
-| parameterGroups.description          | Body | String   | Additional information on parameter group                                                 |
-| parameterGroups.dbVersion            | Body | Enum     | DB version information                                                          |
-| parameterGroups.createdYmdt          | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                 |
-| parameterGroups.updatedYmdt          | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                 |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| parameterGroups | Body | Array | Parameter groups |
+| parameterGroups.parameterGroupId | Body | UUID | Parameter group identifier |
+| parameterGroups.parameterGroupName | Body | String | Name to identify parameter groups |
+| parameterGroups.description | Body | String | Additional information on parameter group |
+| parameterGroups.dbVersion | Body | Enum | DB version information |
+| parameterGroups.parameterGroupStatus | Body | Enum | Parameter group current status<br/>- STABLE: `Applied`<br/>- NEED_TO_APPLY: `Need to apply`<br/>- DELETED: `Deleted` |
+| parameterGroups.createdYmdt | Body | DateTime | Created date and time |
+| parameterGroups.updatedYmdt | Body | DateTime | Modified date and time |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -3976,96 +4483,22 @@ This API does not require a request body.
     },
     "parameterGroups": [
         {
-            "parameterGroupId": "404e8a89-ca4d-4fca-96c2-1518754d50b7",
-            "parameterGroupName": "parameter-group",
+            "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "parameterGroupName": "parameterGroupName-example",
+            "description": "description-example",
+            "dbVersion": "POSTGRESQL_V14_17",
             "parameterGroupStatus": "STABLE",
-            "description": null,
-            "dbVersion": "POSTGRESQL_V17_6",
-            "createdYmdt": "2023-02-31T15:28:17+09:00",
-            "updatedYmdt": "2023-02-31T15:28:17+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
+
+</p>
 </details>
 
-
-### List Parameter Group Details
-
-```http
-GET /v1.0/parameter-groups/{parameterGroupId}
-```
-
-#### Required permissions
-
-| Permission Name                                 | Description            |
-|-------------------------------------|---------------|
-| RDSforPostgreSQL:ParameterGroup.Get | List Parameter Group Details |
-
-#### Request
-
-This API does not require a request body.
-
-| Name               | Type  | Format   | Required | Description           |
-|------------------|-----|------|----|--------------|
-| parameterGroupId | URL | UUID | O  | Parameter group identifier |
-
-#### Response
-
-| Name                           | Type   | Format       | Description                                                                                                                                                                                                                                                                                                                                                 |
-|------------------------------|------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| parameterGroupId             | Body | UUID     | Parameter group identifier                                                                                                                                                                                                                                                                                                                                       |
-| parameterGroupName           | Body | String   | Name to identify parameter groups                                                                                                                                                                                                                                                                                                                               |
-| description                  | Body | String   | Additional information on parameter group                                                                                                                                                                                                                                                                                                                                  |
-| dbVersion                    | Body | Enum     | DB version information                                                                                                                                                                                                                                                                                                                                           |
-| parameterGroupStatus         | Body | Enum     | Parameter group current status<br/>- `STABLE`: Applied<br/>- `NEED_TO_APPLY`: Need to apply<br/>- `DELETED`: Deleted                                                                                                                                                                                                                                                             |
-| parameters                   | Body | Array    | Parameter list                                                                                                                                                                                                                                                                                                                                            |
-| parameters.parameterCategory | Body | String   | Parameter Categories                                                                                                                                                                                                                                                                                                                                          |
-| parameters.parameterName     | Body | String   | Parameter name                                                                                                                                                                                                                                                                                                                                            |
-| parameters.value             | Body | String   | Current value                                                                                                                                                                                                                                                                                                                                           |
-| parameters.valueUnit         | Body | Enum     | The units of the currently set value<br/>- `B`: Bytes<br/>- `kB`: Kilobyte<br/>- `MB`: Megabytes<br/>- `GB`: Gigabyte<br/>- `TB`: Terabyte<br/>- `us`: Microseconds<br/>- `ms`: milliseconds<br/>- `s`: seconds<br/>- `min`: Minutes<br/>- `h`: hour<br/>- `d`: day                                                                                                                                                        |
-| parameters.defaultValue      | Body | String   | Default value                                                                                                                                                                                                                                                                                                                                                |
-| parameters.allowedValue      | Body | String   | Permitted values                                                                                                                                                                                                                                                                                                                                              |
-| parameters.valueType         | Body | Enum     | Value type<br/>- `BOOLEAN: Boolean` type<br/>- `STRING`: String type<br/>- `NUMERIC`: Integer and floating-point types<br/>- `NUMERIC_WITH_BYTE_UNIT`: Numeric type with byte unit (e.g. 120 KB, 100 MB)<br/>- `NUMERIC_WITH_TIME_UNIT`: Numeric type with time unit (e.g. 120ms, 100s, 1d)<br/>- `ENUMERATED`: Enter one of the values declared in Allowed Values<br/>- `MULTI_ENUMERATED`: Enter multiple of the values declared in Allowed values (separated by commas (,))<br/>- `TIMEZONE`: Timezone type |
-| parameters.updateType        | Body | Enum     | Modification type<br/>- `VARIABLE`: Modifiable any time<br/>- `CONSTANT`: Not modifiable                                                                                                                                                                                                                                                                                         |
-| parameters.applyType         | Body | Enum     | Applied type<br/>- `SESSION`: Apply session<br/>- `FILE`: Apply setting file (restart required)<br/>- `BOTH`: All                                                                                                                                                                                                                                                                       | 
-| createdYmdt                  | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                                                                                                                                                                                  |
-| updatedYmdt                  | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                                                                                                                                                                                  |
-| expressionAvailable          | Body | Boolean  | Allow formulas or not                                                                                                                                                                                                                                                                                                                                           |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroupId": "404e8a89-ca4d-4fca-96c2-1518754d50b7",
-    "parameterGroupName": "parameter-group",
-    "description": null,
-    "dbVersion": "POSTGRESQL_V17_6",
-    "parameterGroupStatus": "STABLE",
-    "parameters": [
-        {
-            "parameterCategory": "Write-Ahead Log / Checkpoints",
-            "parameterName": "checkpoint_timeout",
-            "value": "300s",
-            "defaultValue": "300s",
-            "allowedValue": "30~86400s",
-            "valueType": "NUMERIC_WITH_TIME_UNIT",
-            "updateType": "VARIABLE",
-            "applyType": "BOTH",
-            "expressionAvailable": true
-        }
-    ],
-    "createdYmdt": "2023-03-13T11:02:28+09:00",
-    "updatedYmdt": "2023-03-13T11:02:28+09:00"
-}
-```
-</details>
-
+---
 
 ### Create Parameter Group
 
@@ -4075,36 +4508,40 @@ POST /v1.0/parameter-groups
 
 #### Required permissions
 
-| Permission Name                                    | Description           |
-|----------------------------------------|--------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforPostgreSQL:ParameterGroup.Create | Create Parameter Group |
 
 #### Request
 
-| Name                 | Type   | Format     | Required | Description                   |
-|--------------------|------|--------|----|----------------------|
-| parameterGroupName | Body | String | O  | Name to identify parameter groups |
-| description        | Body | String | X  | Additional information on parameter group    |
-| dbVersion          | Body | Enum   | O  | DB version information             |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupName | Body | String | O | Name to identify parameter groups |
+| description | Body | String | X | Additional information on parameter group |
+| dbVersion | Body | Enum | O | DB version information |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
-    "parameterGroupName": "parameter-group",
-    "description": "description",
-    "dbVersion": "POSTGRESQL_V17_6"
+    "parameterGroupName": "parameterGroupName-example",
+    "description": "description-example",
+    "dbVersion": "POSTGRESQL_V14_17"
 }
 ```
+
+</p>
 </details>
 
 #### Response
 
-| Name               | Type   | Format   | Description           |
-|------------------|------|------|--------------|
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
 | parameterGroupId | Body | UUID | Parameter group identifier |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -4113,194 +4550,14 @@ POST /v1.0/parameter-groups
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "parameterGroupId": "404e8a89-ca4d-4fca-96c2-1518754d50b7"
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-### Copy Parameter Group
-
-```http
-POST /v1.0/parameter-groups/{parameterGroupId}/copy
-```
-
-#### Required permissions
-
-| Permission Name                                  | Description           |
-|--------------------------------------|--------------|
-| RDSforPostgreSQL:ParameterGroup.Copy | Copy Parameter Group |
-
-#### Request
-
-| Name                 | Type   | Format     | Required | Description                   |
-|--------------------|------|--------|----|----------------------|
-| parameterGroupId   | URL  | UUID   | O  | Parameter group identifier         |
-| parameterGroupName | Body | String | O  | Name to identify parameter groups |
-| description        | Body | String | X  | Additional information on parameter group    |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "parameterGroupName": "parameter-group-copy",
-    "description": "copy"
-}
-```
-</details>
-
-#### Response
-
-| Name               | Type   | Format   | Description           |
-|------------------|------|------|--------------|
-| parameterGroupId | Body | UUID | Parameter group identifier |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroupId": "404e8a89-ca4d-4fca-96c2-1518754d50b7"
-}
-```
-</details>
-
-### Modify Parameter Group
-
-```http
-PUT /v1.0/parameter-groups/{parameterGroupId}
-```
-
-#### Required permissions
-
-| Permission Name                                    | Description           |
-|----------------------------------------|--------------|
-| RDSforPostgreSQL:ParameterGroup.Modify | Modify Parameter Group |
-
-#### Request
-
-| Name                 | Type   | Format     | Required | Description                   |
-|--------------------|------|--------|----|----------------------|
-| parameterGroupId   | URL  | UUID   | O  | Parameter group identifier         |
-| parameterGroupName | Body | String | X  | Name to identify parameter groups |
-| description        | Body | String | X  | Additional information on parameter group    |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "parameterGroupName": "parameter-group",
-    "description": "description"
-}
-```
-</details>
-
-#### Response
-
-This API does not return a response body.
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
-
-### Modify Parameter
-
-```http
-PUT /v1.0/parameter-groups/{parameterGroupId}/parameters
-```
-
-#### Required permissions
-
-| Permission Name                                    | Description           |
-|----------------------------------------|--------------|
-| RDSforPostgreSQL:ParameterGroup.Modify | Modify Parameter Group |
-
-#### Request
-
-| Name                               | Type   | Format     | Required | Description           |
-|----------------------------------|------|--------|----|--------------|
-| parameterGroupId                 | URL  | UUID   | O  | Parameter group identifier |
-| modifiedParameters               | Body | Array  | O  | Parameters to change  |
-| modifiedParameters.parameterName | Body | UUID   | O  | Parameter name      |
-| modifiedParameters.value         | Body | String | O  | Parameter value to change   |
-
-<details><summary>Example</summary>
-
-```json
-{
-   "modifiedParameters": [
-       {
-           "parameterName": "checkpoint_timeout",
-           "value": "100s"
-       }
-   ]
-}
-```
-</details>
-
-#### Response
-
-This API does not return a response body.
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
-
-### Reset Parameter Group
-
-```http
-PUT /v1.0/parameter-groups/{parameterGroupId}/reset
-```
-
-#### Required permissions
-
-| Permission Name                                   | Description            |
-|---------------------------------------|---------------|
-| RDSforPostgreSQL:ParameterGroup.Reset | Reset Parameter Group |
-
-#### Request
-
-| Name               | Type  | Format   | Required | Description           |
-|------------------|-----|------|----|--------------|
-| parameterGroupId | URL | UUID | O  | Parameter group identifier |
-
-#### Response
-
-This API does not return a response body.
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
+---
 
 ### Delete Parameter Group
 
@@ -4310,23 +4567,69 @@ DELETE /v1.0/parameter-groups/{parameterGroupId}
 
 #### Required permissions
 
-| Permission Name                                    | Description           |
-|----------------------------------------|--------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforPostgreSQL:ParameterGroup.Delete | Delete Parameter Group |
 
 #### Request
 
 This API does not require a request body.
 
-| Name               | Type  | Format   | Required | Description           |
-|------------------|-----|------|----|--------------|
-| parameterGroupId | URL | UUID | O  | Parameter group identifier |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O | Parameter group identifier |
 
 #### Response
 
 This API does not return a response body.
 
+---
+
+### List Parameter Group Details
+
+```http
+GET /v1.0/parameter-groups/{parameterGroupId}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:ParameterGroup.Get | List Parameter Group Details |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O | Parameter group identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| parameterGroupId | Body | UUID | Parameter group identifier |
+| parameterGroupName | Body | String | Name to identify parameter groups |
+| description | Body | String | Additional information on parameter group |
+| dbVersion | Body | Enum | DB version information |
+| parameterGroupStatus | Body | Enum | Parameter group current status<br/>- STABLE: `Applied`<br/>- NEED_TO_APPLY: `Need to apply`<br/>- DELETED: `Deleted` |
+| parameters | Body | Array | Parameter list |
+| parameters.parameterCategory | Body | String | Parameter category |
+| parameters.parameterName | Body | String | Parameter name |
+| parameters.value | Body | String | Current value |
+| parameters.valueUnit | Body | String | Unit of the current value (byte: B,kB,MB,GB,TB, time: us,ms,s,min,h,d) |
+| parameters.defaultValue | Body | String | Default value |
+| parameters.allowedValue | Body | String | Permitted values |
+| parameters.valueType | Body | Enum | Value type<br/>- BOOLEAN: `Boolean type`<br/> `* ex) on, off, true, false, yes, no, 1, 0`<br/>- STRING: `String type`<br/>- NUMERIC: `Integer and floating-point types`<br/>- NUMERIC_WITH_BYTE_UNIT: `Numeric type with byte unit`<br/> `* ex) 120kB, 100MB`<br/> `* Allowed byte units: B (bytes), kB (kilobytes), MB (megabytes), GB (gigabytes), and TB (terabytes)`<br/>- NUMERIC_WITH_TIME_UNIT: `Numeric type with time unit`<br/> `* ex) 120ms, 100s, 1d`<br/> `* Allowed time units: us (microseconds), ms (milliseconds), s (seconds), min (minutes), h (hours), and d (days)`<br/>- ENUMERATED: `Enter one of the values declared in Allowed Values (separated by commas (,))`<br/>- MULTI_ENUMERATED: `Enter multiple of the values declared in Allowed Values (separated by commas (,))` |
+| parameters.updateType | Body | Enum | Modification type<br/>- VARIABLE: `Modifiable any time`<br/>- CONSTANT: `Not modifiable` |
+| parameters.applyType | Body | Enum | Applied type<br/>- BOTH: `Apply session and setting file`<br/>- SESSION: `Apply session only`<br/>- FILE: `Apply setting file only` |
+| parameters.expressionAvailable | Body | Boolean | Allow formulas or not |
+| createdYmdt | Body | DateTime | Created date and time |
+| updatedYmdt | Body | DateTime | Modified date and time |
+
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -4334,11 +4637,202 @@ This API does not return a response body.
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "parameterGroupName": "parameterGroupName-example",
+    "description": "description-example",
+    "dbVersion": "POSTGRESQL_V14_17",
+    "parameterGroupStatus": "STABLE",
+    "parameters": [
+        {
+            "parameterCategory": "parameterCategory-example",
+            "parameterName": "parameterName-example",
+            "value": "value-example",
+            "valueUnit": "valueUnit-example",
+            "defaultValue": "defaultValue-example",
+            "allowedValue": "allowedValue-example",
+            "valueType": "BOOLEAN",
+            "updateType": "VARIABLE",
+            "applyType": "BOTH",
+            "expressionAvailable": false
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
+
+</p>
 </details>
 
+---
+
+### Modify Parameter Group
+
+```http
+PUT /v1.0/parameter-groups/{parameterGroupId}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:ParameterGroup.Modify | Modify Parameter Group |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O | Parameter group identifier |
+| parameterGroupName | Body | String | X | Name to identify parameter groups |
+| description | Body | String | X | Additional information on parameter group |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "parameterGroupName": "parameterGroupName-example",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+This API does not return a response body.
+
+---
+
+### Copy Parameter Group
+
+```http
+POST /v1.0/parameter-groups/{parameterGroupId}/copy
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:ParameterGroup.Copy | Copy Parameter Group |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O | Parameter group identifier |
+| parameterGroupName | Body | String | O | Name to identify parameter groups |
+| description | Body | String | X | Additional information on parameter group |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "parameterGroupName": "parameterGroupName-example",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| parameterGroupId | Body | UUID | Parameter group identifier |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Modify Parameter
+
+```http
+PUT /v1.0/parameter-groups/{parameterGroupId}/parameters
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:ParameterGroup.Modify | Modify Parameter Group |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O | Parameter group identifier |
+| modifiedParameters | Body | Array | O | Parameters to change |
+| modifiedParameters.parameterName | Body | String | O | Parameter name |
+| modifiedParameters.value | Body | String | O | Parameter value to change |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "modifiedParameters": [
+        {
+            "parameterName": "parameterName-example",
+            "value": "value-example"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+This API does not return a response body.
+
+---
+
+### Reset Parameter Group
+
+```http
+PUT /v1.0/parameter-groups/{parameterGroupId}/reset
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:ParameterGroup.Reset | Reset Parameter Group |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O | Parameter group identifier |
+
+#### Response
+
+This API does not return a response body.
+
+---
 ## User Group
 
 ### List User Groups
@@ -4349,8 +4843,8 @@ GET /v1.0/user-groups
 
 #### Required permissions
 
-| Permission Name                             | Description           |
-|---------------------------------|--------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforPostgreSQL:UserGroup.List | List User Groups |
 
 #### Request
@@ -4359,16 +4853,17 @@ This API does not require a request body.
 
 #### Response
 
-| Name                       | Type   | Format       | Description                                                      |
-|--------------------------|------|----------|---------------------------------------------------------|
-| userGroups               | Body | Array    | User Groups                                               |
-| userGroups.userGroupId   | Body | UUID     | User group identifier                                             |
-| userGroups.userGroupName | Body | String   | Name to identify user groups                                     |
-| userGroupStatus          | Body | Enum     | Current status of user groups<br/>- `CREATED: Created`<br/>- `DELETED`: Deleted |
-| userGroups.createdYmdt   | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                       |
-| userGroups.updatedYmdt   | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                       |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| userGroups | Body | Array | User Groups |
+| userGroups.userGroupId | Body | UUID | User group identifier |
+| userGroups.userGroupName | Body | String | Name to identify user groups |
+| userGroupStatus | Body | Enum | Current status of user groups<br/>- CREATED<br/>- DELETED |
+| userGroups.createdYmdt | Body | DateTime | Created date and time |
+| userGroups.updatedYmdt | Body | DateTime | Modified date and time |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -4379,75 +4874,20 @@ This API does not require a request body.
     },
     "userGroups": [
         {
-            "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-            "userGroupName": "dev-team",
+            "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "userGroupName": "userGroupName-example",
             "userGroupStatus": "CREATED",
-            "createdYmdt": "2023-02-23T10:07:54+09:00",
-            "updatedYmdt": "2023-02-26T01:15:50+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
+
+</p>
 </details>
 
-
-### List User Group Details
-
-```http
-GET /v1.0/user-groups/{userGroupId}
-```
-
-#### Required permissions
-
-| Permission Name                            | Description           |
-|--------------------------------|--------------|
-| RDSforPostgreSQL:UserGroup.Get | List User Group Details |
-
-#### Request
-
-This API does not require a request body.
-
-| Name          | Type  | Format   | Required | Description          |
-|-------------|-----|------|----|-------------|
-| userGroupId | URL | UUID | O  | User group identifier |
-
-#### Response
-
-| Name                | Type   | Format       | Description                                                                                                        |
-|-------------------|------|----------|-----------------------------------------------------------------------------------------------------------|
-| userGroupId       | Body | UUID     | User group identifier                                                                                               |
-| userGroupName     | Body | String   | Name to identify user groups                                                                                       |
-| userGroupTypeCode | Body | Enum     | User group type    <br /> `ENTIRE`: User group including all project members <br /> `INDIVIDUAL_MEMBER`: User group including specific project members |
-| userGroupStatus   | Body | Enum     | Current status of user groups<br/>- `CREATED: Created`<br/>- `DELETED`: Deleted                                                   |
-| members           | Body | Array    | Project member list                                                                                                |
-| members.memberId  | Body | UUID     | Project member identifier                                                                                              |
-| createdYmdt       | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                         |
-| updatedYmdt       | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                         |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-    "userGroupName": "dev-team",
-    "userGroupStatus": "CREATED",
-    "userGroupTypeCode": "INDIVIDUAL_MEMBER",
-    "members": [
-        {
-            "memberId": "1321e759-2ef3-4b85-9921-b13e918b24b5"
-        }
-    ],
-    "createdYmdt": "2023-02-23T10:07:54+09:00",
-    "updatedYmdt": "2023-02-26T01:15:50+09:00"
-}
-```
-</details>
-
+---
 
 ### Create User Group
 
@@ -4457,78 +4897,40 @@ POST /v1.0/user-groups
 
 #### Required permissions
 
-| Permission Name                               | Description          |
-|-----------------------------------|-------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforPostgreSQL:UserGroup.Create | Create User Group |
 
 #### Request
 
-| Name            | Type   | Format      | Required | Description                                                              |
-|---------------|------|---------|----|-----------------------------------------------------------------|
-| userGroupName | Body | String  | O  | Name to identify user groups                                             |
-| memberIds     | Body | Array   | O  | Project member identifiers     <br /> Ignored when `selectAllYN` is true |
-| selectAllYN   | Body | Boolean | X  | All project members or not <br /> If true, the group is set for all members              |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| userGroupName | Body | String | O | Name to identify user groups |
+| memberIds | Body | Array | O | List of project member identifiers |
+| selectAllYN | Body | Boolean | O | All project members or not<br/>- Default: `false` |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
-    "userGroupName": "dev-team",
-    "memberIds": ["1321e759-2ef3-4b85-9921-b13e918b24b5"]
+    "userGroupName": "userGroupName-example",
+    "memberIds": [],
+    "selectAllYN": false
 }
 ```
 
-```json
-{
-    "userGroupName": "dev-team",
-    "selectAllYN":true
-}
-```
+</p>
 </details>
 
 #### Response
 
-| Name          | Type   | Format   | Description          |
-|-------------|------|------|-------------|
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
 | userGroupId | Body | UUID | User group identifier |
 
-
-### Modify User Group
-
-```http
-PUT /v1.0/user-groups/{userGroupId}
-```
-
-#### Required permissions
-
-| Permission Name                               | Description          |
-|-----------------------------------|-------------|
-| RDSforPostgreSQL:UserGroup.Modify | Modify User Group |
-
-#### Request
-
-| Name            | Type   | Format      | Required | Description                                                 |
-|---------------|------|---------|----|----------------------------------------------------|
-| userGroupId   | URL  | UUID    | O  | User group identifier                                        |
-| userGroupName | Body | String  | X  | Name to identify user groups                                |
-| memberIds     | Body | Array   | X  | Project member identifiers                                    |
-| selectAllYN   | Body | Boolean | X  | All project members or not <br /> If true, the group is set for all members |
-
 <details><summary>Example</summary>
-
-```json
-{
-    "userGroupName": "dev-team",
-    "memberIds": ["1321e759-2ef3-4b85-9921-b13e918b24b5","f9064b09-2b15-442e-a4b0-3a5a2754555e"]
-}
-```
-</details>
-
-#### Response
-
-This API does not return a response body.
-
-<details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -4536,10 +4938,15 @@ This API does not return a response body.
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "userGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
+
+---
 
 ### Delete User Group
 
@@ -4549,21 +4956,59 @@ DELETE /v1.0/user-groups/{userGroupId}
 
 #### Required permissions
 
-| Permission Name                               | Description          |
-|-----------------------------------|-------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforPostgreSQL:UserGroup.Delete | Delete User Group |
 
 #### Request
 
-| Name          | Type  | Format   | Required | Description          |
-|-------------|-----|------|----|-------------|
-| userGroupId | URL | UUID | O  | User group identifier |
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | O | User group identifier |
 
 #### Response
 
 This API does not return a response body.
 
+---
+
+### List User Group Details
+
+```http
+GET /v1.0/user-groups/{userGroupId}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:UserGroup.Get | List User Group Details |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | O | User group identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| userGroupId | Body | UUID | User group identifier |
+| userGroupName | Body | String | Name to identify user groups |
+| userGroupTypeCode | Body | Enum | User group type<br/>- ENTIRE: `All project members`<br/>- INDIVIDUAL_MEMBER: `Custom` |
+| userGroupStatus | Body | Enum | Current status of user groups<br/>- CREATED<br/>- DELETED |
+| members | Body | Array | Project member list |
+| members.memberId | Body | UUID | Project member identifier |
+| createdYmdt | Body | DateTime | Created date and time |
+| updatedYmdt | Body | DateTime | Modified date and time |
+
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -4571,12 +5016,67 @@ This API does not return a response body.
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "userGroupName": "userGroupName-example",
+    "userGroupTypeCode": "ENTIRE",
+    "userGroupStatus": "CREATED",
+    "members": [
+        {
+            "memberId": "550e8400-e29b-41d4-a716-446655440000"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
+
+</p>
 </details>
 
-## Notification Group
+---
+
+### Modify User Group
+
+```http
+PUT /v1.0/user-groups/{userGroupId}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:UserGroup.Modify | Modify User Group |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | O | User group identifier |
+| userGroupName | Body | String | X | Name to identify user groups |
+| memberIds | Body | Array | X | List of project member identifiers |
+| selectAllYN | Body | Boolean | O | All project members or not<br/>- Default: `false` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "userGroupName": "userGroupName-example",
+    "memberIds": [],
+    "selectAllYN": false
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+This API does not return a response body.
+
+---
+## Notification Groups
 
 ### List Notification Groups
 
@@ -4586,8 +5086,8 @@ GET /v1.0/notification-groups
 
 #### Required permissions
 
-| Permission Name                                     | Description          |
-|-----------------------------------------|-------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforPostgreSQL:NotificationGroup.List | List Notification Groups |
 
 #### Request
@@ -4596,19 +5096,20 @@ This API does not require a request body.
 
 #### Response
 
-| Name                                         | Type   | Format       | Description                                                     |
-|--------------------------------------------|------|----------|--------------------------------------------------------|
-| notificationGroups                         | Body | Array    | Notification Groups                                               |
-| notificationGroups.notificationGroupId     | Body | UUID     | Notification group identifier                                             |
-| notificationGroups.notificationGroupName   | Body | String   | Name to identify notification groups                                     |
-| notificationGroups.notificationGroupStatus | Body | Enum     | Current status of notification groups<br/>- `CREATED: Created`<br/>- `DELETED`: Deleted |
-| notificationGroups.notifyEmail             | Body | Boolean  | Whether to be notified by email                                              |
-| notificationGroups.notifySms               | Body | Boolean  | Whether to be notified by SMS                                              |
-| notificationGroups.isEnabled               | Body | Boolean  | Indicates whether the flavor is enabled                                                 |
-| notificationGroups.createdYmdt             | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                      |
-| notificationGroups.updatedYmdt             | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                      |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| notificationGroups | Body | Array |  |
+| notificationGroups.notificationGroupId | Body | UUID | Notification group identifier |
+| notificationGroups.notificationGroupName | Body | String | Name to identify notification groups |
+| notificationGroups.notificationGroupStatus | Body | Enum | Current status of notification groups<br/>- CREATED: `Created`<br/>- DELETED: `Deleted` |
+| notificationGroups.notifyEmail | Body | Boolean | Whether to be notified by email |
+| notificationGroups.notifySms | Body | Boolean | Whether to be notified by SMS |
+| notificationGroups.isEnabled | Body | Boolean | Whether it is enabled |
+| notificationGroups.createdYmdt | Body | DateTime | Created date and time |
+| notificationGroups.updatedYmdt | Body | DateTime | Modified date and time |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -4619,91 +5120,23 @@ This API does not require a request body.
     },
     "notificationGroups": [
         {
-            "notificationGroupId": "b3901f17-9971-4d1e-8a81-8448cf533dc7",
-            "notificationGroupName": "dev-team-noti",
-            "notifyEmail": true,
+            "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "notificationGroupName": "notificationGroupName-example",
+            "notificationGroupStatus": "CREATED",
+            "notifyEmail": false,
             "notifySms": false,
-            "isEnabled": true,
-            "createdYmdt": "2023-02-20T13:34:13+09:00",
-            "updatedYmdt": "2023-02-20T13:34:13+09:00"
+            "isEnabled": false,
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
+
+</p>
 </details>
 
-
-### List Notification Groups
-
-```http
-GET /v1.0/notification-groups/{notificationGroupId}
-```
-
-#### Required permissions
-
-| Permission Name                                    | Description          |
-|----------------------------------------|-------------|
-| RDSforPostgreSQL:NotificationGroup.Get | List Notification Groups |
-
-#### Request
-
-This API does not require a request body.
-
-| Name                  | Type  | Format   | Required | Description         |
-|---------------------|-----|------|----|------------|
-| notificationGroupId | URL | UUID | O  | Notification group identifier |
-
-#### Response
-
-| Name                         | Type   | Format       | Description                                                     |
-|----------------------------|------|----------|--------------------------------------------------------|
-| notificationGroupId        | Body | UUID     | Notification group identifier                                             |
-| notificationGroupName      | Body | String   | Name to identify notification groups                                     |
-| notificationGroupStatus    | Body | Enum     | Current status of notification groups<br/>- `CREATED: Created`<br/>- `DELETED`: Deleted |
-| notifyEmail                | Body | Boolean  | Whether to be notified by email                                              |
-| notifySms                  | Body | Boolean  | Whether to be notified by SMS                                              |
-| isEnabled                  | Body | Boolean  | Indicates whether the flavor is enabled                                                 |
-| dbInstances                | Body | Array    | DB Instances to monitor                                       |
-| dbInstances.dbInstanceId   | Body | UUID     | DB instance identifier                                           |
-| dbInstances.dbInstanceName | Body | String   | Name to identify DB instances                                   |
-| userGroups                 | Body | Array    | User Groups                                              |
-| userGroups.userGroupId     | Body | UUID     | User group identifier                                            |
-| userGroups.userGroupName   | Body | String   | Name to identify user groups                                    |
-| createdYmdt                | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                      |
-| updatedYmdt                | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                      |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "notificationGroupId": "b3901f17-9971-4d1e-8a81-8448cf533dc7",
-    "notificationGroupName": "dev-team-noti",
-    "notifyEmail": true,
-    "notifySms": false,
-    "isEnabled": true,
-    "dbInstances": [
-        {
-            "dbInstanceId": "ed5cb985-526f-4c54-9ae0-40288593de65",
-            "dbInstanceName": "database"
-        }
-    ],
-    "userGroups": [
-        {
-            "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-            "userGroupName": "dev-team"
-        }
-    ],
-    "createdYmdt": "2023-02-20T13:34:13+09:00",
-    "updatedYmdt": "2023-02-20T13:34:13+09:00"
-}
-```
-</details>
-
+---
 
 ### Create Notification Group
 
@@ -4713,80 +5146,46 @@ POST /v1.0/notification-groups
 
 #### Required permissions
 
-| Permission Name                                       | Description         |
-|-------------------------------------------|------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforPostgreSQL:NotificationGroup.Create | Create Notification Group |
 
 #### Request
 
-| Name                    | Type   | Format      | Required | Description                          |
-|-----------------------|------|---------|----|-----------------------------|
-| notificationGroupName | Body | String  | O  | Name to identify notification groups          |
-| notifyEmail           | Body | Boolean | X  | Whether to be notified by email<br/>Default: `true` |
-| notifySms             | Body | Boolean | X  | Whether to be notified by SMS<br/>Default: `true` |
-| isEnabled             | Body | Boolean | X  | Indicates whether the flavor is enabled<br/>Default: `true`    |
-| dbInstanceIds         | Body | Array   | X  | DB instance identifiers to monitor       |
-| userGroupIds          | Body | Array   | X  | User group identifiers              |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| notificationGroupName | Body | String | O | Name to identify notification groups |
+| notifyEmail | Body | Boolean | X | Whether to be notified by email<br/>- Default: `true` |
+| notifySms | Body | Boolean | X | Whether to be notified by SMS<br/>- Default: `true` |
+| isEnabled | Body | Boolean | X | Whether it is enabled<br/>- Default: `true` |
+| dbInstanceIds | Body | Array | O | List of identifiers of DB instances to monitor |
+| userGroupIds | Body | Array | O | List of user group identifiers |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
-    "notificationGroupName": "dev-team-noti",
-    "notifyEmail": false,
-    "isEnable": true,
-    "dbInstanceIds": ["ed5cb985-526f-4c54-9ae0-40288593de65"],
-    "userGroupIds": ["1aac0437-f32d-4923-ad3c-ac61c1cfdfe0"]
+    "notificationGroupName": "notificationGroupName-example",
+    "notifyEmail": true,
+    "notifySms": true,
+    "isEnabled": true,
+    "dbInstanceIds": [],
+    "userGroupIds": []
 }
 ```
+
+</p>
 </details>
 
 #### Response
 
-| Name                  | Type   | Format   | Description         |
-|---------------------|------|------|------------|
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
 | notificationGroupId | Body | UUID | Notification group identifier |
 
-
-### Modify Notification Group
-
-```http
-PUT /v1.0/notification-groups/{notificationGroupId}
-```
-
-#### Required permissions
-
-| Permission Name                                       | Description         |
-|-------------------------------------------|------------|
-| RDSforPostgreSQL:NotificationGroup.Modify | Modify Notification Group |
-
-#### Request
-
-| Name                    | Type   | Format      | Required | Description                    |
-|-----------------------|------|---------|----|-----------------------|
-| notificationGroupId   | URL  | UUID    | O  | Notification group identifier            |
-| notificationGroupName | Body | String  | X  | Name to identify notification groups    |
-| notifyEmail           | Body | Boolean | X  | Whether to be notified by email             |
-| notifySms             | Body | Boolean | X  | Whether to be notified by SMS             |
-| isEnabled             | Body | Boolean | X  | Indicates whether the flavor is enabled                |
-| dbInstanceIds         | Body | Array   | X  | DB instance identifiers to monitor |
-| userGroupIds          | Body | Array   | X  | User group identifiers        |
-
 <details><summary>Example</summary>
-
-```json
-{
-    "notifyEmail": true,
-    "dbInstanceIds": ["ed5cb985-526f-4c54-9ae0-40288593de65", "d51b7da0-682f-47ff-b588-b739f6adc740"]
-}
-```
-</details>
-
-#### Response
-
-This API does not return a response body.
-
-<details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -4794,10 +5193,15 @@ This API does not return a response body.
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
+
+---
 
 ### Delete Notification Group
 
@@ -4807,65 +5211,65 @@ DELETE /v1.0/notification-groups/{notificationGroupId}
 
 #### Required permissions
 
-| Permission Name                                       | Description         |
-|-------------------------------------------|------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforPostgreSQL:NotificationGroup.Delete | Delete Notification Group |
 
 #### Request
 
 This API does not require a request body.
 
-| Name                  | Type  | Format   | Required | Description         |
-|---------------------|-----|------|----|------------|
-| notificationGroupId | URL | UUID | O  | Notification group identifier |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O | Notification group identifier |
 
 #### Response
 
 This API does not return a response body.
 
-<details><summary>Example</summary>
+---
 
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
-
-### View the list of watch settings
+### View Notification Group Details
 
 ```http
-GET /v1.0/notification-groups/{notificationGroupId}/watchdogs
+GET /v1.0/notification-groups/{notificationGroupId}
 ```
 
 #### Required permissions
 
-| Permission Name                                        | Description          |
-|--------------------------------------------|-------------|
-| RDSforPostgreSQL:NotificationWatchdog.List | View the list of watch settings |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:NotificationGroup.Get | View Notification Group Details |
 
 #### Request
 
 This API does not require a request body.
 
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O | Notification group identifier |
+
 #### Response
 
-| Name                           | Type   | Format       | Description                                                                     |
-|------------------------------|------|----------|------------------------------------------------------------------------|
-| notificationGroupId          | URL  | UUID     | Notification group identifier                                                             | Notification group identifier                                                            |
-| watchdogs                    | Body | Array    | List of watch settings                                                               |
-| watchdogs.watchdogId         | Body | UUID     | Identifier of the watch setting                                                             |
-| watchdogs.metricName         | Body | Enum     | Performance metrics to watch<br/>- For the performance metrics you can set, see [Viewing the performance metrics list](#성능-지표-목록-보기). |
-| watchdogs.comparisonOperator | Body | Enum     | How to compare watchlists<br/>- `LE`: <=<br/>- `LT`: <<br/>- `GE`: >=<br/>- `GT`: >  |
-| watchdogs.threshold          | Body | Long     | Thresholds to watch                                                              |
-| watchdogs.duration           | Body | Long     | Watchlist duration<br/>- Unit: `minutes`                                              |
-| watchdogs.createdYmdt        | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                      |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| notificationGroupId | Body | UUID | Notification group identifier |
+| notificationGroupName | Body | String | Name to identify notification groups |
+| notificationGroupStatus | Body | Enum | Current status of notification groups<br/>- CREATED: `Created`<br/>- DELETED: `Deleted` |
+| notifyEmail | Body | Boolean | Whether to be notified by email |
+| notifySms | Body | Boolean | Whether to be notified by SMS |
+| isEnabled | Body | Boolean | Whether it is enabled |
+| dbInstances | Body | Array | List of DB instances to monitor |
+| dbInstances.dbInstanceId | Body | UUID | DB instance identifier |
+| dbInstances.dbInstanceName | Body | String | Name to identify DB instances |
+| userGroups | Body | Array | List of user groups |
+| userGroups.userGroupId | Body | UUID | User group identifier |
+| userGroups.userGroupName | Body | String | Name to identify user groups |
+| createdYmdt | Body | DateTime | Created date and time |
+| updatedYmdt | Body | DateTime | Modified date and time |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -4874,22 +5278,142 @@ This API does not require a request body.
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "watchdogs": [
+    "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "notificationGroupName": "notificationGroupName-example",
+    "notificationGroupStatus": "CREATED",
+    "notifyEmail": false,
+    "notifySms": false,
+    "isEnabled": false,
+    "dbInstances": [
         {
-            "watchdogId": "b3901f17-9971-4d1e-8a81-8448cf533dc7",
-            "metricName": "DATABASE_STATUS",
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbInstanceName": "dbInstanceName-example"
+        }
+    ],
+    "userGroups": [
+        {
+            "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "userGroupName": "userGroupName-example"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Modify Notification Group
+
+```http
+PUT /v1.0/notification-groups/{notificationGroupId}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:NotificationGroup.Modify | Modify Notification Group |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O | Notification group identifier |
+| notificationGroupName | Body | String | X | Name to identify notification groups |
+| notifyEmail | Body | Boolean | X | Whether to be notified by email<br/>- Default: `false` |
+| notifySms | Body | Boolean | X | Whether to be notified by SMS<br/>- Default: `false` |
+| isEnabled | Body | Boolean | X | Whether it is enabled<br/>- Default: `false` |
+| dbInstanceIds | Body | Array | O | List of identifiers of DB instances to monitor |
+| userGroupIds | Body | Array | O | List of user group identifiers |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "notificationGroupName": "notificationGroupName-example",
+    "notifyEmail": false,
+    "notifySms": false,
+    "isEnabled": false,
+    "dbInstanceIds": [],
+    "userGroupIds": []
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+This API does not return a response body.
+
+---
+
+### List Watch Settings
+
+```http
+GET /v1.0/notification-groups/{notificationGroupId}/watchdogs
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:NotificationWatchdog.List | List Watch Settings |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O | Notification group identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| notificationWatchdogs | Body | Array | Watch setting information |
+| notificationWatchdogs.watchdogId | Body | UUID | Watch setting identifier |
+| notificationWatchdogs.metricName | Body | String | Performance metrics to watch |
+| notificationWatchdogs.comparisonOperator | Body | Enum | Comparison method for watch target<br/>- LE: `<=`<br/>- LT: `<`<br/>- GE: `>=`<br/>- GT: `>` |
+| notificationWatchdogs.threshold | Body | Number | Threshold for watch target |
+| notificationWatchdogs.duration | Body | Number | Duration for watch target |
+| notificationWatchdogs.createdYmdt | Body | DateTime | Created date and time |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "notificationWatchdogs": [
+        {
+            "watchdogId": "550e8400-e29b-41d4-a716-446655440000",
+            "metricName": "metricName-example",
             "comparisonOperator": "LE",
-            "threshold": 0,
-            "duration": 5,
-            "createdYmdt": "2023-02-20T13:34:13+09:00",
-            "updatedYmdt": "2023-02-20T13:34:13+09:00"
+            "threshold": 1,
+            "duration": 1,
+            "createdYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
+
+</p>
 </details>
 
-### Create a watch setting
+---
+
+### Create Watch Setting
 
 ```http
 POST /v1.0/notification-groups/{notificationGroupId}/watchdogs
@@ -4897,79 +5421,43 @@ POST /v1.0/notification-groups/{notificationGroupId}/watchdogs
 
 #### Required permissions
 
-| Permission Name                                          | Description         |
-|----------------------------------------------|------------|
-| RDSforPostgreSQL:NotificationWatchdog.Create | Create a watch setting |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:NotificationWatchdog.Create | Create Watch Setting |
 
 #### Request
 
-| Name                  | Type   | Format   | Required | Description                                                                     |
-|---------------------|------|------|----|------------------------------------------------------------------------|
-| notificationGroupId | URL  | UUID | O  | Notification group identifier                                                             |
-| metricName          | Body | Enum | O  | Performance metrics to watch<br/>- For the performance metrics you can set, see [Viewing the performance metrics list](#성능-지표-목록-보기). |
-| comparisonOperator  | Body | Enum | O  | How to compare watchlists<br/>- `LE`: <=<br/>- `LT`: <<br/>- `GE`: >=<br/>- `GT`: >  |
-| threshold           | Body | Long | O  | Thresholds to watch                                                              |
-| duration            | Body | Long | O  | Watchlist duration<br/>- Unit: `minutes`                                              |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O | Notification group identifier |
+| metricName | Body | String | O | Performance metrics to watch |
+| comparisonOperator | Body | Enum | O | Comparison method for watch target<br/>- LE: `<=`<br/>- LT: `<`<br/>- GE: `>=`<br/>- GT: `>` |
+| threshold | Body | Number | O | Threshold for watch target<br/>- Minimum value: `0` |
+| duration | Body | Number | O | Duration for watch target (minutes)<br/>- Minimum value: `0` |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
-    "metricName": "DATABASE_STATUS",
+    "metricName": "metricName-example",
     "comparisonOperator": "LE",
     "threshold": 0,
-    "duration": 5
+    "duration": 0
 }
 ```
+
+</p>
 </details>
 
 #### Response
 
-| Name         | Type   | Format   | Description         |
-|------------|------|------|------------|
-| watchdogId | Body | UUID | Identifier of the watch setting |
-
-
-### Modify watch settings
-
-```http
-PUT /v1.0/notification-groups/{notificationGroupId}/watchdogs/{watchdogId}
-```
-
-#### Required permissions
-
-| Permission Name                                          | Description         |
-|----------------------------------------------|------------|
-| RDSforPostgreSQL:NotificationWatchdog.Modify | Modify watch settings |
-
-#### Request
-
-| Name                  | Type   | Format   | Required | Description                                                                     |
-|---------------------|------|------|----|------------------------------------------------------------------------|
-| notificationGroupId | URL  | UUID | O  | Notification group identifier                                                             |
-| watchdogId          | URL  | UUID | O  | Identifier of the watch setting                                                             |
-| metricName          | Body | Enum | O  | Performance metrics to watch<br/>- For the performance metrics you can set, see [Viewing the performance metrics list](#성능-지표-목록-보기). |
-| comparisonOperator  | Body | Enum | O  | How to compare watchlists<br/>- `LE`: <=<br/>- `LT`: <<br/>- `GE`: >=<br/>- `GT`: >  |
-| threshold           | Body | Long | O  | Thresholds to watch                                                              |
-| duration            | Body | Long | O  | Watchlist duration<br/>- Unit: `minutes`                                              |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| watchdogId | Body | UUID | Watch setting identifier |
 
 <details><summary>Example</summary>
-
-```json
-{
-    "metricName": "DATABASE_STATUS",
-    "comparisonOperator": "LE",
-    "threshold": 0,
-    "duration": 10
-}
-```
-</details>
-
-#### Response
-
-This API does not return a response body.
-
-<details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -4977,12 +5465,17 @@ This API does not return a response body.
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "watchdogId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-### Deleting a watch setting
+---
+
+### Delete Notification Group
 
 ```http
 DELETE /v1.0/notification-groups/{notificationGroupId}/watchdogs/{watchdogId}
@@ -4990,37 +5483,91 @@ DELETE /v1.0/notification-groups/{notificationGroupId}/watchdogs/{watchdogId}
 
 #### Required permissions
 
-| Permission Name                                          | Description         |
-|----------------------------------------------|------------|
-| RDSforPostgreSQL:NotificationWatchdog.Delete | Deleting a watch setting |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:NotificationWatchdog.Delete | Delete Notification Group |
 
 #### Request
 
 This API does not require a request body.
 
-| Name                  | Type  | Format   | Required | Description         |
-|---------------------|-----|------|----|------------|
-| notificationGroupId | URL | UUID | O  | Notification group identifier |
-| watchdogId          | URL | UUID | O  | Identifier of the watch setting |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O | Notification group identifier |
+| watchdogId | URL | UUID | O | Watch setting identifier |
 
 #### Response
 
 This API does not return a response body.
 
+---
+
+### Modify Watch Setting
+
+```http
+PUT /v1.0/notification-groups/{notificationGroupId}/watchdogs/{watchdogId}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:NotificationWatchdog.Modify | Modify Watch Setting |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O | Notification group identifier |
+| watchdogId | URL | UUID | O | Watch setting identifier |
+| metricName | Body | String | O | Performance metrics to watch |
+| comparisonOperator | Body | Enum | O | Comparison method for watch target<br/>- LE: `<=`<br/>- LT: `<`<br/>- GE: `>=`<br/>- GT: `>` |
+| threshold | Body | Number | O | Threshold for watch target<br/>- Minimum value: `0` |
+| duration | Body | Number | O | Duration for watch target (minutes)<br/>- Minimum value: `0` |
+
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
+    "metricName": "metricName-example",
+    "comparisonOperator": "LE",
+    "threshold": 0,
+    "duration": 0
 }
 ```
+
+</p>
 </details>
 
+#### Response
+
+This API does not return a response body.
+
+---
 ## Monitoring
+
+### View stats
+
+```http
+GET /v1.0/metric-statistics
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:Metric.List | View stats |
+
+#### Request
+
+This API does not require a request body.
+
+#### Response
+
+This API does not return a response body.
+
+---
 
 ### View a list of performance metrics
 
@@ -5030,9 +5577,9 @@ GET /v1.0/metrics
 
 #### Required permissions
 
-| Permission Name                          | Description       |
-|------------------------------|----------|
-| RDSforPostgreSQL:Metric.List | View stats |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:Metric.List | View a list of performance metrics |
 
 #### Request
 
@@ -5040,13 +5587,14 @@ This API does not require a request body.
 
 #### Response
 
-| Name                 | Type   | Format     | Description       |
-|--------------------|------|--------|----------|
-| metrics            | Body | Array  | List of performance metrics |
-| metrics.metricName | Body | Enum   | Performance metric types |
-| metrics.unit       | Body | String | Measure unit   |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| metrics | Body | Array | List of performance metrics |
+| metrics.metricName | Body | String | Performance metric types |
+| metrics.unit | Body | String | Measure unit |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -5057,161 +5605,34 @@ This API does not require a request body.
     },
     "metrics": [
         {
-            "metricName": "CPU_USAGE",
-            "unit": "%"
+            "metricName": "metricName-example",
+            "unit": "unit-example"
         }
     ]
 }
 ```
+
+</p>
 </details>
 
-### View stats
-
-```http
-GET /v1.0/metric-statistics
-```
-
-#### Required permissions
-
-| Permission Name                          | Description       |
-|------------------------------|----------|
-| RDSforPostgreSQL:Metric.List | View stats |
-
-#### Request
-
-| Name           | Type    | Format       | Required | Description                                                        |
-|--------------|-------|----------|----|-----------------------------------------------------------|
-| dbInstanceId | Query | UUID     | O  | DB instance identifier                                              |
-| metricNames  | Query | Array    | O  | List of performance metrics to look up<br/>- Minimum length: `1`                             |
-| from         | Query | Datetime | O  | Start date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                         |
-| to           | Query | Datetime | O  | End date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                         |
-| interval     | Query | Number   | X  | View interval<br/>- Unit: `minutes`<br/>- Default: Automatically selects the appropriate value based on start/end dates |
-
-#### Response
-
-| Name                                | Type   | Format        | Description       |
-|-----------------------------------|------|-----------|----------|
-| metricStatistics                  | Body | Array     | Statistics information list |
-| metricStatistics.metricName       | Body | Enum      | Performance metric types |
-| metricStatistics.unit             | Body | String    | Measure unit   |
-| metricStatistics.values           | Body | Array     | Measure values   |
-| metricStatistics.values.timestamp | Body | Timestamp | Measure time    |
-| metricStatistics.values.value     | Body | Object    | Measure value      |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "metricStatistics": [
-        {
-            "metricName": "DATABASE_STATUS",
-            "unit": "",
-            "values": [
-                [
-                    1679298540,
-                    "1"
-                ],
-                [
-                    1679298600,
-                    "1"
-                ],
-                [
-                    1679298660,
-                    "1"
-                ]
-            ]
-        }
-    ]
-}
-```
-</details>
+---
 
 ## Event
 
-### View the list of events
+### Event categories
 
-```
-GET /v1.0/events
-```
+Events can be classified by category as follows.
 
-#### Required permissions
+| Event category | Description |
+|-------------|---------|
+| ALL         | All |
+| BACKUP      | Backup |
+| DB_INSTANCE | DB instance |
+| JOB         | Job |
+| TENANT      | Tenant |
+| MONITORING  | Monitoring |
 
-| Permission Name                         | Description        |
-|-----------------------------|-----------|
-| RDSforPostgreSQL:Event.List | View the list of events |
-
-#### Request
-
-This API does not require a request body.
-
-| Name                | Type    | Format       | Required | Description                                                                                                                                                                               |
-|-------------------|-------|----------|----|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| page              | Query | Number   | O  | Page to retrieve<br/>- Minimum value: `1`                                                                                                                                                       |
-| size              | Query | Number   | O  | Page size to retrieve<br/>- Minimum value: `1`<br/>- Maximum value: `100`                                                                                                                                   |
-| from              | Query | Datetime | O  | Start date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                |
-| to                | Query | Datetime | O  | End date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                |
-| eventCategoryType | Query | Enum     | O  | Event category types to query<br/>ALL: All<br/>- `BACKUP`: Backup<br/>- `DB_INSTANCE`: DB instance<br/>- `DB_SECURITY_GROUP`: DB security group<br/>- `JOB: Job`<br/>- `TENANT`: Tenant<br/>- `MONITORING`: Monitoring |
-| sourceId          | Query | String   | X  | Event target resource identifier                                                                                                                                                             |
-| keyword           | Query | String   | X  | String keyword in event message                                                                                                                                                             |
-
-#### Response
-
-| Name                       | Type   | Format       | Description                                                 |
-|--------------------------|------|----------|----------------------------------------------------|
-| totalCounts              | Body | Number   | Total number of events                                        |
-| events                   | Body | Array    | Events                                             |
-| events.eventCategoryType | Body | Enum     | Event category type                                        |
-| events.eventCode         | Body | Enum     | Occurred event type<br/>- See [Events](event/) for a detailed description. |
-| events.sourceId          | Body | String   | Event source identifier                                        |
-| events.sourceName        | Body | String   | Name to identify event sources                                |
-| events.messages          | Body | Array    | Event messages                                         |
-| events.messages.langCode | Body | String   | Language code                                              |
-| events.messages.message  | Body | String   | Event Message                                            |
-| events.eventYmdt         | Body | DateTime | Event occurred date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)              |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 28,
-    "events": [
-        {
-            "eventCategoryType": "INSTANCE",
-            "eventCode": "INSTC_02_01",
-            "sourceId": "76f00947-356e-4a20-8922-428368cc45ed",
-            "sourceName": "db-instance",
-            "messages": [
-                {
-                    "langCode": "EN",
-                    "message": "DB instance started"
-                },
-                {
-                    "langCode": "JA",
-                    "message": "DBインスタンスの起動"
-                },
-                {
-                    "langCode": "KO",
-                    "message": "DB 인스턴스 시작"
-                },
-                {
-                    "langCode": "ZH",
-                    "message": "DB instance started"
-                }
-            ],
-            "eventYmdt": "2023-03-20T16:31:59+09:00"
-        }
-    ]
-}
-```
-</details>
-
-
-### List Subscribable Event Codes
+### List subscribable event codes
 
 ```http
 GET /v1.0/event-codes
@@ -5219,9 +5640,9 @@ GET /v1.0/event-codes
 
 #### Required permissions
 
-| Permission Name                         | Description        |
-|-----------------------------|-----------|
-| RDSforPostgreSQL:Event.List | View the list of events |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:Event.List | List subscribable event codes |
 
 #### Request
 
@@ -5229,13 +5650,14 @@ This API does not require a request body.
 
 #### Response
 
-| Name                           | Type   | Format    | Description          |
-|------------------------------|------|-------|-------------|
-| eventCodes                   | Body | Array | Event Codes   |
-| eventCodes.eventCode         | Body | Enum  | Event Code      |
-| eventCodes.eventCategoryType | Body | Enum  | Event category type |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| eventCodes | Body | Array | Event codes |
+| eventCodes.eventCode | Body | Enum | Event code |
+| eventCodes.eventCategoryType | Body | Enum | Event category type<br/>- ALL: `All`<br/>- DB_INSTANCE: `Events generated from DB instance`<br/>- DB_SECURITY_GROUP: `Events generated from DB security group`<br/>- MONITORING: `Events generated from monitoring`<br/>- JOB: `Events generated from JOB`<br/>- BACKUP: `Events generated from backup`<br/>- TENANT: `Events generated from tenant` |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -5246,10 +5668,79 @@ This API does not require a request body.
     },
     "eventCodes": [
         {
-            "eventCode": "DB_INSTANCE_02_01",
-            "eventCategoryType": "DB_INSTANCE"
+            "eventCode": "ENUM_VALUE",
+            "eventCategoryType": "ALL"
         }
     ]
 }
 ```
+
+</p>
 </details>
+
+---
+
+### View the list of events
+
+```http
+GET /v1.0/events
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:Event.List | View the list of events |
+
+#### Request
+
+This API does not require a request body.
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | Total number of events |
+| events | Body | Array | Events |
+| events.eventCategoryType | Body | Enum | Event category type<br/>- ALL: `All`<br/>- DB_INSTANCE: `Events generated from DB instance`<br/>- DB_SECURITY_GROUP: `Events generated from DB security group`<br/>- MONITORING: `Events generated from monitoring`<br/>- JOB: `Events generated from JOB`<br/>- BACKUP: `Events generated from backup`<br/>- TENANT: `Events generated from tenant` |
+| events.eventCode | Body | Enum | Occurred event type |
+| events.sourceId | Body | UUID | Event source identifier |
+| events.sourceName | Body | String | Name to identify event sources |
+| events.messages | Body | Array | Event messages |
+| events.messages.langCode | Body | Enum | Language code<br/>- KO<br/>- EN<br/>- JA<br/>- ZH |
+| events.messages.message | Body | String | Event message |
+| events.eventYmdt | Body | DateTime | Event occurred date and time |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "totalCounts": 1,
+    "events": [
+        {
+            "eventCategoryType": "ALL",
+            "eventCode": "ENUM_VALUE",
+            "sourceId": "550e8400-e29b-41d4-a716-446655440000",
+            "sourceName": "sourceName-example",
+            "messages": [
+                {
+                    "langCode": "KO",
+                    "message": "message-example"
+                }
+            ],
+            "eventYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---

--- a/en/api-guide-v1.0.md
+++ b/en/api-guide-v1.0.md
@@ -1,70 +1,85 @@
-## Database > RDS for PostgreSQL > API Guide > API v1.0 Guide
+## RDS for PostgreSQL API Guide
+
+**Database > RDS for PostgreSQL > API v1.0 Guide**
 
 ## Common Information on RDS for PostgreSQL API
 
 ### API Endpoint
 
-| Region                | Endpoint                                         |
-|-----------------------|--------------------------------------------------|
+| Region | Endpoint |
+|------|----------|
 | Korea (Pangyo) region | https://kr1-rds-postgres.api.nhncloudservice.com |
+| Korea (Pyeongchon) region | https://kr2-rds-postgres.api.nhncloudservice.com |
+
 
 ### Authentication and Authorization
 
 RDS for PostgreSQL uses User Access Key tokens for authentication and authorization when making API calls. The User Access Key token is a temporary, Bearer-type access token issued from a User Access Key. For more information on issuing and using User Access Key tokens, please refer to the [User Access Key Token](/nhncloud/en/public-api/user-access-key-token).
 The issued token must be included in the request header along with the Appkey.
 
-| Name                | Type   | Format | Required | Description                                                         |
-|---------------------|--------|--------|----------|---------------------------------------------------------------------|
-| X-TC-APP-KEY        | Header | String | O        | Appkey or project integration appkey for RDS for PostgreSQL service |
-| X-NHN-AUTHORIZATION | Header | String | O        | Bearer type token issued with the Public API                        |
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| X-TC-APP-KEY | Header | String | Y | Appkey or project integration appkey for RDS for PostgreSQL service |
+| X-NHN-AUTHORIZATION | Header | String | Y | Bearer type token issued with the Public API |
 
 Project permissions also limit the APIs that can be called. The `RDS for` `PostgreSQL` `ADMIN` and `RDS for PostgreSQL VIEWER` roles are granted default permissions, as shown below, and you can grant only the permissions you need from the Manage Role Groups menu within the project.
 
 * The `RDS for PostgreSQL ADMIN` role is granted all the permissions required to run the API.
 * The `RDS for PostgreSQL VIEWER` role is granted with the permission to view information only.
-    * Cannot use any features aimed at DB instances or create, modify, or delete any DB instance.
-    * However, you can use features related to notification groups and user groups.
+* Cannot use any features aimed at DB instances or create, modify, or delete any DB instance.
+* However, you can use features related to notification groups and user groups.
 
 If an API request fails to authenticate or is not authorized, the following error occurs.
 
-| resultCode | resultMessage | Description            |
-|------------|---------------|------------------------|
-| 80401      | Unauthorized  | Failed to authenticate |
-| 80403      | Forbidden     | Unauthorized.          |
+| resultCode | resultMessage | Description |
+|------------|---------------|-----|
+| 80401 | Unauthorized | Failed to authenticate |
+| 80403 | Forbidden | Unauthorized. |
 
-### Response Common Information
+### Common Response Information
 
 The API responds with "200 OK" to all API requests. For more information on the response results, see Response Body Header.
 
-#### Response Body
+<details>
+  <summary><strong>Successful Response</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+}
 }
 ```
 
-#### Field
+</details>
 
-| Name          | Data type | Description                              |
-|---------------|-----------|------------------------------------------|
-| resultCode    | Number    | Result code (Success: 0, Other: Failure) |
-| resultMessage | String    | Result message                           |
-| successful    | Boolean   | Successful or not                        |
+<details>
+  <summary><strong>Failure Response</strong></summary>
 
+```json
+{
+"header": {
+        "resultCode": -1,
+        "resultMessage": "FAIL",
+        "isSuccessful": false
+}
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| resultCode | Number | Result code (Success: 0, Other: Failure) |
+| resultMessage | String | Result message |
+| isSuccessful | Boolean | Successful or not |
 ## DB Version
 
 ### View DB Version List
 
-```http
-GET /v1.0/db-versions
-```
-
-#### Required Permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -72,41 +87,46 @@ GET /v1.0/db-versions
 
 #### Request
 
+```http
+GET /v1.0/db-versions
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| dbVersions | Body | Array | DB version information |
-| dbVersions.dbVersionCode | Body | Enum | DB version code<br/>- MYSQL_V5633<br/>- MYSQL_V5715<br/>- MYSQL_V5719<br/>- MYSQL_V5726<br/>- MYSQL_V5731<br/>- MYSQL_V5733<br/>- MYSQL_V5737<br/>- MYSQL_V8018<br/>- MYSQL_V8023<br/>- MYSQL_V8028<br/>- MYSQL_V8032<br/>- MYSQL_V8033<br/>- MYSQL_V8034<br/>- MYSQL_V8035<br/>- MYSQL_V8036<br/>- MYSQL_V8040<br/>- MYSQL_V8041<br/>- MYSQL_V8042<br/>- MYSQL_V8043<br/>- MYSQL_V8044<br/>- MYSQL_V8045<br/>- MYSQL_V8405<br/>- MYSQL_V8406<br/>- MYSQL_V8407<br/>- MYSQL_V8408<br/>- MYSQL_V8409<br/>- MARIADB_V10330<br/>- MARIADB_V10611<br/>- MARIADB_V10612<br/>- MARIADB_V10616<br/>- MARIADB_V10622<br/>- MARIADB_V10625<br/>- MARIADB_V101107<br/>- MARIADB_V101108<br/>- MARIADB_V101113<br/>- MARIADB_V101116<br/>- MARIADB_V11407<br/>- MARIADB_V11410<br/>- MARIADB_V11806<br/>- POSTGRESQL_V14_6<br/>- POSTGRESQL_V14_15<br/>- POSTGRESQL_V14_17<br/>- POSTGRESQL_V14_19<br/>- POSTGRESQL_V17_2<br/>- POSTGRESQL_V17_4<br/>- POSTGRESQL_V17_6 |
-| dbVersions.dbMajorVersionCode | Body | Enum | DB major version code<br/>- MYSQL_V56<br/>- MYSQL_V57<br/>- MYSQL_V80<br/>- MYSQL_V84<br/>- MARIADB_V103<br/>- MARIADB_V106<br/>- MARIADB_V1011<br/>- MARIADB_V114<br/>- MARIADB_V118<br/>- POSTGRES_V14<br/>- POSTGRES_V17 |
-| dbVersions.name | Body | String | DB version name |
-| dbVersions.canCreate | Body | Boolean | Whether new creation is available |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbVersions": [
-        {
-            "dbVersionCode": "MYSQL_V5633",
-            "dbMajorVersionCode": "MYSQL_V56",
-            "name": "PostgreSQL V14.6",
-            "canCreate": false
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbVersions": [
+{
+            "dbVersionCode": "dbVersionCode-example",
+            "dbMajorVersionCode": "dbMajorVersionCode-example",
+"name": "PostgreSQL V14.6",
+"canCreate": false
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| dbVersions | Array | DB version information |
+| dbVersions.dbVersionCode | String | DB version code |
+| dbVersions.dbMajorVersionCode | String | DB major version code |
+| dbVersions.name | String | DB version name |
+| dbVersions.canCreate | Boolean | Whether creation is available |
 
 ---
 
@@ -114,11 +134,7 @@ This API does not require a request body.
 
 ### List DB Instance Specifications
 
-```http
-GET /v1.0/db-flavors
-```
-
-#### Required Permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -126,41 +142,46 @@ GET /v1.0/db-flavors
 
 #### Request
 
+```http
+GET /v1.0/db-flavors
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| dbFlavors | Body | Array | List of DB instance specifications |
-| dbFlavors.dbFlavorId | Body | UUID | Identifier of DB instance specifications |
-| dbFlavors.dbFlavorName | Body | String | Name of DB instance specifications |
-| dbFlavors.ram | Body | Number | Memory size (MB) |
-| dbFlavors.vcpus | Body | Number | CPU cores |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbFlavors": [
-        {
-            "dbFlavorId": "289e34e9-cd8a-4baf-82e3-a3d013c5186b",
-            "dbFlavorName": "r2.c2m4",
-            "ram": 4096,
-            "vcpus": 2
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbFlavors": [
+{
+"dbFlavorId": "289e34e9-cd8a-4baf-82e3-a3d013c5186b",
+"dbFlavorName": "r2.c2m4",
+"ram": 4096,
+"vcpus": 2
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| dbFlavors | Array | List of DB instance specifications |
+| dbFlavors.dbFlavorId | UUID | Identifier of DB instance specifications |
+| dbFlavors.dbFlavorName | String | Name of DB instance specifications |
+| dbFlavors.ram | Number | Memory size (MB) |
+| dbFlavors.vcpus | Number | CPU cores |
 
 ---
 
@@ -168,11 +189,7 @@ This API does not require a request body.
 
 ### List Project Members
 
-```http
-GET /v1.0/project/members
-```
-
-#### Required Permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -180,51 +197,52 @@ GET /v1.0/project/members
 
 #### Request
 
+```http
+GET /v1.0/project/members
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| projectMembers | Body | Array | Project member information |
-| projectMembers.memberId | Body | UUID | Project member identifier |
-| projectMembers.memberName | Body | String | Project member name |
-| projectMembers.emailAddress | Body | String | Project member email address |
-| projectMembers.phoneNumber | Body | String | Project member phone number |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "projectMembers": [
-        {
-            "memberId": "550e8400-e29b-41d4-a716-446655440000",
-            "memberName": "memberName-example",
-            "emailAddress": "user@example.com",
-            "phoneNumber": "010-1234-5678"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"projectMembers": [
+{
+"memberId": "550e8400-e29b-41d4-a716-446655440000",
+"memberName": "memberName-example",
+"emailAddress": "user@example.com",
+"phoneNumber": "010-1234-5678"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| projectMembers | Array | Project member information |
+| projectMembers.memberId | UUID | Project member identifier |
+| projectMembers.memberName | String | Project member name |
+| projectMembers.emailAddress | String | Project member email address |
+| projectMembers.phoneNumber | String | Project member phone number |
 
 ---
 
 ### List Regions
 
-```http
-GET /v1.0/project/regions
-```
-
-#### Required Permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -232,37 +250,42 @@ GET /v1.0/project/regions
 
 #### Request
 
+```http
+GET /v1.0/project/regions
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| regions | Body | Array | Region information |
-| regions.regionCode | Body | Enum | Region code<br/>- KR1: `Korea (Pangyo)`<br/>- KR2: `Korea (Pyeongchon)` |
-| regions.isEnabled | Body | Boolean | Whether the region is enabled |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "regions": [
-        {
-            "regionCode": "KR1",
-            "isEnabled": false
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"regions": [
+{
+"regionCode": "KR1",
+"isEnabled": false
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| regions | Array | Region information |
+| regions.regionCode | Enum | Region code<br/>- KR1: `Korea (Pangyo)`<br/>- KR2: `Korea (Pyeongchon)` |
+| regions.isEnabled | Boolean | Whether the region is enabled |
 
 ---
 
@@ -270,11 +293,7 @@ This API does not require a request body.
 
 ### List Subnets
 
-```http
-GET /v1.0/network/subnets
-```
-
-#### Required Permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -282,43 +301,48 @@ GET /v1.0/network/subnets
 
 #### Request
 
+```http
+GET /v1.0/network/subnets
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| subnets | Body | Array | Subnet information |
-| subnets.subnetId | Body | UUID | Subnet identifier |
-| subnets.subnetName | Body | String | Name to identify subnets |
-| subnets.subnetCidr | Body | String | Subnet CIDR |
-| subnets.usingGateway | Body | Boolean | Whether to use gateway |
-| subnets.availableIpCount | Body | Number | Number of available IPs |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "subnets": [
-        {
-            "subnetId": "550e8400-e29b-41d4-a716-446655440000",
-            "subnetName": "subnetName-example",
-            "subnetCidr": "192.168.0.0/24",
-            "usingGateway": false,
-            "availableIpCount": 1
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"subnets": [
+{
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"subnetName": "subnetName-example",
+"subnetCidr": "192.168.0.0/24",
+"usingGateway": false,
+"availableIpCount": 1
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| subnets | Array | Subnet object |
+| subnets.subnetId | UUID | Subnet identifier |
+| subnets.subnetName | String | Name to identify subnets |
+| subnets.subnetCidr | String | CIDR of subnet |
+| subnets.usingGateway | Boolean | Whether to use gateway |
+| subnets.availableIpCount | Number | Number of available IPs |
 
 ---
 
@@ -326,11 +350,7 @@ This API does not require a request body.
 
 ### View the List of Storage Types
 
-```http
-GET /v1.0/storage-types
-```
-
-#### Required Permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -338,33 +358,38 @@ GET /v1.0/storage-types
 
 #### Request
 
+```http
+GET /v1.0/storage-types
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| storageTypes | Body | Array | List of storage types |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "storageTypes": [
-        "General SSD",
-        "General HDD"
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"storageTypes": [
+"General SSD",
+"General HDD"
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| storageTypes | Array | List of storage types |
 
 ---
 
@@ -389,11 +414,7 @@ This API does not require a request body.
 
 ### View Task Details
 
-```http
-GET /v1.0/jobs/{jobId}
-```
-
-#### Required Permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -401,60 +422,64 @@ GET /v1.0/jobs/{jobId}
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v1.0/jobs/{jobId}
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| jobId | URL | UUID | O |  |
+| jobId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Task identifier |
-| jobStatus | Body | Enum | Current task status<br/>- DELETED<br/>- CANNOT_PROGRESS<br/>- FAILED<br/>- ERROR<br/>- CANCELED<br/>- INTERRUPTED<br/>- COMPLETED<br/>- COMPLETED_WITH_ERROR<br/>- RUNNING<br/>- PREPARING<br/>- READY<br/>- CREATED<br/>- FAIL_TO_READY<br/>- REGISTERED<br/>- FAIL_TO_REGISTER<br/>- WAIT_TO_REGISTER |
-| resourceRelations | Body | Array | Related resource list |
-| resourceRelations.resourceType | Body | String | Related resource type |
-| resourceRelations.resourceId | Body | String | Related resource identifier |
-| createdYmdt | Body | DateTime | Created date and time |
-| updatedYmdt | Body | DateTime | Modified date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000",
-    "jobStatus": "DELETED",
-    "resourceRelations": [
-        {
-            "resourceType": "resourceType-example",
-            "resourceId": "resourceId-example"
-        }
-    ],
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000",
+"jobStatus": "DELETED",
+"resourceRelations": [
+{
+"resourceType": "resourceType-example",
+"resourceId": "resourceId-example"
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
 
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Task identifier |
+| jobStatus | Enum | Current task status<br/>- DELETED<br/>- CANNOT_PROGRESS<br/>- FAILED<br/>- ERROR<br/>- CANCELED<br/>- INTERRUPTED<br/>- COMPLETED<br/>- COMPLETED_WITH_ERROR<br/>- RUNNING<br/>- PREPARING<br/>- READY<br/>- CREATED<br/>- FAIL_TO_READY<br/>- REGISTERED<br/>- FAIL_TO_REGISTER<br/>- WAIT_TO_REGISTER |
+| resourceRelations | Array | Related resource list |
+| resourceRelations.resourceType | String | Related resource type |
+| resourceRelations.resourceId | String | Related resource identifier |
+| createdYmdt | DateTime | Created date and time |
+| updatedYmdt | DateTime | Modified date and time |
+
 ---
+
 ## DB Instance Group
 
 ### List DB Instance Groups
 
-```http
-GET /v1.0/db-instance-groups
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -462,53 +487,54 @@ GET /v1.0/db-instance-groups
 
 #### Request
 
+```http
+GET /v1.0/db-instance-groups
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| dbInstanceGroups | Body | Array | DB instance group information |
-| dbInstanceGroups.dbInstanceGroupId | Body | UUID | DB instance group identifier |
-| dbInstanceGroups.dbInstanceGroupStatus | Body | Enum | Current status of the DB instance group<br/>- CREATED: `Created`<br/>- DELETED: `Deleted` |
-| dbInstanceGroups.replicationType | Body | Enum | DB instance group replication type<br/>- STANDALONE: `High availability not used`<br/>- HIGH_AVAILABILITY: `High availability used` |
-| dbInstanceGroups.createdYmdt | Body | DateTime | Created date and time |
-| dbInstanceGroups.updatedYmdt | Body | DateTime | Modified date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceGroups": [
-        {
-            "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbInstanceGroupStatus": "CREATED",
-            "replicationType": "STANDALONE",
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbInstanceGroups": [
+{
+"dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceGroupStatus": "CREATED",
+"replicationType": "STANDALONE",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| dbInstanceGroups | Array | DB instance group information |
+| dbInstanceGroups.dbInstanceGroupId | UUID | DB instance group identifier |
+| dbInstanceGroups.dbInstanceGroupStatus | Enum | Current status of the DB instance group<br/>- CREATED: `Created`<br/>- DELETED: `Deleted` |
+| dbInstanceGroups.replicationType | Enum | DB instance group replication type<br/>- STANDALONE: `High availability not used`<br/>- HIGH_AVAILABILITY: `High availability used` |
+| dbInstanceGroups.createdYmdt | DateTime | Created date and time |
+| dbInstanceGroups.updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### List DB Instance Group Details
 
-```http
-GET /v1.0/db-instance-groups/{dbInstanceGroupId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -516,63 +542,66 @@ GET /v1.0/db-instance-groups/{dbInstanceGroupId}
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v1.0/db-instance-groups/{dbInstanceGroupId}
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceGroupId | URL | UUID | O |  |
+| dbInstanceGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| dbInstanceGroupId | Body | UUID | DB instance group identifier |
-| dbInstanceGroupStatus | Body | Enum | Current status of the DB instance group<br/>- CREATED: `Created`<br/>- DELETED: `Deleted` |
-| replicationType | Body | Enum | DB instance group replication type<br/>- STANDALONE: `High availability not used`<br/>- HIGH_AVAILABILITY: `High availability used` |
-| dbInstances | Body | Array | List of DB instances belonging to the DB instance group |
-| dbInstances.dbInstanceId | Body | UUID | DB instance identifier |
-| dbInstances.dbInstanceType | Body | Enum | DB instance role type<br/>- MASTER: `Master`<br/>- FAILED_MASTER: `Failed over master`<br/>- CANDIDATE_MASTER: `Candidate master`<br/>- READ_ONLY_SLAVE: `Read replica` |
-| dbInstances.dbInstanceStatus | Body | Enum | Current status of the DB instance<br/>- BEFORE_CREATE: `Before creation (gray)`<br/>- AVAILABLE: `Available (green)`<br/>- STORAGE_FULL: `Insufficient storage (red)`<br/>- FAIL_TO_CREATE: `Failed to create (red)`<br/>- FAIL_TO_CONNECT: `Failed to connect (red)`<br/>- REPLICATION_STOP: `Replication stopped (red)`<br/>- REPLICATION_DELAY: `Replication delayed (yellow)`<br/>- FAILOVER: `Failover complete (red)`<br/>- SHUTDOWN: `Stopped (gray)`<br/>- DELETED: `Deleted (gray)` |
-| createdYmdt | Body | DateTime | Created date and time |
-| updatedYmdt | Body | DateTime | Modified date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbInstanceGroupStatus": "CREATED",
-    "replicationType": "STANDALONE",
-    "dbInstances": [
-        {
-            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbInstanceType": "MASTER",
-            "dbInstanceStatus": "BEFORE_CREATE"
-        }
-    ],
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceGroupStatus": "CREATED",
+"replicationType": "STANDALONE",
+"dbInstances": [
+{
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceType": "MASTER",
+"dbInstanceStatus": "BEFORE_CREATE"
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| dbInstanceGroupId | UUID | DB instance group identifier |
+| dbInstanceGroupStatus | Enum | Current status of the DB instance group<br/>- CREATED: `Created`<br/>- DELETED: `Deleted` |
+| replicationType | Enum | DB instance group replication type<br/>- STANDALONE: `High availability not used`<br/>- HIGH_AVAILABILITY: `High availability used` |
+| dbInstances | Array | List of DB instances belonging to the DB instance group |
+| dbInstances.dbInstanceId | UUID | DB instance identifier |
+| dbInstances.dbInstanceType | Enum | DB instance role type<br/>- MASTER: `Master`<br/>- FAILED_MASTER: `Failed master`<br/>- CANDIDATE_MASTER: `Candidate master`<br/>- READ_ONLY_SLAVE: `Read replica` |
+| dbInstances.dbInstanceStatus | Enum | DB instance current status<br/>- BEFORE_CREATE: `Before creation (gray)`<br/>- AVAILABLE: `Available (green)`<br/>- STORAGE_FULL: `Storage full (red)`<br/>- FAIL_TO_CREATE: `Failed to create (red)`<br/>- FAIL_TO_CONNECT: `Failed to connect (red)`<br/>- REPLICATION_STOP: `Replication stopped (red)`<br/>- REPLICATION_DELAY: `Replication delayed (yellow)`<br/>- FAILOVER: `Failover completed (red)`<br/>- SHUTDOWN: `Stopped (gray)`<br/>- DELETED: `Deleted (gray)` |
+| createdYmdt | DateTime | Created date and time |
+| updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### View Extension List
 
-```http
-GET /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -580,72 +609,75 @@ GET /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceGroupId | URL | UUID | O | DB instance group ID |
+| dbInstanceGroupId | URL | UUID | Y | DB instance group ID |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| extensions | Body | Array | Extension information |
-| extensions.extensionId | Body | UUID | Extension identifier |
-| extensions.extensionName | Body | String | Extension name |
-| extensions.extensionStatus | Body | Enum | Extension status<br/>- AVAILABLE: `Available`<br/>- NEED_TO_APPLY: `Need to apply`<br/>- APPLYING: `Applying` |
-| extensions.databases | Body | Array | Database information |
-| extensions.databases.dbInstanceGroupExtensionId | Body | UUID | Identifier of an extension within a DB instance group |
-| extensions.databases.databaseId | Body | UUID | Database identifier |
-| extensions.databases.databaseName | Body | String | Database name |
-| extensions.databases.dbInstanceGroupExtensionStatus | Body | Enum | Extension installation status within the database<br/>- CREATED: `Created`<br/>- INSTALLED: `Installed`<br/>- INSTALLING: `Installing`<br/>- INSTALL_ERROR: `Installation error`<br/>- DELETED: `Deleted`<br/>- DELETING: `Deleting`<br/>- DELETE_ERROR: `Deletion error` |
-| extensions.databases.reservedAction | Body | Enum | Scheduled task<br/>- NONE: `None`<br/>- INSTALL: `Scheduled installation (need to apply)`<br/>- INSTALL_WITH_CASCADE: `Scheduled forced installation (need to apply)`<br/>- DELETE: `Scheduled deletion (need to apply)`<br/>- DELETE_WITH_CASCADE: `Scheduled forced deletion (need to apply)` |
-| extensions.databases.errorReason | Body | String | Reason for error |
-| isNeedToApply | Body | Boolean | Whether changes need to be applied |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "extensions": [
-        {
-            "extensionId": "550e8400-e29b-41d4-a716-446655440000",
-            "extensionName": "extensionName-example",
-            "extensionStatus": "AVAILABLE",
-            "databases": [
-                {
-                    "dbInstanceGroupExtensionId": "550e8400-e29b-41d4-a716-446655440000",
-                    "databaseId": "550e8400-e29b-41d4-a716-446655440000",
-                    "databaseName": "databaseName-example",
-                    "dbInstanceGroupExtensionStatus": "CREATED",
-                    "reservedAction": "NONE",
-                    "errorReason": "errorReason-example"
-                }
-            ]
-        }
-    ],
-    "isNeedToApply": false
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"extensions": [
+{
+"extensionId": "550e8400-e29b-41d4-a716-446655440000",
+"extensionName": "extensionName-example",
+"extensionStatus": "AVAILABLE",
+"databases": [
+{
+"dbInstanceGroupExtensionId": "550e8400-e29b-41d4-a716-446655440000",
+"databaseId": "550e8400-e29b-41d4-a716-446655440000",
+"databaseName": "databaseName-example",
+"dbInstanceGroupExtensionStatus": "CREATED",
+"reservedAction": "NONE",
+"errorReason": "errorReason-example"
+}
+]
+}
+],
+"isNeedToApply": false
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| extensions | Array | Extension information |
+| extensions.extensionId | UUID | Extension identifier |
+| extensions.extensionName | String | Extension name |
+| extensions.extensionStatus | Enum | Extension status<br/>- AVAILABLE: `Available`<br/>- NEED_TO_APPLY: `Need to apply`<br/>- APPLYING: `Applying` |
+| extensions.databases | Array | Database information |
+| extensions.databases.dbInstanceGroupExtensionId | UUID | Identifier of the extension within the DB instance group |
+| extensions.databases.databaseId | UUID | Database identifier |
+| extensions.databases.databaseName | String | Database name |
+| extensions.databases.dbInstanceGroupExtensionStatus | Enum | Extension installation status within the database<br/>- CREATED: `Created`<br/>- INSTALLED: `Installed`<br/>- INSTALLING: `Installing`<br/>- INSTALL_ERROR: `Installation error`<br/>- DELETED: `Deleted`<br/>- DELETING: `Deleting`<br/>- DELETE_ERROR: `Deletion error` |
+| extensions.databases.reservedAction | Enum | Scheduled task<br/>- NONE: `None`<br/>- INSTALL: `Scheduled installation (need to apply)`<br/>- INSTALL_WITH_CASCADE: `Scheduled forced installation (need to apply)`<br/>- DELETE: `Scheduled deletion (need to apply)`<br/>- DELETE_WITH_CASCADE: `Scheduled forced deletion (need to apply)` |
+| extensions.databases.errorReason | String | Reason for error |
+| isNeedToApply | Boolean | Whether changes need to be applied |
 
 ---
 
 ### Apply Extension Changes
 
-```http
-POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/apply
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -653,44 +685,47 @@ POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/apply
 
 #### Request
 
-This API does not require a request body.
+```http
+POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/apply
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceGroupId | URL | UUID | O | DB instance group ID |
+| dbInstanceGroupId | URL | UUID | Y | DB instance group ID |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of the requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Synchronize Extensions
 
-```http
-POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/sync
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -698,44 +733,47 @@ POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/sync
 
 #### Request
 
-This API does not require a request body.
+```http
+POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/sync
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceGroupId | URL | UUID | O | DB instance group ID |
+| dbInstanceGroupId | URL | UUID | Y | DB instance group ID |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of the requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Delete Extension (Cancel)
 
-```http
-DELETE /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{dbInstanceGroupExtensionId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -743,13 +781,21 @@ DELETE /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{dbInstanceGroupE
 
 #### Request
 
-This API does not require a request body.
+```http
+DELETE /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{dbInstanceGroupExtensionId}
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceGroupId | URL | UUID | O | DB instance group ID |
-| dbInstanceGroupExtensionId | URL | UUID | O | Identifier of the extension within the DB instance group |
-| withCascade | Query | Boolean | O | Whether to force deletion |
+| dbInstanceGroupId | URL | UUID | Y | DB instance group ID |
+| dbInstanceGroupExtensionId | URL | UUID | Y | Identifier of the extension within the DB instance group |
+| withCascade | Query | Boolean | Y | Whether to force deletion |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
@@ -759,11 +805,7 @@ This API does not return a response body.
 
 ### Install Extension
 
-```http
-POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{extensionId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -771,87 +813,94 @@ POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{extensionId}
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceGroupId | URL | UUID | O | DB instance group ID |
-| extensionId | URL | UUID | O | Extension identifier |
-| databaseId | Body | UUID | O | Database identifier |
-| schemaName | Body | String | O | Schema name |
-| withCascade | Body | Boolean | X | Whether to automatically install dependencies<br/>- Default: `false` |
+```http
+POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{extensionId}
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | Y | DB instance group ID |
+| extensionId | URL | UUID | Y | Extension identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "databaseId": "550e8400-e29b-41d4-a716-446655440000",
-    "schemaName": "schemaName-example",
-    "withCascade": false
+"databaseId": "550e8400-e29b-41d4-a716-446655440000",
+"schemaName": "schemaName-example",
+"withCascade": false
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| databaseId | UUID | Y | Database identifier |
+| schemaName | String | Y | Schema name |
+| withCascade | Boolean | N | Whether to automatically install dependencies<br/>- Default: `false` |
 
 #### Response
 
 This API does not return a response body.
 
 ---
+
 ## DB Instance
 
 ### DB Instance Status
 
-| Status                  | Description                           |
-|---------------------|-------------------------------|
-| `AVAILABLE`         | DB instance is available           |
-| `BEFORE_CREATE`     | Before creating a DB instance            |
-| `STORAGE_FULL`      | Insufficient DB instance storage          |
-| `FAIL_TO_CREATE`    | Failed to create DB instance           |
-| `FAIL_TO_CONNECT`   | Failed to connect DB instance           |
-| `REPLICATION_STOP`  | Replication of DB instance is stopped          |
-| `FAILOVER`          | When failover of a highly available DB instance is complete       |
-| `SHUTDOWN`          | DB instance is stopped               |
-| `DELETED`           | DB instance is deleted               |
+| Status | Description |
+|---------------------|------------------------------|
+| `AVAILABLE` | DB instance is available |
+| `BEFORE_CREATE` | Before creating a DB instance |
+| `STORAGE_FULL` | Insufficient DB instance storage |
+| `FAIL_TO_CREATE` | Failed to create DB instance |
+| `FAIL_TO_CONNECT` | Failed to connect DB instance |
+| `REPLICATION_STOP` | Replication of DB instance is stopped |
+| `FAILOVER` | When failover of a highly available DB instance is complete |
+| `SHUTDOWN` | DB instance is stopped |
+| `DELETED` | DB instance is deleted |
 
 ### DB Instance Progress Status
 
-| Status                       | Description            |
+| Status | Description |
 |----------------------------|--------------|
 | `APPLYING_PARAMETER_GROUP` | Parameter group is being applied |
-| `BACKING_UP`               | Backing up          |
-| `CANCELING`                | Canceling          |
-| `CREATING`                 | Creating          |
-| `CREATING_SCHEMA`          | Creating a schema  |
-| `CREATING_USER`            | Creating user      |
-| `DELETING`                 | Deleting          |
-| `DELETING_SCHEMA`          | Deleting a schema  |
-| `DELETING_USER`            | Deleting user      |
-| `EXPORTING_BACKUP`         | Exporting a backup   |
-| `FAILING_OVER`             | Under failover      |
-| `MIGRATING`                | Under migration       |
-| `MODIFYING`                | Under modification           |
-| `PREPARING`                | In preparation           |
-| `PROMOTING`                | Promoting           |
-| `REBUILDING`               | Rebuilding          |
-| `REPAIRING`                | Recovering           |
-| `REPLICATING`              | Replicating           |
-| `RESTARTING`               | Restarting          |
-| `RESTARTING_FORCIBLY`      | Force restarting       |
-| `RESTORING`                | Restoring           |
-| `STARTING`                 | Starting           |
-| `STOPPING`                 | Stopping           |
-| `SYNCING_SCHEMA`           | Synchronizing the schema   |
-| `SYNCING_USER`             | Synchronizing user     |
-| `UPDATING_USER`            | Modifying user      |
+| `BACKING_UP` | Backing up |
+| `CANCELING` | Canceling |
+| `CREATING` | Creating |
+| `CREATING_SCHEMA` | Creating a schema |
+| `CREATING_USER` | Creating user |
+| `DELETING` | Deleting |
+| `DELETING_SCHEMA` | Deleting a schema |
+| `DELETING_USER` | Deleting user |
+| `EXPORTING_BACKUP` | Exporting a backup |
+| `FAILING_OVER` | Under failover |
+| `MIGRATING` | Under migration |
+| `MODIFYING` | Under modification |
+| `PREPARING` | In preparation |
+| `PROMOTING` | Promoting |
+| `REBUILDING` | Rebuilding |
+| `REPAIRING` | Recovering |
+| `REPLICATING` | Replicating |
+| `RESTARTING` | Restarting |
+| `RESTARTING_FORCIBLY` | Force restarting |
+| `RESTORING` | Restoring |
+| `STARTING` | Starting |
+| `STOPPING` | Stopping |
+| `SYNCING_SCHEMA` | Synchronizing the schema |
+| `SYNCING_USER` | Synchronizing user |
+| `UPDATING_USER` | Modifying user |
 
 ### List DB Instances
 
-```http
-GET /v1.0/db-instances
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -859,65 +908,66 @@ GET /v1.0/db-instances
 
 #### Request
 
+```http
+GET /v1.0/db-instances
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| dbInstances | Body | Array | DB instances |
-| dbInstances.dbInstanceId | Body | UUID | DB instance identifier |
-| dbInstances.dbInstanceGroupId | Body | UUID | DB instance group identifier |
-| dbInstances.dbInstanceName | Body | String | Name to identify DB instances |
-| dbInstances.description | Body | String | Additional information on DB instances |
-| dbInstances.dbVersion | Body | Enum | DB version information |
-| dbInstances.dbPort | Body | Number | DB port |
-| dbInstances.dbInstanceType | Body | Enum | DB instance role type<br/>- MASTER: `Master`<br/>- FAILED_MASTER: `Failed over master`<br/>- CANDIDATE_MASTER: `Candidate master`<br/>- READ_ONLY_SLAVE: `Read replica` |
-| dbInstances.dbInstanceStatus | Body | Enum | DB instance current status<br/>- BEFORE_CREATE: `Before creating (gray)`<br/>- AVAILABLE: `Available (green)`<br/>- STORAGE_FULL: `Insufficient storage (red)`<br/>- FAIL_TO_CREATE: `Failed to create (red)`<br/>- FAIL_TO_CONNECT: `Failed to connect (red)`<br/>- REPLICATION_STOP: `Replication stopped (red)`<br/>- REPLICATION_DELAY: `Replication delayed (yellow)`<br/>- FAILOVER: `Failover complete (red)`<br/>- SHUTDOWN: `Stopped (gray)`<br/>- DELETED: `Deleted (gray)` |
-| dbInstances.progressStatus | Body | String | DB instance current progress status |
-| dbInstances.createdYmdt | Body | DateTime | Created date and time |
-| dbInstances.updatedYmdt | Body | DateTime | Modified date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstances": [
-        {
-            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbInstanceName": "dbInstanceName-example",
-            "description": "description-example",
-            "dbVersion": "POSTGRESQL_V14_17",
-            "dbPort": 1,
-            "dbInstanceType": "MASTER",
-            "dbInstanceStatus": "BEFORE_CREATE",
-            "progressStatus": "progressStatus-example",
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbInstances": [
+{
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceName": "dbInstanceName-example",
+"description": "description-example",
+"dbVersion": "POSTGRESQL_V14_17",
+"dbPort": 1,
+"dbInstanceType": "MASTER",
+"dbInstanceStatus": "BEFORE_CREATE",
+"progressStatus": "progressStatus-example",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| dbInstances | Array | DB instances |
+| dbInstances.dbInstanceId | UUID | DB instance identifier |
+| dbInstances.dbInstanceGroupId | UUID | DB instance group identifier |
+| dbInstances.dbInstanceName | String | Name to identify DB instances |
+| dbInstances.description | String | Additional information on DB instances |
+| dbInstances.dbVersion | String | DB engine type |
+| dbInstances.dbPort | Number | DB port |
+| dbInstances.dbInstanceType | Enum | DB instance role type<br/>- MASTER: `Master`<br/>- FAILED_MASTER: `Failed master`<br/>- CANDIDATE_MASTER: `Candidate master`<br/>- READ_ONLY_SLAVE: `Read replica` |
+| dbInstances.dbInstanceStatus | Enum | DB instance current status<br/>- BEFORE_CREATE: `Before creation (gray)`<br/>- AVAILABLE: `Available (green)`<br/>- STORAGE_FULL: `Storage full (red)`<br/>- FAIL_TO_CREATE: `Failed to create (red)`<br/>- FAIL_TO_CONNECT: `Failed to connect (red)`<br/>- REPLICATION_STOP: `Replication stopped (red)`<br/>- REPLICATION_DELAY: `Replication delayed (yellow)`<br/>- FAILOVER: `Failover completed (red)`<br/>- SHUTDOWN: `Stopped (gray)`<br/>- DELETED: `Deleted (gray)` |
+| dbInstances.progressStatus | String | Current task status of DB instance |
+| dbInstances.createdYmdt | DateTime | Created date and time |
+| dbInstances.updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### Create DB Instance
 
-```http
-POST /v1.0/db-instances
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -925,117 +975,118 @@ POST /v1.0/db-instances
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceName | Body | String | O | Name to identify DB instances |
-| dbInstanceCandidateName | Body | String | X | Name to identify the candidate master of the DB instance |
-| description | Body | String | X | Additional information on DB instances |
-| dbFlavorId | Body | UUID | O | Identifier of DB instance specifications |
-| dbVersion | Body | Enum | O | DB version information |
-| dbPort | Body | Number | O | DB port<br/>- Minimum value: 5432, Maximum value: 45432 |
-| databaseName | Body | String | O | Database name |
-| dbUserName | Body | String | O | DB user account name |
-| dbPassword | Body | String | O | DB user account password |
-| parameterGroupId | Body | UUID | O | Parameter group identifier |
-| dbSecurityGroupIds | Body | Array | X | List of DB security group identifiers |
-| userGroupIds | Body | Array | X | List of user group identifiers |
-| useHighAvailability | Body | Boolean | X | Whether to use high availability<br/>- Default: `false` |
-| useDefaultNotification | Body | Boolean | X | Whether to use default notification<br/>- Default: `false` |
-| useDeletionProtection | Body | Boolean | X | Whether to enable deletion protection<br/>- Default: `false` |
-| pingInterval | Body | Number | X | Ping interval (sec)<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
-| failoverReplWaitingTime | Body | Number | X | Failover replication delay waiting time (sec)<br/>- Minimum value: `-1` |
-| network | Body | Object | O | Network information objects |
-| network.subnetId | Body | UUID | O | Subnet identifier |
-| network.usePublicAccess | Body | Boolean | X | External access is available or not<br/>- Default: `false` |
-| network.availabilityZone | Body | Enum | X | Availability zone where DB instance will be created |
-| storage | Body | Object | O | Storage information objects |
-| storage.storageType | Body | Enum | O | Data storage type |
-| storage.storageSize | Body | Number | O | Block storage size (GB)<br/>- Minimum value: `20` |
-| backup | Body | Object | O | Backup information objects |
-| backup.backupPeriod | Body | Number | O | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
-| backup.backupRetryCount | Body | Number | X | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
-| backup.backupSchedules | Body | Array | O | Backup schedule information |
-| backup.backupSchedules.backupWndBgnTime | Body | Time | O | Backup start time |
-| backup.backupSchedules.backupWndDuration | Body | Enum | O | Backup window<br/>Auto backup is executed within the set duration from the backup start time.<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hours`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2.5 hours`<br/>- THREE_HOURS: `3 hours` |
+```http
+POST /v1.0/db-instances
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "dbInstanceName": "dbInstanceName-example",
-    "dbInstanceCandidateName": "dbInstanceCandidateName-example",
-    "description": "description-example",
-    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbVersion": "POSTGRESQL_V14_17",
-    "dbPort": 1,
-    "databaseName": "databaseName-example",
-    "dbUserName": "dbUserName-example",
-    "dbPassword": "dbPassword-example",
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbSecurityGroupIds": [],
-    "userGroupIds": [],
-    "useHighAvailability": false,
-    "useDefaultNotification": false,
-    "useDeletionProtection": false,
-    "pingInterval": 1,
-    "failoverReplWaitingTime": 1,
-    "network": {
-        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
-        "usePublicAccess": false,
-        "availabilityZone": "kr-pub-a"
-    },
-    "storage": {
-        "storageType": "General SSD",
-        "storageSize": 20
-    },
-    "backup": {
-        "backupPeriod": 0,
-        "backupRetryCount": 0,
-        "backupSchedules": [
-            {
-                "backupWndBgnTime": "00:00:00",
-                "backupWndDuration": "HALF_AN_HOUR"
-            }
-        ]
-    }
+"dbInstanceName": "dbInstanceName-example",
+"dbInstanceCandidateName": "dbInstanceCandidateName-example",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbVersion": "POSTGRESQL_V14_17",
+"dbPort": 1,
+"databaseName": "databaseName-example",
+"dbUserName": "dbUserName-example",
+"dbPassword": "dbPassword-example",
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useHighAvailability": false,
+"useDefaultNotification": false,
+"useDeletionProtection": false,
+"pingInterval": 1,
+"failoverReplWaitingTime": 1,
+"network": {
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
+},
+"storage": {
+"storageType": "General SSD",
+"storageSize": 20
+},
+"backup": {
+"backupPeriod": 0,
+"backupRetryCount": 0,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
+}
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | Name to identify DB instances |
+| dbInstanceCandidateName | String | N | Candidate master name to identify the DB instance |
+| description | String | N | Additional information on DB instances |
+| dbFlavorId | UUID | Y | Identifier of DB instance specifications |
+| dbVersion | String | Y | DB engine type |
+| dbPort | Number | Y | DB port<br/>- Minimum value: 5432, Maximum value: 45432 |
+| databaseName | String | Y | Database name |
+| dbUserName | String | Y | DB user account name |
+| dbPassword | String | Y | DB user account password |
+| parameterGroupId | UUID | Y | Parameter group identifier |
+| dbSecurityGroupIds | Array | N | List of DB security group identifiers |
+| userGroupIds | Array | N | List of user group identifiers |
+| useHighAvailability | Boolean | N | Whether to use high availability<br/>- Default: `false` |
+| useDefaultNotification | Boolean | N | Whether to use default notification<br/>- Default: `false` |
+| useDeletionProtection | Boolean | N | Whether to use deletion protection<br/>- Default: `false` |
+| pingInterval | Number | N | Ping interval (seconds)<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
+| failoverReplWaitingTime | Number | N | Failover replication delay waiting time (seconds)<br/>- Minimum value: `-1` |
+| network | Object | Y | Network information objects |
+| network.subnetId | UUID | Y | Subnet identifier |
+| network.usePublicAccess | Boolean | N | Whether external access is available<br/>- Default: `false` |
+| network.availabilityZone | Enum | N | Availability zone where DB instance will be created |
+| storage | Object | Y | Storage information objects |
+| storage.storageType | Enum | Y | Storage type |
+| storage.storageSize | Number | Y | Data storage size (GB)<br/>- Minimum value: `20` |
+| backup | Object | Y | Backup information objects |
+| backup.backupPeriod | Number | Y | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| backup.backupRetryCount | Number | N | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| backup.backupSchedules | Array | Y | Backup schedule information |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | Backup start time |
+| backup.backupSchedules.backupWndDuration | Enum | Y | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hours`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2.5 hours`<br/>- THREE_HOURS: `3 hours` |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
+
 ---
+
 ### Restore DB Instance from Backup in Object Storage
 
-```http
-POST /v1.0/db-instances/restore-from-obs
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -1043,129 +1094,129 @@ POST /v1.0/db-instances/restore-from-obs
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceName | Body | String | X | Name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
-| dbInstanceCandidateName | Body | String | X | Candidate master name to identify the DB instance |
-| description | Body | String | X | Additional information on DB instances<br/>- Maximum length: `100` |
-| dbFlavorId | Body | UUID | O | Identifier of DB instance specifications |
-| dbPort | Body | Number | X | DB port<br/>- Minimum value: 5432, Maximum value: 45432 |
-| dbVersion | Body | Enum | O | DB engine type |
-| useHighAvailability | Body | Boolean | X | Whether to use high availability<br/>- Default: `false` |
-| imageId | Body | UUID | X | Image identifier |
-| pingInterval | Body | Number | X | Ping interval (sec) when using high availability<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
-| failoverReplWaitingTime | Body | Number | X | Failover replication delay waiting time (sec)<br/>- Minimum value: `-1` |
-| storage | Body | Object | O | Storage information object |
-| storage.storageType | Body | Enum | O | Storage type |
-| storage.storageSize | Body | Number | O | Data storage size (GB)<br/>- Minimum value: `20` |
-| network | Body | Object | O | Network information object |
-| network.subnetId | Body | UUID | O | Subnet identifier |
-| network.usePublicAccess | Body | Boolean | X | External access availability<br/>- Default: `false` |
-| network.availabilityZone | Body | Enum | X | Availability zone where DB instance will be created |
-| backup | Body | Object | O | Backup information object |
-| backup.backupPeriod | Body | Number | O | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
-| backup.backupRetryCount | Body | Number | X | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
-| backup.replicationRegion | Body | Enum | X | Backup replication region<br/>- KR1: `Korea (Pangyo)`<br/>- KR2: `Korea (Pyeongchon)` |
-| backup.backupSchedules | Body | Array | O | Backup schedule list |
-| backup.backupSchedules.backupWndBgnTime | Body | Time | O | Backup start time |
-| backup.backupSchedules.backupWndDuration | Body | Enum | O | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1 hour 30 minutes`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2 hours 30 minutes`<br/>- THREE_HOURS: `3 hours` |
-| restore | Body | Object | O | Restoration information object |
-| restore.tenantId | Body | String | O | Tenant ID of the object storage where the backup is stored |
-| restore.username | Body | String | O | NHN Cloud account or IAM member ID |
-| restore.password | Body | String | O | API password for the object storage where the backup is stored |
-| restore.targetContainer | Body | String | O | Container of the object storage where the backup is stored |
-| restore.objectPath | Body | String | O | Path of the backup stored in the container |
-| useDefaultNotification | Body | Boolean | X | Whether to use default notifications<br/>- Default: `false` |
-| parameterGroupId | Body | UUID | O | Parameter group identifier |
-| dbSecurityGroupIds | Body | Array | X | List of DB security group identifiers |
-| userGroupIds | Body | Array | X | List of user group identifiers |
-| useDeletionProtection | Body | Boolean | X | Whether deletion protection is enabled<br/>- Default: `false` |
+```http
+POST /v1.0/db-instances/restore-from-obs
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "dbInstanceName": "dbInstanceName",
-    "dbInstanceCandidateName": "dbInstanceCandidateName-example",
-    "description": "description-example",
-    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbPort": 1,
-    "dbVersion": "POSTGRESQL_V14_17",
-    "useHighAvailability": false,
-    "imageId": "550e8400-e29b-41d4-a716-446655440000",
-    "pingInterval": 3,
-    "failoverReplWaitingTime": 60,
-    "storage": {
-        "storageType": "General SSD",
-        "storageSize": 20
-    },
-    "network": {
-        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
-        "usePublicAccess": false,
-        "availabilityZone": "kr-pub-a"
-    },
-    "backup": {
-        "backupPeriod": 0,
-        "backupRetryCount": 0,
-        "replicationRegion": "KR1",
-        "backupSchedules": [
-            {
-                "backupWndBgnTime": "00:00:00",
-                "backupWndDuration": "HALF_AN_HOUR"
-            }
-        ]
-    },
-    "restore": {
-        "tenantId": "0123456789abcdef0123456789abcdef",
-        "username": "username-example",
-        "password": "password-example",
-        "targetContainer": "targetContainer-example",
-        "objectPath": "objectPath-example"
-    },
-    "useDefaultNotification": false,
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbSecurityGroupIds": [],
-    "userGroupIds": [],
-    "useDeletionProtection": false
+"dbInstanceName": "dbInstanceName",
+"dbInstanceCandidateName": "dbInstanceCandidateName-example",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbPort": 1,
+"dbVersion": "POSTGRESQL_V14_17",
+"useHighAvailability": false,
+"imageId": "550e8400-e29b-41d4-a716-446655440000",
+"pingInterval": 3,
+"failoverReplWaitingTime": 60,
+"storage": {
+"storageType": "General SSD",
+"storageSize": 20
+},
+"network": {
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
+},
+"backup": {
+"backupPeriod": 0,
+"backupRetryCount": 0,
+"replicationRegion": "KR1",
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
+},
+"restore": {
+"tenantId": "0123456789abcdef0123456789abcdef",
+"username": "username-example",
+"password": "password-example",
+"targetContainer": "targetContainer-example",
+"objectPath": "objectPath-example"
+},
+"useDefaultNotification": false,
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useDeletionProtection": false
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbInstanceName | String | N | Name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| dbInstanceCandidateName | String | N | Candidate master name to identify the DB instance |
+| description | String | N | Additional information on the DB instance<br/>- Maximum length: `100` |
+| dbFlavorId | UUID | Y | Identifier of DB instance specifications |
+| dbPort | Number | N | DB port<br/>- Minimum value: 5432, Maximum value: 45432 |
+| dbVersion | String | Y | DB engine type |
+| useHighAvailability | Boolean | N | Whether to use high availability<br/>- Default: `false` |
+| imageId | UUID | N | Image identifier |
+| pingInterval | Number | N | Ping interval (sec) when using high availability<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
+| failoverReplWaitingTime | Number | N | Failover replication delay waiting time (seconds)<br/>- Minimum value: `-1` |
+| storage | Object | Y | Storage information objects |
+| storage.storageType | Enum | Y | Storage type |
+| storage.storageSize | Number | Y | Data storage size (GB)<br/>- Minimum value: `20` |
+| network | Object | Y | Network information objects |
+| network.subnetId | UUID | Y | Subnet identifier |
+| network.usePublicAccess | Boolean | N | Whether external access is available<br/>- Default: `false` |
+| network.availabilityZone | Enum | N | Availability zone where DB instance will be created |
+| backup | Object | Y | Backup information objects |
+| backup.backupPeriod | Number | Y | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| backup.backupRetryCount | Number | N | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| backup.replicationRegion | Enum | N | Backup replication region<br/>- KR1: `Korea (Pangyo)`<br/>- KR2: `Korea (Pyeongchon)` |
+| backup.backupSchedules | Array | Y | Backup schedules |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | Backup start time |
+| backup.backupSchedules.backupWndDuration | Enum | Y | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hours`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2.5 hours`<br/>- THREE_HOURS: `3 hours` |
+| restore | Object | Y | Restoration information object |
+| restore.tenantId | String | Y | Tenant ID of the object storage where the backup is stored |
+| restore.username | String | Y | NHN Cloud account or IAM member ID |
+| restore.password | String | Y | API password for the object storage where the backup is stored |
+| restore.targetContainer | String | Y | Container of the object storage where the backup is stored |
+| restore.objectPath | String | Y | Path of the backup stored in the container |
+| useDefaultNotification | Boolean | N | Whether to use default notification<br/>- Default: `false` |
+| parameterGroupId | UUID | Y | Parameter group identifier |
+| dbSecurityGroupIds | Array | N | List of DB security group identifiers |
+| userGroupIds | Array | N | List of user group identifiers |
+| useDeletionProtection | Boolean | N | Whether to use deletion protection<br/>- Default: `false` |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Delete DB Instance
 
-```http
-DELETE /v1.0/db-instances/{dbInstanceId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -1173,44 +1224,47 @@ DELETE /v1.0/db-instances/{dbInstanceId}
 
 #### Request
 
-This API does not require a request body.
+```http
+DELETE /v1.0/db-instances/{dbInstanceId}
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### List DB Instance Details
 
-```http
-GET /v1.0/db-instances/{dbInstanceId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -1218,84 +1272,87 @@ GET /v1.0/db-instances/{dbInstanceId}
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v1.0/db-instances/{dbInstanceId}
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| dbInstanceId | Body | UUID | DB instance identifier |
-| dbInstanceGroupId | Body | UUID | DB instance group identifier |
-| dbInstanceName | Body | String | Name to identify DB instances |
-| description | Body | String | Additional information on DB instances |
-| dbVersion | Body | Enum | DB engine type |
-| dbPort | Body | Number | DB port |
-| dbInstanceType | Body | Enum | DB instance role type<br/>- MASTER: `Master`<br/>- FAILED_MASTER: `Failed over master`<br/>- CANDIDATE_MASTER: `Candidate master`<br/>- READ_ONLY_SLAVE: `Read replica` |
-| dbInstanceStatus | Body | Enum | DB instance current status<br/>- BEFORE_CREATE: `Before creation (gray)`<br/>- AVAILABLE: `Available (green)`<br/>- STORAGE_FULL: `Storage full (red)`<br/>- FAIL_TO_CREATE: `Failed to create (red)`<br/>- FAIL_TO_CONNECT: `Failed to connect (red)`<br/>- REPLICATION_STOP: `Replication stopped (red)`<br/>- REPLICATION_DELAY: `Replication delayed (yellow)`<br/>- FAILOVER: `Failover completed (red)`<br/>- SHUTDOWN: `Stopped (gray)`<br/>- DELETED: `Deleted (gray)` |
-| progressStatus | Body | String | Current task status of DB instance |
-| dbFlavorId | Body | UUID | Identifier of DB instance specifications |
-| parameterGroupId | Body | UUID | Identifier of the parameter group applied to the DB instance |
-| dbSecurityGroupIds | Body | Array | List of DB security group identifiers applied to the DB instance |
-| notificationGroupIds | Body | Array | List of identifiers of notification groups applied to the DB instance |
-| useDeletionProtection | Body | Boolean | Whether deletion protection is enabled for the DB instance |
-| needToApplyParameterGroup | Body | Boolean | Whether the latest parameter group needs to be applied |
-| needMigration | Body | Boolean | Whether migration is required |
-| osVersion | Body | String | OS version |
-| createdYmdt | Body | DateTime | Created date and time |
-| updatedYmdt | Body | DateTime | Modified date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbInstanceName": "dbInstanceName-example",
-    "description": "description-example",
-    "dbVersion": "POSTGRESQL_V14_17",
-    "dbPort": 1,
-    "dbInstanceType": "MASTER",
-    "dbInstanceStatus": "BEFORE_CREATE",
-    "progressStatus": "progressStatus-example",
-    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbSecurityGroupIds": [
-        "550e8400-e29b-41d4-a716-446655440000"
-    ],
-    "notificationGroupIds": [
-        "550e8400-e29b-41d4-a716-446655440000"
-    ],
-    "useDeletionProtection": false,
-    "needToApplyParameterGroup": false,
-    "needMigration": false,
-    "osVersion": "osVersion-example",
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceName": "dbInstanceName-example",
+"description": "description-example",
+"dbVersion": "POSTGRESQL_V14_17",
+"dbPort": 1,
+"dbInstanceType": "MASTER",
+"dbInstanceStatus": "BEFORE_CREATE",
+"progressStatus": "progressStatus-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [
+"550e8400-e29b-41d4-a716-446655440000"
+],
+"notificationGroupIds": [
+"550e8400-e29b-41d4-a716-446655440000"
+],
+"useDeletionProtection": false,
+"needToApplyParameterGroup": false,
+"needMigration": false,
+"osVersion": "osVersion-example",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| dbInstanceId | UUID | DB instance identifier |
+| dbInstanceGroupId | UUID | DB instance group identifier |
+| dbInstanceName | String | Name to identify DB instances |
+| description | String | Additional information on DB instances |
+| dbVersion | String | DB engine type |
+| dbPort | Number | DB port |
+| dbInstanceType | Enum | DB instance role type<br/>- MASTER: `Master`<br/>- FAILED_MASTER: `Failed master`<br/>- CANDIDATE_MASTER: `Candidate master`<br/>- READ_ONLY_SLAVE: `Read replica` |
+| dbInstanceStatus | Enum | DB instance current status<br/>- BEFORE_CREATE: `Before creation (gray)`<br/>- AVAILABLE: `Available (green)`<br/>- STORAGE_FULL: `Storage full (red)`<br/>- FAIL_TO_CREATE: `Failed to create (red)`<br/>- FAIL_TO_CONNECT: `Failed to connect (red)`<br/>- REPLICATION_STOP: `Replication stopped (red)`<br/>- REPLICATION_DELAY: `Replication delayed (yellow)`<br/>- FAILOVER: `Failover completed (red)`<br/>- SHUTDOWN: `Stopped (gray)`<br/>- DELETED: `Deleted (gray)` |
+| progressStatus | String | Current task status of DB instance |
+| dbFlavorId | UUID | Identifier of DB instance specifications |
+| parameterGroupId | UUID | Identifier of the parameter group applied to the DB instance |
+| dbSecurityGroupIds | Array | List of DB security group identifiers applied to the DB instance |
+| notificationGroupIds | Array | List of identifiers of notification groups applied to the DB instance |
+| useDeletionProtection | Boolean | Whether deletion protection is enabled for the DB instance |
+| needToApplyParameterGroup | Boolean | Whether the latest parameter group needs to be applied |
+| needMigration | Boolean | Whether migration is required |
+| osVersion | String | OS version |
+| createdYmdt | DateTime | Created date and time |
+| updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### Modify DB Instance
 
-```http
-PUT /v1.0/db-instances/{dbInstanceId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -1303,77 +1360,82 @@ PUT /v1.0/db-instances/{dbInstanceId}
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| dbInstanceName | Body | String | X | Name to identify DB instances |
-| dbInstanceCandidateName | Body | String | X | Candidate master name to identify the DB instance |
-| description | Body | String | X | Additional information on DB instances<br/>- Maximum length: `100` |
-| dbPort | Body | Number | X | DB port<br/>- Minimum value: 5432, Maximum value: 45432 |
-| dbFlavorId | Body | UUID | X | Identifier of DB instance specifications |
-| parameterGroupId | Body | UUID | X | Parameter group identifier |
-| dbVersion | Body | Enum | X | DB engine version code |
-| dbSecurityGroupIds | Body | Array | X | List of DB security group identifiers |
-| executeBackup | Body | Boolean | X | Whether to execute backup at this time<br/>- Default: `false` |
-| useOnlineFailover | Body | Boolean | X | Whether to restart using failover<br/>- Default: `false` |
-| waitReplicationDelay | Body | Boolean | X | Whether to wait for replication delay to resolve<br/>- Default: `false` |
-| useReadOnly | Body | Boolean | X | Whether to block write workloads<br/>- Default: `false` |
+```http
+PUT /v1.0/db-instances/{dbInstanceId}
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "dbInstanceName": "dbInstanceName-example",
-    "dbInstanceCandidateName": "dbInstanceCandidateName-example",
-    "description": "description-example",
-    "dbPort": 1,
-    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbVersion": "POSTGRESQL_V14_17",
-    "dbSecurityGroupIds": [],
-    "executeBackup": false,
-    "useOnlineFailover": false,
-    "waitReplicationDelay": false,
-    "useReadOnly": false
+"dbInstanceName": "dbInstanceName-example",
+"dbInstanceCandidateName": "dbInstanceCandidateName-example",
+"description": "description-example",
+"dbPort": 1,
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbVersion": "POSTGRESQL_V14_17",
+"dbSecurityGroupIds": [],
+"executeBackup": false,
+"useOnlineFailover": false,
+"waitReplicationDelay": false,
+"useReadOnly": false
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbInstanceName | String | N | Name to identify DB instances |
+| dbInstanceCandidateName | String | N | Candidate master name to identify the DB instance |
+| description | String | N | Additional information on the DB instance<br/>- Maximum length: `100` |
+| dbPort | Number | N | DB port<br/>- Minimum value: 5432, Maximum value: 45432 |
+| dbFlavorId | UUID | N | Identifier of DB instance specifications |
+| parameterGroupId | UUID | N | Parameter group identifier |
+| dbVersion | String | N | DB engine version code |
+| dbSecurityGroupIds | Array | N | List of DB security group identifiers |
+| executeBackup | Boolean | N | Whether to execute backup at this time<br/>- Default: `false` |
+| useOnlineFailover | Boolean | N | Whether to restart using failover<br/>- Default: `false` |
+| waitReplicationDelay | Boolean | N | Whether to wait for replication delay to resolve<br/>- Default: `false` |
+| useReadOnly | Boolean | N | Whether to block write workloads<br/>- Default: `false` |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Apply Latest Parameter Group to DB Instance
 
-```http
-POST /v1.0/db-instances/{dbInstanceId}/apply-recent-parameter-group
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -1381,43 +1443,47 @@ POST /v1.0/db-instances/{dbInstanceId}/apply-recent-parameter-group
 
 #### Request
 
-This API does not require a request body.
+```http
+POST /v1.0/db-instances/{dbInstanceId}/apply-recent-parameter-group
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
+
 ---
+
 ### Get selectable DB versions in the current DB instance
 
-```http
-GET /v1.0/db-instances/{dbInstanceId}/available-db-versions
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -1425,55 +1491,58 @@ GET /v1.0/db-instances/{dbInstanceId}/available-db-versions
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v1.0/db-instances/{dbInstanceId}/available-db-versions
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| availableDbVersions | Body | Array | DB version information |
-| availableDbVersions.dbVersionCode | Body | Enum | DB version code<br/>- MYSQL_V5633<br/>- MYSQL_V5715<br/>- MYSQL_V5719<br/>- MYSQL_V5726<br/>- MYSQL_V5731<br/>- MYSQL_V5733<br/>- MYSQL_V5737<br/>- MYSQL_V8018<br/>- MYSQL_V8023<br/>- MYSQL_V8028<br/>- MYSQL_V8032<br/>- MYSQL_V8033<br/>- MYSQL_V8034<br/>- MYSQL_V8035<br/>- MYSQL_V8036<br/>- MYSQL_V8040<br/>- MYSQL_V8041<br/>- MYSQL_V8042<br/>- MYSQL_V8043<br/>- MYSQL_V8044<br/>- MYSQL_V8045<br/>- MYSQL_V8405<br/>- MYSQL_V8406<br/>- MYSQL_V8407<br/>- MYSQL_V8408<br/>- MYSQL_V8409<br/>- MARIADB_V10330<br/>- MARIADB_V10611<br/>- MARIADB_V10612<br/>- MARIADB_V10616<br/>- MARIADB_V10622<br/>- MARIADB_V10625<br/>- MARIADB_V101107<br/>- MARIADB_V101108<br/>- MARIADB_V101113<br/>- MARIADB_V101116<br/>- MARIADB_V11407<br/>- MARIADB_V11410<br/>- MARIADB_V11806<br/>- POSTGRESQL_V14_6<br/>- POSTGRESQL_V14_15<br/>- POSTGRESQL_V14_17<br/>- POSTGRESQL_V14_19<br/>- POSTGRESQL_V17_2<br/>- POSTGRESQL_V17_4<br/>- POSTGRESQL_V17_6 |
-| availableDbVersions.dbMajorVersionCode | Body | Enum | DB major version code<br/>- MYSQL_V56<br/>- MYSQL_V57<br/>- MYSQL_V80<br/>- MYSQL_V84<br/>- MARIADB_V103<br/>- MARIADB_V106<br/>- MARIADB_V1011<br/>- MARIADB_V114<br/>- MARIADB_V118<br/>- POSTGRES_V14<br/>- POSTGRES_V17 |
-| availableDbVersions.name | Body | String | DB version name |
-| availableDbVersions.canCreate | Body | Boolean | Whether creation is available |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "availableDbVersions": [
-        {
-            "dbVersionCode": "MYSQL_V5633",
-            "dbMajorVersionCode": "MYSQL_V56",
-            "name": "PostgreSQL V14.6",
-            "canCreate": false
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"availableDbVersions": [
+{
+            "dbVersionCode": "dbVersionCode-example",
+            "dbMajorVersionCode": "dbMajorVersionCode-example",
+"name": "PostgreSQL V14.6",
+"canCreate": false
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| availableDbVersions | Array | DB version information |
+| availableDbVersions.dbVersionCode | String | DB version code |
+| availableDbVersions.dbMajorVersionCode | String | DB major version code |
+| availableDbVersions.name | String | DB version name |
+| availableDbVersions.canCreate | Boolean | Whether creation is available |
 
 ---
 
 ### Backup DB Instance
 
-```http
-POST /v1.0/db-instances/{dbInstanceId}/backup
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -1481,55 +1550,60 @@ POST /v1.0/db-instances/{dbInstanceId}/backup
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| backupName | Body | String | O | Name to identify backups |
+```http
+POST /v1.0/db-instances/{dbInstanceId}/backup
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "backupName": "backupName-example"
+"backupName": "backupName-example"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| backupName | String | Y | Name to identify backups |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Get DB Instance Backup Information
 
-```http
-GET /v1.0/db-instances/{dbInstanceId}/backup-info
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -1537,59 +1611,62 @@ GET /v1.0/db-instances/{dbInstanceId}/backup-info
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v1.0/db-instances/{dbInstanceId}/backup-info
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| allowAutoBackup | Body | Boolean | Whether automatic backup is allowed |
-| usePeriodicAutoBackup | Body | Boolean | Whether scheduled automatic backup is used |
-| backupPeriod | Body | Number | Backup retention period (days) |
-| backupRetryCount | Body | Number | Number of backup retries |
-| backupSchedules | Body | Array | Backup schedules |
-| backupSchedules.backupWndBgnTime | Body | Time | Backup start time |
-| backupSchedules.backupWndDuration | Body | Enum | Backup Window<br/>Auto backup is executed within the set duration from the backup start time.<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hour`<br/>- TWO_HOURS: `2 hour`<br/>- TWO_HOURS_AND_HALF: `2.5 hour`<br/>- THREE_HOURS: `3 hour` |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "allowAutoBackup": false,
-    "usePeriodicAutoBackup": false,
-    "backupPeriod": 1,
-    "backupRetryCount": 1,
-    "backupSchedules": [
-        {
-            "backupWndBgnTime": "00:00:00",
-            "backupWndDuration": "HALF_AN_HOUR"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"allowAutoBackup": false,
+"usePeriodicAutoBackup": false,
+"backupPeriod": 1,
+"backupRetryCount": 1,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| allowAutoBackup | Boolean | Whether automatic backup is allowed |
+| usePeriodicAutoBackup | Boolean | Whether scheduled automatic backup is used |
+| backupPeriod | Number | Backup retention period (days) |
+| backupRetryCount | Number | Number of backup retries |
+| backupSchedules | Array | Backup schedules |
+| backupSchedules.backupWndBgnTime | Time | Backup start time |
+| backupSchedules.backupWndDuration | Enum | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hours`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2.5 hours`<br/>- THREE_HOURS: `3 hours` |
 
 ---
 
 ### Modify DB Instance Backup Information
 
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/backup-info
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -1597,70 +1674,75 @@ PUT /v1.0/db-instances/{dbInstanceId}/backup-info
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| allowAutoBackup | Body | Boolean | X | Whether automatic backup is allowed |
-| usePeriodicAutoBackup | Body | Boolean | X | Whether scheduled automatic backup is used |
-| backupPeriod | Body | Number | X | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
-| backupRetryCount | Body | Number | X | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
-| backupSchedules | Body | Array | X | Backup schedules |
-| backupSchedules.backupWndBgnTime | Body | Time | O | Backup start time |
-| backupSchedules.backupWndDuration | Body | Enum | O | Backup Window<br/>Auto backup is executed within the set duration from the backup start time.<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hour`<br/>- TWO_HOURS: `2 hour`<br/>- TWO_HOURS_AND_HALF: `2.5 hour`<br/>- THREE_HOURS: `3 hour` |
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/backup-info
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "allowAutoBackup": false,
-    "usePeriodicAutoBackup": false,
-    "backupPeriod": 0,
-    "backupRetryCount": 0,
-    "backupSchedules": [
-        {
-            "backupWndBgnTime": "00:00:00",
-            "backupWndDuration": "HALF_AN_HOUR"
-        }
-    ]
+"allowAutoBackup": false,
+"usePeriodicAutoBackup": false,
+"backupPeriod": 0,
+"backupRetryCount": 0,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| allowAutoBackup | Boolean | N | Whether automatic backup is allowed |
+| usePeriodicAutoBackup | Boolean | N | Whether scheduled automatic backup is used |
+| backupPeriod | Number | N | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| backupRetryCount | Number | N | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| backupSchedules | Array | N | Backup schedules |
+| backupSchedules.backupWndBgnTime | Time | Y | Backup start time |
+| backupSchedules.backupWndDuration | Enum | Y | Backup Window<br/>Auto backup is executed within the set duration from the backup start time.<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hour`<br/>- TWO_HOURS: `2 hour`<br/>- TWO_HOURS_AND_HALF: `2.5 hour`<br/>- THREE_HOURS: `3 hour` |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Export after Backing up DB Instance to Object Storage
 
-```http
-POST /v1.0/db-instances/{dbInstanceId}/backup-to-object-storage
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -1668,62 +1750,68 @@ POST /v1.0/db-instances/{dbInstanceId}/backup-to-object-storage
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| tenantId | Body | String | O | Tenant ID of object storage to store backup<br/>- Minimum length: `32`<br/>- Maximum length: `32` |
-| username | Body | String | O | ID of NHN Cloud Account or IAM Account |
-| password | Body | String | O | API password for object storage where backup is stored |
-| targetContainer | Body | String | O | Object storage container where backup is stored |
-| objectPath | Body | String | O | Backup path to be stored in container |
+```http
+POST /v1.0/db-instances/{dbInstanceId}/backup-to-object-storage
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "tenantId": "0123456789abcdef0123456789abcdef",
-    "username": "username-example",
-    "password": "password-example",
-    "targetContainer": "targetContainer-example",
-    "objectPath": "objectPath-example"
+"tenantId": "0123456789abcdef0123456789abcdef",
+"username": "username-example",
+"password": "password-example",
+"targetContainer": "targetContainer-example",
+"objectPath": "objectPath-example"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| tenantId | String | Y | Tenant ID of object storage where backup will be stored<br/>- Minimum length: `32`<br/>- Maximum length: `32` |
+| username | String | Y | NHN Cloud account or IAM member ID |
+| password | String | Y | API password for object storage where backup will be stored |
+| targetContainer | String | Y | Object storage container where backup will be stored |
+| objectPath | String | Y | Path of the backup to be stored in the container |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
+
 ---
+
 ### View the list of databases
 
-```http
-GET /v1.0/db-instances/{dbInstanceId}/databases
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -1731,66 +1819,69 @@ GET /v1.0/db-instances/{dbInstanceId}/databases
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v1.0/db-instances/{dbInstanceId}/databases
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| databases | Body | Array | Database information |
-| databases.databaseId | Body | UUID | Database identifier |
-| databases.databaseName | Body | String | Database name |
-| databases.databaseStatus | Body | Enum | Current state of the database<br/>- STABLE: `Available`<br/>- CREATING: `Creating`<br/>- MODIFYING: `Modifying`<br/>- DELETING: `Deleting`<br/>- DELETED: `Deleted`<br/>- SYNCING: `Synchronizing`<br/>- DELETE_ERROR: `Deletion failed` |
-| databases.createdYmdt | Body | DateTime | Created date and time |
-| databases.updatedYmdt | Body | DateTime | Modified date and time |
-| databases.schemas | Body | Array | Schema information |
-| databases.schemas.schemaName | Body | String | Schema name |
-| databases.errorReason | Body | String | Reason for deletion failure |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "databases": [
-        {
-            "databaseId": "550e8400-e29b-41d4-a716-446655440000",
-            "databaseName": "databaseName-example",
-            "databaseStatus": "STABLE",
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00",
-            "schemas": [
-                {
-                    "schemaName": "schemaName-example"
-                }
-            ],
-            "errorReason": "errorReason-example"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"databases": [
+{
+"databaseId": "550e8400-e29b-41d4-a716-446655440000",
+"databaseName": "databaseName-example",
+"databaseStatus": "STABLE",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00",
+"schemas": [
+{
+"schemaName": "schemaName-example"
+}
+],
+"errorReason": "errorReason-example"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| databases | Array | Database information |
+| databases.databaseId | UUID | Database identifier |
+| databases.databaseName | String | Database name |
+| databases.databaseStatus | Enum | Current state of the database<br/>- STABLE: `Available`<br/>- CREATING: `Creating`<br/>- MODIFYING: `Modifying`<br/>- DELETING: `Deleting`<br/>- DELETED: `Deleted`<br/>- SYNCING: `Synchronizing`<br/>- DELETE_ERROR: `Deletion failed` |
+| databases.createdYmdt | DateTime | Created date and time |
+| databases.updatedYmdt | DateTime | Modified date and time |
+| databases.schemas | Array | Schema information |
+| databases.schemas.schemaName | String | Schema name |
+| databases.errorReason | String | Reason for deletion failure |
 
 ---
 
 ### Create a database
 
-```http
-POST /v1.0/db-instances/{dbInstanceId}/databases
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -1798,55 +1889,60 @@ POST /v1.0/db-instances/{dbInstanceId}/databases
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| databaseName | Body | String | O | Database name |
+```http
+POST /v1.0/db-instances/{dbInstanceId}/databases
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "databaseName": "databaseName-example"
+"databaseName": "databaseName-example"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| databaseName | String | Y | Database name |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of the requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Delete a database
 
-```http
-DELETE /v1.0/db-instances/{dbInstanceId}/databases/{databaseId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -1854,45 +1950,48 @@ DELETE /v1.0/db-instances/{dbInstanceId}/databases/{databaseId}
 
 #### Request
 
-This API does not require a request body.
+```http
+DELETE /v1.0/db-instances/{dbInstanceId}/databases/{databaseId}
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| databaseId | URL | UUID | O | Database identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+| databaseId | URL | UUID | Y | Database identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of the requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Modify a database
 
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/databases/{databaseId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -1900,57 +1999,63 @@ PUT /v1.0/db-instances/{dbInstanceId}/databases/{databaseId}
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| databaseId | URL | UUID | O | Database identifier |
-| applyHbaRulesImmediately | Body | Boolean | X | Whether to apply associated access control rules immediately<br/>- Default: `false` |
-| databaseName | Body | String | O | Database name |
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/databases/{databaseId}
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+| databaseId | URL | UUID | Y | Database identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "applyHbaRulesImmediately": false,
-    "databaseName": "databaseName-example"
+"applyHbaRulesImmediately": false,
+"databaseName": "databaseName-example"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| applyHbaRulesImmediately | Boolean | N | Whether to apply associated access control rules immediately<br/>- Default: `false` |
+| databaseName | String | Y | Database name |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of the requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
+
 ---
+
 ### View the list of users
 
-```http
-GET /v1.0/db-instances/{dbInstanceId}/db-users
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -1958,59 +2063,62 @@ GET /v1.0/db-instances/{dbInstanceId}/db-users
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v1.0/db-instances/{dbInstanceId}/db-users
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| dbUsers | Body | Array | DB user list |
-| dbUsers.dbUserId | Body | UUID | DB user identifier |
-| dbUsers.dbUserName | Body | String | DB user account name |
-| dbUsers.authorityType | Body | Enum | DB user permission types<br/>- CUSTOM: `Custom permission`<br/>- READ: `READ permission (read-only permission)`<br/>- CRUD: `CRUD permission (includes read permission)`<br/>- DDL: `DDL permission (includes CRUD permission)` |
-| dbUsers.dbUserStatus | Body | Enum | DB user current status<br/>- STABLE: `Available`<br/>- CREATING: `Creating`<br/>- MODIFYING: `Modifying`<br/>- DELETING: `Deleting`<br/>- DELETED: `Deleted`<br/>- SYNCING: `Synchronizing`<br/>- DELETE_ERROR: `Deletion failed` |
-| dbUsers.createdYmdt | Body | DateTime | Created date and time |
-| dbUsers.updatedYmdt | Body | DateTime | Modified date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbUsers": [
-        {
-            "dbUserId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbUserName": "dbUserName-example",
-            "authorityType": "CUSTOM",
-            "dbUserStatus": "STABLE",
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbUsers": [
+{
+"dbUserId": "550e8400-e29b-41d4-a716-446655440000",
+"dbUserName": "dbUserName-example",
+"authorityType": "CUSTOM",
+"dbUserStatus": "STABLE",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| dbUsers | Array | DB user list |
+| dbUsers.dbUserId | UUID | DB user identifier |
+| dbUsers.dbUserName | String | DB user account name |
+| dbUsers.authorityType | Enum | DB user permission types<br/>- CUSTOM: `Custom permission`<br/>- READ: `READ permission (read-only permission)`<br/>- CRUD: `CRUD permission (includes read permission)`<br/>- DDL: `DDL permission (includes CRUD permission)` |
+| dbUsers.dbUserStatus | Enum | DB user current status<br/>- STABLE: `Available`<br/>- CREATING: `Creating`<br/>- MODIFYING: `Modifying`<br/>- DELETING: `Deleting`<br/>- DELETED: `Deleted`<br/>- SYNCING: `Synchronizing`<br/>- DELETE_ERROR: `Deletion failed` |
+| dbUsers.createdYmdt | DateTime | Created date and time |
+| dbUsers.updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### Create a user
 
-```http
-POST /v1.0/db-instances/{dbInstanceId}/db-users
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2018,63 +2126,68 @@ POST /v1.0/db-instances/{dbInstanceId}/db-users
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| dbUserName | Body | String | O | DB user account name |
-| dbPassword | Body | String | O | DB user account password |
-| authorityType | Body | Enum | O | DB user permission types<br/>- CUSTOM: `Custom permission`<br/>- READ: `Read permission`<br/>- CRUD: `CRUD permission`<br/>- DDL: `DDL permission` |
-| createDefaultHbaRules | Body | Boolean | X | Whether to create default access control rules<br/>- Default: `false` |
-| address | Body | String | X | Connection address |
+```http
+POST /v1.0/db-instances/{dbInstanceId}/db-users
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "dbUserName": "dbUserName-example",
-    "dbPassword": "dbPassword-example",
-    "authorityType": "CUSTOM",
-    "createDefaultHbaRules": false,
-    "address": "address-example"
+"dbUserName": "dbUserName-example",
+"dbPassword": "dbPassword-example",
+"authorityType": "CUSTOM",
+"createDefaultHbaRules": false,
+"address": "address-example"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbUserName | String | Y | DB user account name |
+| dbPassword | String | Y | DB user account password |
+| authorityType | Enum | Y | DB user permission types<br/>- CUSTOM: `Custom permission`<br/>- READ: `Read permission`<br/>- CRUD: `CRUD permission`<br/>- DDL: `DDL permission` |
+| createDefaultHbaRules | Boolean | N | Whether to create default access control rules<br/>- Default: `false` |
+| address | String | N | Connection address |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Delete a user
 
-```http
-DELETE /v1.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2082,45 +2195,48 @@ DELETE /v1.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
 
 #### Request
 
-This API does not require a request body.
+```http
+DELETE /v1.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| dbUserId | URL | UUID | O | DB user identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+| dbUserId | URL | UUID | Y | DB user identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Edit a user
 
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2128,62 +2244,67 @@ PUT /v1.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| dbUserId | URL | UUID | O | DB user identifier |
-| dbUserName | Body | String | X | DB user account name |
-| dbPassword | Body | String | X | DB user account password |
-| authorityType | Body | Enum | X | DB user permission<br/>- CUSTOM: `Custom permission`<br/>- READ: `Read permission`<br/>- CRUD: `CRUD permission`<br/>- DDL: `DDL permission` |
-| applyHbaRulesImmediately | Body | Boolean | X | Whether to apply access control changes immediately<br/>- Default: `false` |
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+| dbUserId | URL | UUID | Y | DB user identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "dbUserName": "dbUserName-example",
-    "dbPassword": "dbPassword-example",
-    "authorityType": "CUSTOM",
-    "applyHbaRulesImmediately": false
+"dbUserName": "dbUserName-example",
+"dbPassword": "dbPassword-example",
+"authorityType": "CUSTOM",
+"applyHbaRulesImmediately": false
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbUserName | String | N | DB user account name |
+| dbPassword | String | N | DB user account password |
+| authorityType | Enum | N | DB user permission<br/>- CUSTOM: `Custom permission`<br/>- READ: `Read permission`<br/>- CRUD: `CRUD permission`<br/>- DDL: `DDL permission` |
+| applyHbaRulesImmediately | Boolean | N | Whether to apply access control changes immediately<br/>- Default: `false` |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Change DB Instance Deletion Protection Settings
 
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/deletion-protection
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2191,22 +2312,32 @@ PUT /v1.0/db-instances/{dbInstanceId}/deletion-protection
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| useDeletionProtection | Body | Boolean | O | Whether to enable deletion protection |
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/deletion-protection
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "useDeletionProtection": false
+"useDeletionProtection": false
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| useDeletionProtection | Boolean | Y | Whether to enable deletion protection |
 
 #### Response
 
@@ -2216,11 +2347,7 @@ This API does not return a response body.
 
 ### Force Restart DB Instance
 
-```http
-POST /v1.0/db-instances/{dbInstanceId}/force-restart
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2228,24 +2355,29 @@ POST /v1.0/db-instances/{dbInstanceId}/force-restart
 
 #### Request
 
-This API does not require a request body.
+```http
+POST /v1.0/db-instances/{dbInstanceId}/force-restart
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
 This API does not return a response body.
 
 ---
+
 ### View a list of access control rules
 
-```http
-GET /v1.0/db-instances/{dbInstanceId}/hba-rules
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2253,85 +2385,88 @@ GET /v1.0/db-instances/{dbInstanceId}/hba-rules
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v1.0/db-instances/{dbInstanceId}/hba-rules
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| hbaRules | Body | Array | List of access control rules |
-| hbaRules.hbaRuleId | Body | UUID | Identifier of the access control rule |
-| hbaRules.hbaRuleStatus | Body | Enum | Current status of the access control rule<br/>- CREATED: `Created`<br/>- APPLIED: `Applied`<br/>- CREATING: `Creating`<br/>- MODIFYING: `Modifying`<br/>- DELETING: `Deleting`<br/>- DELETED: `Deleted` |
-| hbaRules.databaseApplyType | Body | Enum | Database apply type<br/>- ENTIRE: `All`<br/>- USER_CUSTOM: `Customize` |
-| hbaRules.dbUserApplyTypeCode | Body | Enum | DB user apply type<br/>- ENTIRE: `All`<br/>- USER_CUSTOM: `Customize` |
-| hbaRules.databases | Body | Array | List of custom databases |
-| hbaRules.databases.databaseId | Body | UUID | Database identifier |
-| hbaRules.databases.databaseName | Body | String | Database name |
-| hbaRules.dbUsers | Body | Array | Custom DB user list |
-| hbaRules.dbUsers.dbUserId | Body | UUID | DB user identifier |
-| hbaRules.dbUsers.dbUserName | Body | String | DB user account name |
-| hbaRules.address | Body | String | Connection address |
-| hbaRules.authMethod | Body | Enum | Authentication method<br/>- TRUST: `Trust (no password required)`<br/>- REJECT: `Block access`<br/>- SCRAM_SHA_256: `Password (SCRAM-SHA-256)` |
-| hbaRules.reservedAction | Body | Enum | Scheduled task<br/>- NONE: `None`<br/>- CREATE: `Schedule a creation (requires application)`<br/>- MODIFY: `Schedule a modification (requires application)`<br/>- DELETE: `Schedule a deletion (requires application)` |
-| hbaRules.order | Body | Number | Application order |
-| hbaRules.applicable | Body | Boolean | Whether the rule is applicable |
-| needToApply | Body | Boolean | Whether changes need to be applied |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "hbaRules": [
-        {
-            "hbaRuleId": "550e8400-e29b-41d4-a716-446655440000",
-            "hbaRuleStatus": "CREATED",
-            "databaseApplyType": "ENTIRE",
-            "dbUserApplyTypeCode": "ENTIRE",
-            "databases": [
-                {
-                    "databaseId": "550e8400-e29b-41d4-a716-446655440000",
-                    "databaseName": "databaseName-example"
-                }
-            ],
-            "dbUsers": [
-                {
-                    "dbUserId": "550e8400-e29b-41d4-a716-446655440000",
-                    "dbUserName": "dbUserName-example"
-                }
-            ],
-            "address": "address-example",
-            "authMethod": "TRUST",
-            "reservedAction": "NONE",
-            "order": 1,
-            "applicable": false
-        }
-    ],
-    "needToApply": false
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"hbaRules": [
+{
+"hbaRuleId": "550e8400-e29b-41d4-a716-446655440000",
+"hbaRuleStatus": "CREATED",
+"databaseApplyType": "ENTIRE",
+"dbUserApplyTypeCode": "ENTIRE",
+"databases": [
+{
+"databaseId": "550e8400-e29b-41d4-a716-446655440000",
+"databaseName": "databaseName-example"
+}
+],
+"dbUsers": [
+{
+"dbUserId": "550e8400-e29b-41d4-a716-446655440000",
+"dbUserName": "dbUserName-example"
+}
+],
+"address": "address-example",
+"authMethod": "TRUST",
+"reservedAction": "NONE",
+"order": 1,
+"applicable": false
+}
+],
+"needToApply": false
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| hbaRules | Array | List of access control rules |
+| hbaRules.hbaRuleId | UUID | Identifier of the access control rule |
+| hbaRules.hbaRuleStatus | Enum | Current status of the access control rule<br/>- CREATED: `Created`<br/>- APPLIED: `Applied`<br/>- CREATING: `Creating`<br/>- MODIFYING: `Modifying`<br/>- DELETING: `Deleting`<br/>- DELETED: `Deleted` |
+| hbaRules.databaseApplyType | Enum | Database apply type<br/>- ENTIRE: `All`<br/>- USER_CUSTOM: `Customize` |
+| hbaRules.dbUserApplyTypeCode | Enum | DB user apply type<br/>- ENTIRE: `All`<br/>- USER_CUSTOM: `Customize` |
+| hbaRules.databases | Array | List of custom databases |
+| hbaRules.databases.databaseId | UUID | Database identifier |
+| hbaRules.databases.databaseName | String | Database name |
+| hbaRules.dbUsers | Array | Custom DB user list |
+| hbaRules.dbUsers.dbUserId | UUID | DB user identifier |
+| hbaRules.dbUsers.dbUserName | String | DB user account name |
+| hbaRules.address | String | Connection address |
+| hbaRules.authMethod | Enum | Authentication method<br/>- TRUST: `Trust (no password required)`<br/>- REJECT: `Block access`<br/>- SCRAM_SHA_256: `Password (SCRAM-SHA-256)` |
+| hbaRules.reservedAction | Enum | Scheduled task<br/>- NONE: `None`<br/>- CREATE: `Schedule a creation (requires application)`<br/>- MODIFY: `Schedule a modification (requires application)`<br/>- DELETE: `Schedule a deletion (requires application)` |
+| hbaRules.order | Number | Application order |
+| hbaRules.applicable | Boolean | Whether the rule is applicable |
+| needToApply | Boolean | Whether changes need to be applied |
 
 ---
 
 ### Add an access control rule
 
-```http
-POST /v1.0/db-instances/{dbInstanceId}/hba-rules
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2339,67 +2474,72 @@ POST /v1.0/db-instances/{dbInstanceId}/hba-rules
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| connectionTypeCode | Body | Enum | X | Access control record type<br/>- HOST: `Valid for TCP/IP connections`<br/>- HOST_NO_SSL: `Valid only for connections without SSL encryption` |
-| databaseApplyType | Body | Enum | O | Database apply type<br/>- ENTIRE: `All`<br/>- USER_CUSTOM: `Customize` |
-| dbUserApplyType | Body | Enum | O | DB user apply type<br/>- ENTIRE: `All`<br/>- USER_CUSTOM: `Customize` |
-| databaseIds | Body | Array | X | List of database identifiers |
-| dbUserIds | Body | Array | X | List of DB user identifiers |
-| address | Body | String | O | Connection address |
-| authMethod | Body | Enum | O | Authentication method<br/>- TRUST: `Trust (no password required)`<br/>- REJECT: `Block access`<br/>- SCRAM_SHA_256: `Password (SCRAM-SHA-256)` |
+```http
+POST /v1.0/db-instances/{dbInstanceId}/hba-rules
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "connectionTypeCode": "HOST",
-    "databaseApplyType": "ENTIRE",
-    "dbUserApplyType": "ENTIRE",
-    "databaseIds": [],
-    "dbUserIds": [],
-    "address": "address-example",
-    "authMethod": "TRUST"
+"connectionTypeCode": "HOST",
+"databaseApplyType": "ENTIRE",
+"dbUserApplyType": "ENTIRE",
+"databaseIds": [],
+"dbUserIds": [],
+"address": "address-example",
+"authMethod": "TRUST"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| connectionTypeCode | Enum | N | Access control record type<br/>- HOST: `Valid for TCP/IP connections`<br/>- HOST_NO_SSL: `Valid only for connections without SSL encryption` |
+| databaseApplyType | Enum | Y | Database apply type<br/>- ENTIRE: `All`<br/>- USER_CUSTOM: `Customize` |
+| dbUserApplyType | Enum | Y | DB user apply type<br/>- ENTIRE: `All`<br/>- USER_CUSTOM: `Customize` |
+| databaseIds | Array | N | List of database identifiers |
+| dbUserIds | Array | N | List of DB user identifiers |
+| address | String | Y | Connection address |
+| authMethod | Enum | Y | Authentication method<br/>- TRUST: `Trust (no password required)`<br/>- REJECT: `Block access`<br/>- SCRAM_SHA_256: `Password (SCRAM-SHA-256)` |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| hbaRuleId | Body | UUID | Identifier of the access control rule |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "hbaRuleId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"hbaRuleId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| hbaRuleId | UUID | Identifier of the access control rule |
 
 ---
 
 ### Apply access control rules
 
-```http
-POST /v1.0/db-instances/{dbInstanceId}/hba-rules/apply
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2407,44 +2547,47 @@ POST /v1.0/db-instances/{dbInstanceId}/hba-rules/apply
 
 #### Request
 
-This API does not require a request body.
+```http
+POST /v1.0/db-instances/{dbInstanceId}/hba-rules/apply
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of the requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Reorder access control rules
 
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/hba-rules/orders
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2452,22 +2595,32 @@ PUT /v1.0/db-instances/{dbInstanceId}/hba-rules/orders
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| hbaRuleIds | Body | Array | O | Sorted list of access control rule identifiers (saved in the order requested) |
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/hba-rules/orders
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "hbaRuleIds": []
+"hbaRuleIds": []
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| hbaRuleIds | Array | Y | Sorted list of access control rule identifiers (saved in the order requested) |
 
 #### Response
 
@@ -2477,11 +2630,7 @@ This API does not return a response body.
 
 ### Delete an access control rule
 
-```http
-DELETE /v1.0/db-instances/{dbInstanceId}/hba-rules/{hbaRuleId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2489,12 +2638,20 @@ DELETE /v1.0/db-instances/{dbInstanceId}/hba-rules/{hbaRuleId}
 
 #### Request
 
-This API does not require a request body.
+```http
+DELETE /v1.0/db-instances/{dbInstanceId}/hba-rules/{hbaRuleId}
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| hbaRuleId | URL | UUID | O | Identifier of the access control rule |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+| hbaRuleId | URL | UUID | Y | Identifier of the access control rule |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
@@ -2504,11 +2661,7 @@ This API does not return a response body.
 
 ### Modify an access control rule
 
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/hba-rules/{hbaRuleId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2516,48 +2669,55 @@ PUT /v1.0/db-instances/{dbInstanceId}/hba-rules/{hbaRuleId}
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| hbaRuleId | URL | UUID | O | Identifier of the access control rule |
-| connectionTypeCode | Body | Enum | X | Access control record type<br/>- HOST: `Valid for TCP/IP connections`<br/>- HOST_NO_SSL: `Valid only for connections without SSL encryption` |
-| databaseApplyType | Body | Enum | O | Database apply type<br/>- ENTIRE: `All`<br/>- USER_CUSTOM: `Customize` |
-| dbUserApplyType | Body | Enum | O | DB user apply type<br/>- ENTIRE: `All`<br/>- USER_CUSTOM: `Customize` |
-| databaseIds | Body | Array | X | List of database identifiers |
-| dbUserIds | Body | Array | X | List of DB user identifiers |
-| address | Body | String | O | Connection address |
-| authMethod | Body | Enum | O | Authentication method<br/>- TRUST: `Trust (no password required)`<br/>- REJECT: `Block access`<br/>- SCRAM_SHA_256: `Password (SCRAM-SHA-256)` |
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/hba-rules/{hbaRuleId}
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+| hbaRuleId | URL | UUID | Y | Identifier of the access control rule |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "connectionTypeCode": "HOST",
-    "databaseApplyType": "ENTIRE",
-    "dbUserApplyType": "ENTIRE",
-    "databaseIds": [],
-    "dbUserIds": [],
-    "address": "address-example",
-    "authMethod": "TRUST"
+"connectionTypeCode": "HOST",
+"databaseApplyType": "ENTIRE",
+"dbUserApplyType": "ENTIRE",
+"databaseIds": [],
+"dbUserIds": [],
+"address": "address-example",
+"authMethod": "TRUST"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| connectionTypeCode | Enum | N | Access control record type<br/>- HOST: `Valid for TCP/IP connections`<br/>- HOST_NO_SSL: `Valid only for connections without SSL encryption` |
+| databaseApplyType | Enum | Y | Database apply type<br/>- ENTIRE: `All`<br/>- USER_CUSTOM: `Customize` |
+| dbUserApplyType | Enum | Y | DB user apply type<br/>- ENTIRE: `All`<br/>- USER_CUSTOM: `Customize` |
+| databaseIds | Array | N | List of database identifiers |
+| dbUserIds | Array | N | List of DB user identifiers |
+| address | String | Y | Connection address |
+| authMethod | Enum | Y | Authentication method<br/>- TRUST: `Trust (no password required)`<br/>- REJECT: `Block access`<br/>- SCRAM_SHA_256: `Password (SCRAM-SHA-256)` |
 
 #### Response
 
 This API does not return a response body.
 
 ---
+
 ### Get high availability information
 
-```http
-GET /v1.0/db-instances/{dbInstanceId}/high-availability
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2565,48 +2725,51 @@ GET /v1.0/db-instances/{dbInstanceId}/high-availability
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v1.0/db-instances/{dbInstanceId}/high-availability
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| haStatus | Body | Enum | High availability status<br/>- CREATED: `Created`<br/>- STABLE: `Normal`<br/>- PAUSING: `Pausing`<br/>- DISABLE: `Stopped`<br/>- DISABLE_MASTER_IN_REPLICATION: `High availability stopped due to abnormal master replication detected`<br/>- DISABLE_MHA_PROCESS: `High availability process stopped`<br/>- DISABLE_REPLICATION_STOP: `High availability stopped due to replication stop`<br/>- DISABLE_REPLICATION_DELAY: `High availability stopped due to replication delay`<br/>- FAILOVER_STARTED: `Failover started`<br/>- FAILOVER_FAILED: `Failover failed`<br/>- FAILOVER_COMPLETED: `Failover completed`<br/>- DELETED: `Deleted`<br/>- PAUSED: `Paused`<br/>- PAUSED_DUE_TO_TASK: `Paused due to task`<br/>- MASTER_FAILURE_DETECTION: `Master failure detected` |
-| pingInterval | Body | Number | Ping interval (sec) when using high availability |
-| failoverReplWaitingTime | Body | Number | Failover replication delay waiting time (sec) when using high availability |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "haStatus": "CREATED",
-    "pingInterval": 1,
-    "failoverReplWaitingTime": 1
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"haStatus": "CREATED",
+"pingInterval": 1,
+"failoverReplWaitingTime": 1
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| haStatus | Enum | High availability status<br/>- CREATED: `Created`<br/>- STABLE: `Normal`<br/>- PAUSING: `Pausing`<br/>- DISABLE: `Stopped`<br/>- DISABLE_MASTER_IN_REPLICATION: `High availability stopped due to abnormal master replication detected`<br/>- DISABLE_MHA_PROCESS: `High availability process stopped`<br/>- DISABLE_REPLICATION_STOP: `High availability stopped due to replication stop`<br/>- DISABLE_REPLICATION_DELAY: `High availability stopped due to replication delay`<br/>- FAILOVER_STARTED: `Failover started`<br/>- FAILOVER_FAILED: `Failover failed`<br/>- FAILOVER_COMPLETED: `Failover completed`<br/>- DELETED: `Deleted`<br/>- PAUSED: `Paused`<br/>- PAUSED_DUE_TO_TASK: `Paused due to task`<br/>- MASTER_FAILURE_DETECTION: `Master failure detected` |
+| pingInterval | Number | Ping interval (sec) when using high availability |
+| failoverReplWaitingTime | Number | Failover replication delay waiting time (sec) when using high availability |
 
 ---
 
 ### Modify High Availability
 
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/high-availability
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2614,59 +2777,64 @@ PUT /v1.0/db-instances/{dbInstanceId}/high-availability
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| useHighAvailability | Body | Boolean | O | Whether to use high availability |
-| pingInterval | Body | Number | X | Ping interval (sec)<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
-| failoverReplWaitingTime | Body | Number | X | Failover replication delay waiting time (sec)<br/>- Minimum value: `-1` |
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/high-availability
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "useHighAvailability": false,
-    "pingInterval": 1,
-    "failoverReplWaitingTime": 1
+"useHighAvailability": false,
+"pingInterval": 1,
+"failoverReplWaitingTime": 1
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| useHighAvailability | Boolean | Y | Whether to use high availability |
+| pingInterval | Number | N | Ping interval (seconds)<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
+| failoverReplWaitingTime | Number | N | Failover replication delay waiting time (seconds)<br/>- Minimum value: `-1` |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Pause High Availability
 
-```http
-POST /v1.0/db-instances/{dbInstanceId}/high-availability/pause
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2674,44 +2842,47 @@ POST /v1.0/db-instances/{dbInstanceId}/high-availability/pause
 
 #### Request
 
-This API does not require a request body.
+```http
+POST /v1.0/db-instances/{dbInstanceId}/high-availability/pause
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Recover High Availability
 
-```http
-POST /v1.0/db-instances/{dbInstanceId}/high-availability/repair
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2719,44 +2890,47 @@ POST /v1.0/db-instances/{dbInstanceId}/high-availability/repair
 
 #### Request
 
-This API does not require a request body.
+```http
+POST /v1.0/db-instances/{dbInstanceId}/high-availability/repair
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Restart High Availability
 
-```http
-POST /v1.0/db-instances/{dbInstanceId}/high-availability/resume
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2764,44 +2938,47 @@ POST /v1.0/db-instances/{dbInstanceId}/high-availability/resume
 
 #### Request
 
-This API does not require a request body.
+```http
+POST /v1.0/db-instances/{dbInstanceId}/high-availability/resume
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Separate High Availability
 
-```http
-POST /v1.0/db-instances/{dbInstanceId}/high-availability/split
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2809,43 +2986,47 @@ POST /v1.0/db-instances/{dbInstanceId}/high-availability/split
 
 #### Request
 
-This API does not require a request body.
+```http
+POST /v1.0/db-instances/{dbInstanceId}/high-availability/split
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
+
 ---
+
 ### Get DB instance maintenance information
 
-```http
-GET /v1.0/db-instances/{dbInstanceId}/maintenance-info
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2853,52 +3034,55 @@ GET /v1.0/db-instances/{dbInstanceId}/maintenance-info
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v1.0/db-instances/{dbInstanceId}/maintenance-info
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| allowAutoMaintenance | Body | Boolean | Whether to allow automatic maintenance |
-| useAutoStorageCleanup | Body | Boolean | Whether to enable automatic storage cleanup |
-| maintWndBgnTime | Body | Time | Automatic maintenance start time |
-| maintWndDuration | Body | Enum | Maintenance window<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1 hour 30 minutes`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2 hours 30 minutes`<br/>- THREE_HOURS: `3 hours` |
-| logRetentionPeriod | Body | Number | Log retention period (days) |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "allowAutoMaintenance": false,
-    "useAutoStorageCleanup": false,
-    "maintWndBgnTime": "00:00:00",
-    "maintWndDuration": "HALF_AN_HOUR",
-    "logRetentionPeriod": 1
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"allowAutoMaintenance": false,
+"useAutoStorageCleanup": false,
+"maintWndBgnTime": "00:00:00",
+"maintWndDuration": "HALF_AN_HOUR",
+"logRetentionPeriod": 1
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| allowAutoMaintenance | Boolean | Whether to allow automatic maintenance |
+| useAutoStorageCleanup | Boolean | Whether to enable automatic storage cleanup |
+| maintWndBgnTime | Time | Automatic maintenance start time |
+| maintWndDuration | Enum | Maintenance window<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1 hour 30 minutes`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2 hours 30 minutes`<br/>- THREE_HOURS: `3 hours` |
+| logRetentionPeriod | Number | Log retention period (days) |
 
 ---
 
 ### Modify DB instance maintenance information
 
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/maintenance-info
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2906,62 +3090,68 @@ PUT /v1.0/db-instances/{dbInstanceId}/maintenance-info
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| allowAutoMaintenance | Body | Boolean | X | Whether to allow automatic maintenance |
-| useAutoStorageCleanup | Body | Boolean | X | Whether to enable automatic storage cleanup |
-| maintWndBgnTime | Body | Time | X | Automatic maintenance start time |
-| maintWndDuration | Body | Enum | X | Maintenance window<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1 hour 30 minutes`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2 hours 30 minutes`<br/>- THREE_HOURS: `3 hours` |
-| logRetentionPeriod | Body | Number | X | Log retention period (days)<br/>- Minimum: `1`<br/>- Maximum: `30` |
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/maintenance-info
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "allowAutoMaintenance": false,
-    "useAutoStorageCleanup": false,
-    "maintWndBgnTime": "00:00:00",
-    "maintWndDuration": "HALF_AN_HOUR",
-    "logRetentionPeriod": 1
+"allowAutoMaintenance": false,
+"useAutoStorageCleanup": false,
+"maintWndBgnTime": "00:00:00",
+"maintWndDuration": "HALF_AN_HOUR",
+"logRetentionPeriod": 1
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| allowAutoMaintenance | Boolean | N | Whether to allow automatic maintenance |
+| useAutoStorageCleanup | Boolean | N | Whether to enable automatic storage cleanup |
+| maintWndBgnTime | Time | N | Automatic maintenance start time |
+| maintWndDuration | Enum | N | Maintenance window<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1 hour 30 minutes`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2 hours 30 minutes`<br/>- THREE_HOURS: `3 hours` |
+| logRetentionPeriod | Number | N | Log retention period (days)<br/>- Minimum: `1`<br/>- Maximum: `30` |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
+
 ---
+
 ### Get DB instance network information
 
-```http
-GET /v1.0/db-instances/{dbInstanceId}/network-info
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2969,66 +3159,69 @@ GET /v1.0/db-instances/{dbInstanceId}/network-info
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v1.0/db-instances/{dbInstanceId}/network-info
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| availabilityZone | Body | Enum | Availability zone where DB instance will be created |
-| subnet | Body | Object | Subnet object |
-| subnet.subnetId | Body | UUID | Subnet identifier |
-| subnet.subnetName | Body | String | Name to identify subnets |
-| subnet.subnetCidr | Body | String | CIDR of subnet |
-| subnet.publicAccessible | Body | Boolean | External access is available or not |
-| endPoints | Body | Array | List of access information |
-| endPoints.domain | Body | String | Domain |
-| endPoints.ipAddress | Body | String | IP address |
-| endPoints.endPointType | Body | String | Types of access information |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "availabilityZone": "kr-pub-a",
-    "subnet": {
-        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
-        "subnetName": "subnetName-example",
-        "subnetCidr": "192.168.0.0/24",
-        "publicAccessible": false
-    },
-    "endPoints": [
-        {
-            "domain": "domain-example",
-            "ipAddress": "192.168.0.1",
-            "endPointType": "https://example.com"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"availabilityZone": "kr-pub-a",
+"subnet": {
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"subnetName": "subnetName-example",
+"subnetCidr": "192.168.0.0/24",
+"publicAccessible": false
+},
+"endPoints": [
+{
+"domain": "domain-example",
+"ipAddress": "192.168.0.1",
+"endPointType": "https://example.com"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| availabilityZone | Enum | Availability zone where DB instance will be created |
+| subnet | Object | Subnet object |
+| subnet.subnetId | UUID | Subnet identifier |
+| subnet.subnetName | String | Name to identify subnets |
+| subnet.subnetCidr | String | CIDR of subnet |
+| subnet.publicAccessible | Boolean | External access is available or not |
+| endPoints | Array | List of access information |
+| endPoints.domain | String | Domain |
+| endPoints.ipAddress | String | IP address |
+| endPoints.endPointType | String | Types of access information |
 
 ---
 
 ### Modify DB instance network information
 
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/network-info
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -3036,55 +3229,60 @@ PUT /v1.0/db-instances/{dbInstanceId}/network-info
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| usePublicAccess | Body | Boolean | O | External access is available or not |
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/network-info
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "usePublicAccess": false
+"usePublicAccess": false
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| usePublicAccess | Boolean | Y | External access is available or not |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Promote DB Instance
 
-```http
-POST /v1.0/db-instances/{dbInstanceId}/promote
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -3092,43 +3290,47 @@ POST /v1.0/db-instances/{dbInstanceId}/promote
 
 #### Request
 
-This API does not require a request body.
+```http
+POST /v1.0/db-instances/{dbInstanceId}/promote
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
+
 ---
+
 ### Create Read Replica
 
-```http
-POST /v1.0/db-instances/{dbInstanceId}/replicate
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -3136,85 +3338,90 @@ POST /v1.0/db-instances/{dbInstanceId}/replicate
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| dbInstanceName | Body | String | O | Name to identify the DB instance |
-| description | Body | String | X | Additional information on the DB instance |
-| dbFlavorId | Body | UUID | X | Identifier of DB instance specifications |
-| dbPort | Body | Number | X | DB port<br/>- Minimum value: 5432, Maximum value: 45432 |
-| parameterGroupId | Body | UUID | X | Parameter group identifier |
-| dbSecurityGroupIds | Body | Array | X | List of DB security group identifiers |
-| userGroupIds | Body | Array | X | List of user group identifiers |
-| useDefaultNotification | Body | Boolean | X | Whether to use default notification<br/>- Default: `false` |
-| useDeletionProtection | Body | Boolean | X | Whether deletion protection is enabled<br/>- Default: `false` |
-| network | Body | Object | X | Network information object |
-| network.usePublicAccess | Body | Boolean | X | Whether external access is available<br/>- Default: `false` |
-| network.availabilityZone | Body | Enum | X | Availability zone where the DB instance will be created |
-| storage | Body | Object | X | Storage information object |
-| storage.storageType | Body | Enum | X | Data storage type |
-| storage.storageSize | Body | Number | X | Data storage size (GB)<br/>- Minimum value: `20`<br/>- Maximum value: `2048` |
+```http
+POST /v1.0/db-instances/{dbInstanceId}/replicate
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "dbInstanceName": "dbInstanceName-example",
-    "description": "description-example",
-    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbPort": 1,
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbSecurityGroupIds": [],
-    "userGroupIds": [],
-    "useDefaultNotification": false,
-    "useDeletionProtection": false,
-    "network": {
-        "usePublicAccess": false,
-        "availabilityZone": "kr-pub-a"
-    },
-    "storage": {
-        "storageType": "General SSD",
-        "storageSize": 20
-    }
+"dbInstanceName": "dbInstanceName-example",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbPort": 1,
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useDefaultNotification": false,
+"useDeletionProtection": false,
+"network": {
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
+},
+"storage": {
+"storageType": "General SSD",
+"storageSize": 20
+}
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | Name to identify DB instances |
+| description | String | N | Additional information on DB instances |
+| dbFlavorId | UUID | N | Identifier of DB instance specifications |
+| dbPort | Number | N | DB port<br/>- Minimum value: 5432, Maximum value: 45432 |
+| parameterGroupId | UUID | N | Parameter group identifier |
+| dbSecurityGroupIds | Array | N | List of DB security group identifiers |
+| userGroupIds | Array | N | List of user group identifiers |
+| useDefaultNotification | Boolean | N | Whether to use default notification<br/>- Default: `false` |
+| useDeletionProtection | Boolean | N | Whether to use deletion protection<br/>- Default: `false` |
+| network | Object | N | Network information objects |
+| network.usePublicAccess | Boolean | N | Whether external access is available<br/>- Default: `false` |
+| network.availabilityZone | Enum | N | Availability zone where DB instance will be created |
+| storage | Object | N | Storage information objects |
+| storage.storageType | Enum | N | Data storage types |
+| storage.storageSize | Number | N | Data storage size (GB)<br/>- Minimum value: `20`<br/>- Maximum value: `2048` |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of the requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Restart DB Instance
 
-```http
-POST /v1.0/db-instances/{dbInstanceId}/restart
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -3222,44 +3429,47 @@ POST /v1.0/db-instances/{dbInstanceId}/restart
 
 #### Request
 
-This API does not require a request body.
+```http
+POST /v1.0/db-instances/{dbInstanceId}/restart
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of the requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Get DB Instance Restore Information
 
-```http
-GET /v1.0/db-instances/{dbInstanceId}/restoration-info
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -3267,79 +3477,82 @@ GET /v1.0/db-instances/{dbInstanceId}/restoration-info
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v1.0/db-instances/{dbInstanceId}/restoration-info
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| oldestRestorableYmdt | Body | DateTime | Oldest restorable time |
-| latestRestorableYmdt | Body | DateTime | Most recent restorable time |
-| restorableBackups | Body | Array | List of restorable backups |
-| restorableBackups.backupId | Body | UUID | Backup identifier |
-| restorableBackups.backupName | Body | String | Backup name |
-| restorableBackups.backupStatus | Body | Enum | Backup status<br/>- BACKING_UP: `Backing up (spinner)`<br/>- VERIFYING: `Verifying (spinner)`<br/>- COMPLETED: `Available (green icon)`<br/>- DELETING: `Deleting (spinner)`<br/>- DELETED: `Deleted (gray icon)`<br/>- ERROR: `Error (red icon)` |
-| restorableBackups.dbInstanceId | Body | UUID | Original DB instance identifier |
-| restorableBackups.dbInstanceName | Body | String | Original DB instance name |
-| restorableBackups.dbVersion | Body | Enum | DB engine type |
-| restorableBackups.backupType | Body | Enum | Backup type<br/>- AUTO<br/>- MANUAL |
-| restorableBackups.backupSize | Body | Number | Backup size |
-| restorableBackups.failoverCount | Body | Number | Number of failovers |
-| restorableBackups.walFileName | Body | String | WAL file name |
-| restorableBackups.createdYmdt | Body | DateTime | Backup creation date and time |
-| restorableBackups.updatedYmdt | Body | DateTime | Backup update date and time |
-| restorableBackups.startYmdt | Body | DateTime | Backup start date and time |
-| restorableBackups.completedYmdt | Body | DateTime | Backup completion date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "oldestRestorableYmdt": "2023-12-31T15:00:00+09:00",
-    "latestRestorableYmdt": "2023-12-31T15:00:00+09:00",
-    "restorableBackups": [
-        {
-            "backupId": "550e8400-e29b-41d4-a716-446655440000",
-            "backupName": "backupName-example",
-            "backupStatus": "BACKING_UP",
-            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbInstanceName": "dbInstanceName-example",
-            "dbVersion": "POSTGRESQL_V14_17",
-            "backupType": "AUTO",
-            "backupSize": 1,
-            "failoverCount": 1,
-            "walFileName": "walFileName-example",
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00",
-            "startYmdt": "2023-12-31T15:00:00+09:00",
-            "completedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"oldestRestorableYmdt": "2023-12-31T15:00:00+09:00",
+"latestRestorableYmdt": "2023-12-31T15:00:00+09:00",
+"restorableBackups": [
+{
+"backupId": "550e8400-e29b-41d4-a716-446655440000",
+"backupName": "backupName-example",
+"backupStatus": "BACKING_UP",
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceName": "dbInstanceName-example",
+"dbVersion": "POSTGRESQL_V14_17",
+"backupType": "AUTO",
+"backupSize": 1,
+"failoverCount": 1,
+"walFileName": "walFileName-example",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00",
+"startYmdt": "2023-12-31T15:00:00+09:00",
+"completedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| oldestRestorableYmdt | DateTime | Oldest restorable time |
+| latestRestorableYmdt | DateTime | Most recent restorable time |
+| restorableBackups | Array | List of restorable backups |
+| restorableBackups.backupId | UUID | Backup identifier |
+| restorableBackups.backupName | String | Backup name |
+| restorableBackups.backupStatus | Enum | Backup status<br/>- BACKING_UP: `Backing up (spinner)`<br/>- VERIFYING: `Verifying (spinner)`<br/>- COMPLETED: `Available (green icon)`<br/>- DELETING: `Deleting (spinner)`<br/>- DELETED: `Deleted (gray icon)`<br/>- ERROR: `Error (red icon)` |
+| restorableBackups.dbInstanceId | UUID | Original DB instance identifier |
+| restorableBackups.dbInstanceName | String | Original DB instance name |
+| restorableBackups.dbVersion | String | DB engine type |
+| restorableBackups.backupType | Enum | Backup type<br/>- AUTO<br/>- MANUAL |
+| restorableBackups.backupSize | Number | Backup size |
+| restorableBackups.failoverCount | Number | Number of failovers |
+| restorableBackups.walFileName | String | WAL file name |
+| restorableBackups.createdYmdt | DateTime | Backup creation date and time |
+| restorableBackups.updatedYmdt | DateTime | Backup update date and time |
+| restorableBackups.startYmdt | DateTime | Backup start date and time |
+| restorableBackups.completedYmdt | DateTime | Backup completion date and time |
 
 ---
 
 ### Restore DB Instance
 
-```http
-POST /v1.0/db-instances/{dbInstanceId}/restore
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -3347,123 +3560,129 @@ POST /v1.0/db-instances/{dbInstanceId}/restore
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| dbInstanceName | Body | String | X | Name to identify the DB instance |
-| dbInstanceCandidateName | Body | String | X | Candidate master name to identify the DB instance |
-| description | Body | String | X | Additional information on the DB instance<br/>- Maximum length: `100` |
-| dbFlavorId | Body | UUID | O | Identifier of DB instance specifications |
-| dbPort | Body | Number | X | DB port<br/>- Minimum value: 5432, Maximum value: 45432 |
-| useHighAvailability | Body | Boolean | X | Whether to use high availability<br/>- Default: `false` |
-| imageId | Body | UUID | X | Image identifier |
-| pingInterval | Body | Number | X | Ping interval (sec) when using high availability<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
-| failoverReplWaitingTime | Body | Number | X | Failover replication delay wait time (sec)<br/>- Minimum value: `-1` |
-| storage | Body | Object | O | Storage information object |
-| storage.storageType | Body | Enum | O | Storage type |
-| storage.storageSize | Body | Number | O | Data storage size (GB)<br/>- Minimum value: `20` |
-| network | Body | Object | O | Network information object |
-| network.subnetId | Body | UUID | O | Subnet identifier |
-| network.usePublicAccess | Body | Boolean | X | Whether external access is available<br/>- Default: `false` |
-| network.availabilityZone | Body | Enum | X | Availability zone where the DB instance will be created |
-| backup | Body | Object | O | Backup information object |
-| backup.backupPeriod | Body | Number | O | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
-| backup.backupRetryCount | Body | Number | X | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
-| backup.replicationRegion | Body | Enum | X | Backup replication region<br/>- KR1: `Korea (Pangyo)`<br/>- KR2: `Korea (Pyeongchon)` |
-| backup.backupSchedules | Body | Array | O | Backup schedule list |
-| backup.backupSchedules.backupWndBgnTime | Body | Time | O | Backup start time |
-| backup.backupSchedules.backupWndDuration | Body | Enum | O | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1 hour 30 minutes`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2 hours 30 minutes`<br/>- THREE_HOURS: `3 hours` |
-| restore | Body | Object | O | Restoration information object |
-| restore.restoreType | Body | Enum | O | Restoration type<br/>- BACKUP: `Restoration using a previously created backup`<br/>- TIMESTAMP: `Point-in-time recovery using a time within the restorable period` |
-| restore.restoreYmdt | Body | DateTime | X | DB instance restore date and time |
-| restore.backupId | Body | UUID | X | Identifier of the backup to use for restoration |
-| useDefaultNotification | Body | Boolean | X | Whether to use default notification<br/>- Default: `false` |
-| parameterGroupId | Body | UUID | O | Parameter group identifier |
-| dbSecurityGroupIds | Body | Array | X | List of DB security group identifiers |
-| userGroupIds | Body | Array | X | List of user group identifiers |
-| useDeletionProtection | Body | Boolean | X | Whether deletion protection is enabled<br/>- Default: `false` |
+```http
+POST /v1.0/db-instances/{dbInstanceId}/restore
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "dbInstanceName": "dbInstanceName-example",
-    "dbInstanceCandidateName": "dbInstanceCandidateName-example",
-    "description": "description-example",
-    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbPort": 1,
-    "useHighAvailability": false,
-    "imageId": "550e8400-e29b-41d4-a716-446655440000",
-    "pingInterval": 3,
-    "failoverReplWaitingTime": 60,
-    "storage": {
-        "storageType": "General SSD",
-        "storageSize": 20
-    },
-    "network": {
-        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
-        "usePublicAccess": false,
-        "availabilityZone": "kr-pub-a"
-    },
-    "backup": {
-        "backupPeriod": 0,
-        "backupRetryCount": 0,
-        "replicationRegion": "KR1",
-        "backupSchedules": [
-            {
-                "backupWndBgnTime": "00:00:00",
-                "backupWndDuration": "HALF_AN_HOUR"
-            }
-        ]
-    },
-    "restore": {
-        "restoreType": "BACKUP",
-        "restoreYmdt": "2023-12-31T15:00:00+09:00",
-        "backupId": "550e8400-e29b-41d4-a716-446655440000"
-    },
-    "useDefaultNotification": false,
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbSecurityGroupIds": [],
-    "userGroupIds": [],
-    "useDeletionProtection": false
+"dbInstanceName": "dbInstanceName-example",
+"dbInstanceCandidateName": "dbInstanceCandidateName-example",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbPort": 1,
+"useHighAvailability": false,
+"imageId": "550e8400-e29b-41d4-a716-446655440000",
+"pingInterval": 3,
+"failoverReplWaitingTime": 60,
+"storage": {
+"storageType": "General SSD",
+"storageSize": 20
+},
+"network": {
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
+},
+"backup": {
+"backupPeriod": 0,
+"backupRetryCount": 0,
+"replicationRegion": "KR1",
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
+},
+"restore": {
+"restoreType": "BACKUP",
+"restoreYmdt": "2023-12-31T15:00:00+09:00",
+"backupId": "550e8400-e29b-41d4-a716-446655440000"
+},
+"useDefaultNotification": false,
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useDeletionProtection": false
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbInstanceName | String | N | Name to identify DB instances |
+| dbInstanceCandidateName | String | N | Candidate master name to identify the DB instance |
+| description | String | N | Additional information on the DB instance<br/>- Maximum length: `100` |
+| dbFlavorId | UUID | Y | Identifier of DB instance specifications |
+| dbPort | Number | N | DB port<br/>- Minimum value: 5432, Maximum value: 45432 |
+| useHighAvailability | Boolean | N | Whether to use high availability<br/>- Default: `false` |
+| imageId | UUID | N | Image identifier |
+| pingInterval | Number | N | Ping interval (sec) when using high availability<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
+| failoverReplWaitingTime | Number | N | Failover replication delay waiting time (seconds)<br/>- Minimum value: `-1` |
+| storage | Object | Y | Storage information objects |
+| storage.storageType | Enum | Y | Storage type |
+| storage.storageSize | Number | Y | Data storage size (GB)<br/>- Minimum value: `20` |
+| network | Object | Y | Network information objects |
+| network.subnetId | UUID | Y | Subnet identifier |
+| network.usePublicAccess | Boolean | N | Whether external access is available<br/>- Default: `false` |
+| network.availabilityZone | Enum | N | Availability zone where DB instance will be created |
+| backup | Object | Y | Backup information objects |
+| backup.backupPeriod | Number | Y | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| backup.backupRetryCount | Number | N | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| backup.replicationRegion | Enum | N | Backup replication region<br/>- KR1: `Korea (Pangyo)`<br/>- KR2: `Korea (Pyeongchon)` |
+| backup.backupSchedules | Array | Y | Backup schedules |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | Backup start time |
+| backup.backupSchedules.backupWndDuration | Enum | Y | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hours`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2.5 hours`<br/>- THREE_HOURS: `3 hours` |
+| restore | Object | Y | Restoration information object |
+| restore.restoreType | Enum | Y | Restoration type<br/>- BACKUP: `Restoration using a previously created backup`<br/>- TIMESTAMP: `Point-in-time recovery using a time within the restorable period` |
+| restore.restoreYmdt | DateTime | N | DB instance restore date and time |
+| restore.backupId | UUID | N | Identifier of the backup to use for restoration |
+| useDefaultNotification | Boolean | N | Whether to use default notification<br/>- Default: `false` |
+| parameterGroupId | UUID | Y | Parameter group identifier |
+| dbSecurityGroupIds | Array | N | List of DB security group identifiers |
+| userGroupIds | Array | N | List of user group identifiers |
+| useDeletionProtection | Boolean | N | Whether to use deletion protection<br/>- Default: `false` |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of the requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
+
 ---
+
 ### Start DB Instance
 
-```http
-POST /v1.0/db-instances/{dbInstanceId}/start
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -3471,44 +3690,47 @@ POST /v1.0/db-instances/{dbInstanceId}/start
 
 #### Request
 
-This API does not require a request body.
+```http
+POST /v1.0/db-instances/{dbInstanceId}/start
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Stop DB Instance
 
-```http
-POST /v1.0/db-instances/{dbInstanceId}/stop
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -3516,44 +3738,47 @@ POST /v1.0/db-instances/{dbInstanceId}/stop
 
 #### Request
 
-This API does not require a request body.
+```http
+POST /v1.0/db-instances/{dbInstanceId}/stop
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Get DB Instance Storage Information
 
-```http
-GET /v1.0/db-instances/{dbInstanceId}/storage-info
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -3561,48 +3786,51 @@ GET /v1.0/db-instances/{dbInstanceId}/storage-info
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v1.0/db-instances/{dbInstanceId}/storage-info
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| storageType | Body | Enum | Data storage types |
-| storageSize | Body | Number | Data storage size (GB) |
-| storageStatus | Body | Enum | Data storage current status<br/>- DELETED: `Deleted`<br/>- PENDING_DELETION: `Deletion deferred`<br/>- DELETION_RESERVED: `Deletion reserved (pending snapshot cleanup)`<br/>- DETACHED: `Detached`<br/>- ATTACHED: `Attached` |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "storageType": "General SSD",
-    "storageSize": 1,
-    "storageStatus": "DELETED"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"storageType": "General SSD",
+"storageSize": 1,
+"storageStatus": "DELETED"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| storageType | Enum | Data storage types |
+| storageSize | Number | Data storage size (GB) |
+| storageStatus | Enum | Data storage current status<br/>- DELETED: `Deleted`<br/>- PENDING_DELETION: `Deletion deferred`<br/>- DELETION_RESERVED: `Deletion reserved (pending snapshot cleanup)`<br/>- DETACHED: `Detached`<br/>- ATTACHED: `Attached` |
 
 ---
 
 ### Modify DB Instance Storage Information
 
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/storage-info
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -3610,66 +3838,72 @@ PUT /v1.0/db-instances/{dbInstanceId}/storage-info
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| storageSize | Body | Number | O | Data storage size (GB)<br/>- Maximum value: `2048` |
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/storage-info
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "storageSize": 1
+"storageSize": 1
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| storageSize | Number | Y | Data storage size (GB)<br/>- Maximum value: `2048` |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
+
 ---
+
 ## Backup
 
 ### Backup Status
 
-| Status         | Description                  |
-|--------------|------------------------------|
-| `BACKING_UP` | Backup in progress           |
-| `COMPLETED`  | Backup completed             |
-| `DELETING`   | Backup being deleted         |
-| `DELETED`    | Backup deleted               |
-| `ERROR`      | Error occurred               |
+| Status | Description |
+|--------------|--------------|
+| `BACKING_UP` | Backup in progress |
+| `COMPLETED` | Backup completed |
+| `DELETING` | Backup being deleted |
+| `DELETED` | Backup deleted |
+| `ERROR` | Error occurred |
 
 ### Retrieve Backup List
 
-```http
-GET /v1.0/backups
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -3677,67 +3911,68 @@ GET /v1.0/backups
 
 #### Request
 
+```http
+GET /v1.0/backups
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | Number of all backup lists |
-| backups | Body | Array | Backup list |
-| backups.backupId | Body | UUID | Backup identifier |
-| backups.backupName | Body | String | Name to identify backups |
-| backups.backupStatus | Body | Enum | Backup current status<br/>- BACKING_UP: `Backup in progress (spinner)`<br/>- VERIFYING: `Verifying (spinner)`<br/>- COMPLETED: `Available (green icon)`<br/>- DELETING: `Deleting (spinner)`<br/>- DELETED: `Deleted (gray icon)`<br/>- ERROR: `Error (red icon)` |
-| backups.dbInstanceId | Body | UUID | Original DB instance identifier |
-| backups.dbVersion | Body | Enum | DB engine version |
-| backups.backupType | Body | Enum | Backup type<br/>- AUTO<br/>- MANUAL |
-| backups.backupSize | Body | Number | Size of the backup (Bytes) |
-| backups.startYmdt | Body | DateTime | Start date and time |
-| backups.createdYmdt | Body | DateTime | Created date and time |
-| backups.updatedYmdt | Body | DateTime | Modified date and time |
-| backups.completedYmdt | Body | DateTime | End date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 1,
-    "backups": [
-        {
-            "backupId": "550e8400-e29b-41d4-a716-446655440000",
-            "backupName": "backupName-example",
-            "backupStatus": "BACKING_UP",
-            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbVersion": "POSTGRESQL_V14_17",
-            "backupType": "AUTO",
-            "backupSize": 1,
-            "startYmdt": "2023-12-31T15:00:00+09:00",
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00",
-            "completedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"totalCounts": 1,
+"backups": [
+{
+"backupId": "550e8400-e29b-41d4-a716-446655440000",
+"backupName": "backupName-example",
+"backupStatus": "BACKING_UP",
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbVersion": "POSTGRESQL_V14_17",
+"backupType": "AUTO",
+"backupSize": 1,
+"startYmdt": "2023-12-31T15:00:00+09:00",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00",
+"completedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| totalCounts | Number | Number of all backup lists |
+| backups | Array | Backup list |
+| backups.backupId | UUID | Backup identifier |
+| backups.backupName | String | Name to identify backups |
+| backups.backupStatus | Enum | Backup current status<br/>- BACKING_UP: `Backup in progress (spinner)`<br/>- VERIFYING: `Verifying (spinner)`<br/>- COMPLETED: `Available (green icon)`<br/>- DELETING: `Deleting (spinner)`<br/>- DELETED: `Deleted (gray icon)`<br/>- ERROR: `Error (red icon)` |
+| backups.dbInstanceId | UUID | Original DB instance identifier |
+| backups.dbVersion | String | DB version information |
+| backups.backupType | Enum | Backup type<br/>- AUTO<br/>- MANUAL |
+| backups.backupSize | Number | Size of the backup (Bytes) |
+| backups.startYmdt | DateTime | Start date and time |
+| backups.createdYmdt | DateTime | Created date and time |
+| backups.updatedYmdt | DateTime | Modified date and time |
+| backups.completedYmdt | DateTime | End date and time |
 
 ---
 
 ### Delete Backup
 
-```http
-DELETE /v1.0/backups/{backupId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -3745,44 +3980,47 @@ DELETE /v1.0/backups/{backupId}
 
 #### Request
 
-This API does not require a request body.
+```http
+DELETE /v1.0/backups/{backupId}
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| backupId | URL | UUID | O | Backup identifier |
+| backupId | URL | UUID | Y | Backup identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Export Backup to Object Storage
 
-```http
-POST /v1.0/backups/{backupId}/export
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -3790,63 +4028,68 @@ POST /v1.0/backups/{backupId}/export
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| backupId | URL | UUID | O | Backup identifier |
-| tenantId | Body | String | O | Tenant ID of object storage where backup will be stored<br/>- Minimum length: `32`<br/>- Maximum length: `32` |
-| username | Body | String | O | NHN Cloud account or IAM member ID |
-| password | Body | String | O | API password for object storage where backup will be stored |
-| targetContainer | Body | String | O | Object storage container where backup will be stored |
-| objectPath | Body | String | O | Path of the backup to be stored in the container |
+```http
+POST /v1.0/backups/{backupId}/export
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | Y | Backup identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "tenantId": "0123456789abcdef0123456789abcdef",
-    "username": "username-example",
-    "password": "password-example",
-    "targetContainer": "targetContainer-example",
-    "objectPath": "objectPath-example"
+"tenantId": "0123456789abcdef0123456789abcdef",
+"username": "username-example",
+"password": "password-example",
+"targetContainer": "targetContainer-example",
+"objectPath": "objectPath-example"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| tenantId | String | Y | Tenant ID of object storage where backup will be stored<br/>- Minimum length: `32`<br/>- Maximum length: `32` |
+| username | String | Y | NHN Cloud account or IAM member ID |
+| password | String | Y | API password for object storage where backup will be stored |
+| targetContainer | String | Y | Object storage container where backup will be stored |
+| objectPath | String | Y | Path of the backup to be stored in the container |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Restore Backup
 
-```http
-POST /v1.0/backups/{backupId}/restore
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -3854,270 +4097,285 @@ POST /v1.0/backups/{backupId}/restore
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| backupId | URL | UUID | O | Backup identifier |
-| dbInstanceName | Body | String | O | Name to identify DB instances |
-| dbInstanceCandidateName | Body | String | X | Candidate master name to identify the DB instance |
-| description | Body | String | X | Additional information on DB instances |
-| dbFlavorId | Body | UUID | O | Identifier of DB instance specifications |
-| dbPort | Body | Number | O | DB port<br/>- Minimum value: 5432, Maximum value: 45432 |
-| parameterGroupId | Body | UUID | O | Parameter group identifier |
-| dbSecurityGroupIds | Body | Array | X | List of DB security group identifiers |
-| userGroupIds | Body | Array | X | List of user group identifiers |
-| useHighAvailability | Body | Boolean | X | Whether to use high availability<br/>- Default: `false` |
-| useDefaultNotification | Body | Boolean | X | Whether to use default notification<br/>- Default: `false` |
-| useDeletionProtection | Body | Boolean | X | Whether to use deletion protection<br/>- Default: `false` |
-| pingInterval | Body | Number | X | Ping interval (seconds)<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
-| failoverReplWaitingTime | Body | Number | X | Failover replication delay waiting time (seconds)<br/>- Minimum value: `-1` |
-| network | Body | Object | O | Network information objects |
-| network.subnetId | Body | UUID | O | Subnet identifier |
-| network.usePublicAccess | Body | Boolean | X | Whether external access is available<br/>- Default: `false` |
-| network.availabilityZone | Body | Enum | X | Availability zone where DB instance will be created |
-| storage | Body | Object | O | Storage information objects |
-| storage.storageType | Body | Enum | O | Storage type |
-| storage.storageSize | Body | Number | O | Data storage size (GB)<br/>- Minimum value: `20` |
-| backup | Body | Object | O | Backup information objects |
-| backup.backupPeriod | Body | Number | O | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
-| backup.backupRetryCount | Body | Number | X | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
-| backup.backupSchedules | Body | Array | O | Backup schedules |
-| backup.backupSchedules.backupWndBgnTime | Body | Time | O | Backup start time |
-| backup.backupSchedules.backupWndDuration | Body | Enum | O | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hours`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2.5 hours`<br/>- THREE_HOURS: `3 hours` |
+```http
+POST /v1.0/backups/{backupId}/restore
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | Y | Backup identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "dbInstanceName": "dbInstanceName-example",
-    "dbInstanceCandidateName": "dbInstanceCandidateName-example",
-    "description": "description-example",
-    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbPort": 1,
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbSecurityGroupIds": [],
-    "userGroupIds": [],
-    "useHighAvailability": false,
-    "useDefaultNotification": false,
-    "useDeletionProtection": false,
-    "pingInterval": 1,
-    "failoverReplWaitingTime": 1,
-    "network": {
-        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
-        "usePublicAccess": false,
-        "availabilityZone": "kr-pub-a"
-    },
-    "storage": {
-        "storageType": "General SSD",
-        "storageSize": 20
-    },
-    "backup": {
-        "backupPeriod": 0,
-        "backupRetryCount": 0,
-        "backupSchedules": [
-            {
-                "backupWndBgnTime": "00:00:00",
-                "backupWndDuration": "HALF_AN_HOUR"
-            }
-        ]
-    }
+"dbInstanceName": "dbInstanceName-example",
+"dbInstanceCandidateName": "dbInstanceCandidateName-example",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbPort": 1,
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useHighAvailability": false,
+"useDefaultNotification": false,
+"useDeletionProtection": false,
+"pingInterval": 1,
+"failoverReplWaitingTime": 1,
+"network": {
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
+},
+"storage": {
+"storageType": "General SSD",
+"storageSize": 20
+},
+"backup": {
+"backupPeriod": 0,
+"backupRetryCount": 0,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
+}
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | Name to identify DB instances |
+| dbInstanceCandidateName | String | N | Candidate master name to identify the DB instance |
+| description | String | N | Additional information on DB instances |
+| dbFlavorId | UUID | Y | Identifier of DB instance specifications |
+| dbPort | Number | Y | DB port<br/>- Minimum value: 5432, Maximum value: 45432 |
+| parameterGroupId | UUID | Y | Parameter group identifier |
+| dbSecurityGroupIds | Array | N | List of DB security group identifiers |
+| userGroupIds | Array | N | List of user group identifiers |
+| useHighAvailability | Boolean | N | Whether to use high availability<br/>- Default: `false` |
+| useDefaultNotification | Boolean | N | Whether to use default notification<br/>- Default: `false` |
+| useDeletionProtection | Boolean | N | Whether to use deletion protection<br/>- Default: `false` |
+| pingInterval | Number | N | Ping interval (seconds)<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
+| failoverReplWaitingTime | Number | N | Failover replication delay waiting time (seconds)<br/>- Minimum value: `-1` |
+| network | Object | Y | Network information objects |
+| network.subnetId | UUID | Y | Subnet identifier |
+| network.usePublicAccess | Boolean | N | Whether external access is available<br/>- Default: `false` |
+| network.availabilityZone | Enum | N | Availability zone where DB instance will be created |
+| storage | Object | Y | Storage information objects |
+| storage.storageType | Enum | Y | Storage type |
+| storage.storageSize | Number | Y | Data storage size (GB)<br/>- Minimum value: `20` |
+| backup | Object | Y | Backup information objects |
+| backup.backupPeriod | Number | Y | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| backup.backupRetryCount | Number | N | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| backup.backupSchedules | Array | Y | Backup schedules |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | Backup start time |
+| backup.backupSchedules.backupWndDuration | Enum | Y | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hours`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2.5 hours`<br/>- THREE_HOURS: `3 hours` |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
+
 ---
+
 ## DB Security Group
 
 ### DB Security Group Progress Status
 
-| Status          | Description                  |
-|-----------------|------------------------------|
-| `NONE`          | No work in progress          |
-| `CREATING_RULE` | Creating rule policy         |
-| `UPDATING_RULE` | Modifying rule policy        |
-| `DELETING_RULE` | Deleting rule policy         |
+| Status | Description |
+|-----------------|--------------|
+| `NONE` | No work in progress |
+| `CREATING_RULE` | Creating rule policy |
+| `UPDATING_RULE` | Modifying rule policy |
+| `DELETING_RULE` | Deleting rule policy |
 
 ### List DB Security Groups
+
+#### Required Permission
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbSecurityGroup.List | List DB Security Groups |
+
+#### Request
 
 ```http
 GET /v1.0/db-security-groups
 ```
 
-#### Required permissions
-
-| Permission Name                       | Description             |
-|---------------------------------------|-------------------------|
-| RDSforPostgreSQL:DbSecurityGroup.List | List DB Security Groups |
-
-#### Request
+#### Request Body
 
 This API does not require a request body.
 
 #### Response
 
-| Name                                   | Type | Format   | Description                                                                                                                                                                                                                                                         |
-|----------------------------------------|------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroups                       | Body | Array    | DB security groups                                                                                                                                                                                                                                                  |
-| dbSecurityGroups.dbSecurityGroupId     | Body | UUID     | DB security group identifier                                                                                                                                                                                                                                        |
-| dbSecurityGroups.dbSecurityGroupName   | Body | String   | Name to identify the DB security group                                                                                                                                                                                                                              |
-| dbSecurityGroups.dbSecurityGroupStatus | Body | Enum     | Current status of the DB security group<br/>- CREATED: `Created`<br/>- DELETED: `Deleted`                                                                                                                                                                          |
-| dbSecurityGroups.description           | Body | String   | Additional information on the DB security group                                                                                                                                                                                                                     |
-| dbSecurityGroups.progressStatus        | Body | Enum     | Current progress status of the DB security group<br/>- NONE: `No work in progress`<br/>- CREATING_RULE: `Creating rule policy`<br/>- UPDATING_RULE: `Modifying rule policy`<br/>- DELETING_RULE: `Deleting rule policy`<br/>- APPLYING_DEFAULT_RULE: `Applying default rule` |
-| dbSecurityGroups.createdYmdt           | Body | DateTime | Created date and time                                                                                                                                                                                                                                               |
-| dbSecurityGroups.updatedYmdt           | Body | DateTime | Modified date and time                                                                                                                                                                                                                                              |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbSecurityGroups": [
-        {
-            "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbSecurityGroupName": "dbSecurityGroupName-example",
-            "dbSecurityGroupStatus": "CREATED",
-            "description": "description-example",
-            "progressStatus": "NONE",
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbSecurityGroups": [
+{
+"dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupName": "dbSecurityGroupName-example",
+"dbSecurityGroupStatus": "CREATED",
+"description": "description-example",
+"progressStatus": "NONE",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| dbSecurityGroups | Array | DB security groups |
+| dbSecurityGroups.dbSecurityGroupId | UUID | DB security group identifier |
+| dbSecurityGroups.dbSecurityGroupName | String | Name to identify the DB security group |
+| dbSecurityGroups.dbSecurityGroupStatus | Enum | Current status of the DB security group<br/>- CREATED: `Created`<br/>- DELETED: `Deleted` |
+| dbSecurityGroups.description | String | Additional information on the DB security group |
+| dbSecurityGroups.progressStatus | Enum | Current progress status of the DB security group<br/>- NONE: `No work in progress`<br/>- CREATING_RULE: `Creating rule policy`<br/>- UPDATING_RULE: `Modifying rule policy`<br/>- DELETING_RULE: `Deleting rule policy`<br/>- APPLYING_DEFAULT_RULE: `Applying default rule` |
+| dbSecurityGroups.createdYmdt | DateTime | Created date and time |
+| dbSecurityGroups.updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### Create DB Security Group
 
-```http
-POST /v1.0/db-security-groups
-```
+#### Required Permission
 
-#### Required permissions
-
-| Permission Name                         | Description              |
-|-----------------------------------------|--------------------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforPostgreSQL:DbSecurityGroup.Create | Create DB Security Group |
 
 #### Request
 
-| Name                | Type | Format | Required | Description                                                                                                                                                                                                                                                                                                                              |
-|---------------------|------|--------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupName | Body | String | O        | Name to identify the DB security group                                                                                                                                                                                                                                                                                                   |
-| description         | Body | String | X        | Additional information on the DB security group                                                                                                                                                                                                                                                                                          |
-| rules               | Body | Array  | O        | DB security group rule information                                                                                                                                                                                                                                                                                                       |
-| rules.direction     | Body | Enum   | O        | Communication direction<br/>- INGRESS: `Inbound`<br/>- EGRESS: `Outbound`                                                                                                                                                                                                                                                               |
-| rules.etherType     | Body | Enum   | O        | Ether type<br/>- IPV4: `IPv4`<br/>- IPV6: `IPv6`                                                                                                                                                                                                                                                                                        |
-| rules.port          | Body | Object | O        | Port object                                                                                                                                                                                                                                                                                                                              |
-| rules.port.portType | Body | Enum   | O        | Port type<br/>- ALL: `All port ranges (not used in the user console)`<br/>- PORT: `Specific port`<br/>- DB_PORT: `DB listening port`<br/>- PORT_RANGE: `Port range`                                                                                                                                                                      |
-| rules.port.minPort  | Body | Number | X        | Minimum port range<br/>- Minimum value: `1`                                                                                                                                                                                                                                                                                              |
-| rules.port.maxPort  | Body | Number | X        | Maximum port range<br/>- Maximum value: `65535`                                                                                                                                                                                                                                                                                          |
-| rules.cidr          | Body | String | O        | CIDR                                                                                                                                                                                                                                                                                                                                     |
-| rules.description   | Body | String | X        | Additional information on the DB security group rule                                                                                                                                                                                                                                                                                     |
+```http
+POST /v1.0/db-security-groups
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "dbSecurityGroupName": "dbSecurityGroupName-example",
-    "description": "description-example",
-    "rules": [
-        {
-            "direction": "INGRESS",
-            "etherType": "IPV4",
-            "port": {
-                "portType": "ALL",
-                "minPort": 1,
-                "maxPort": 1
-            },
-            "cidr": "192.168.0.0/24",
-            "description": "description-example"
-        }
-    ]
+"dbSecurityGroupName": "dbSecurityGroupName-example",
+"description": "description-example",
+"rules": [
+{
+"direction": "INGRESS",
+"etherType": "IPV4",
+"port": {
+"portType": "ALL",
+"minPort": 1,
+"maxPort": 1
+},
+"cidr": "192.168.0.0/24",
+"description": "description-example"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbSecurityGroupName | String | Y | Name to identify the DB security group |
+| description | String | N | Additional information on the DB security group |
+| rules | Array | Y | DB security group rule information |
+| rules.direction | Enum | Y | Communication direction<br/>- INGRESS: `Inbound`<br/>- EGRESS: `Outbound` |
+| rules.etherType | Enum | Y | Ether type<br/>- IPV4: `IPv4`<br/>- IPV6: `IPv6` |
+| rules.port | Object | Y | Port object |
+| rules.port.portType | Enum | Y | Port type<br/>- ALL: `All port ranges (not used in the user console)`<br/>- PORT: `Specific port`<br/>- DB_PORT: `DB listening port`<br/>- PORT_RANGE: `Port range` |
+| rules.port.minPort | Number | N | Minimum port range<br/>- Minimum value: `1` |
+| rules.port.maxPort | Number | N | Maximum port range<br/>- Maximum value: `65535` |
+| rules.cidr | String | Y | CIDR |
+| rules.description | String | N | Additional information on the DB security group rule |
 
 #### Response
 
-| Name              | Type | Format | Description                  |
-|-------------------|------|--------|------------------------------|
-| dbSecurityGroupId | Body | UUID   | DB security group identifier |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| dbSecurityGroupId | UUID | DB security group identifier |
 
 ---
 
 ### Delete DB Security Group
 
-```http
-DELETE /v1.0/db-security-groups/{dbSecurityGroupId}
-```
+#### Required Permission
 
-#### Required permissions
-
-| Permission Name                         | Description              |
-|-----------------------------------------|--------------------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforPostgreSQL:DbSecurityGroup.Delete | Delete DB Security Group |
 
 #### Request
 
-This API does not require a request body.
+```http
+DELETE /v1.0/db-security-groups/{dbSecurityGroupId}
+```
 
-| Name              | Type | Format | Required | Description |
-|-------------------|------|--------|----------|-------------|
-| dbSecurityGroupId | URL  | UUID   | O        |             |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
@@ -4127,124 +4385,133 @@ This API does not return a response body.
 
 ### List DB Security Group Details
 
-```http
-GET /v1.0/db-security-groups/{dbSecurityGroupId}
-```
+#### Required Permission
 
-#### Required permissions
-
-| Permission Name                      | Description                    |
-|--------------------------------------|--------------------------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforPostgreSQL:DbSecurityGroup.Get | List DB Security Group Details |
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v1.0/db-security-groups/{dbSecurityGroupId}
+```
 
-| Name              | Type | Format | Required | Description                  |
-|-------------------|------|--------|----------|------------------------------|
-| dbSecurityGroupId | URL  | UUID   | O        |                              |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name                          | Type | Format   | Description                                                                                                                                                                                                                                                              |
-|-------------------------------|------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroup               | Body | Object   | DB security group                                                                                                                                                                                                                                                        |
-| dbSecurityGroup.dbSecurityGroupId     | Body | UUID     | DB security group identifier                                                                                                                                                                                                                                             |
-| dbSecurityGroup.dbSecurityGroupName   | Body | String   | Name to identify the DB security group                                                                                                                                                                                                                                   |
-| dbSecurityGroup.dbSecurityGroupStatus | Body | Enum     | Current status of the DB security group<br/>- CREATED: `Created`<br/>- DELETED: `Deleted`                                                                                                                                                                               |
-| dbSecurityGroup.description           | Body | String   | Additional information on the DB security group                                                                                                                                                                                                                          |
-| dbSecurityGroup.progressStatus        | Body | Enum     | Current progress status of the DB security group<br/>- NONE: `No work in progress`<br/>- CREATING_RULE: `Creating rule policy`<br/>- UPDATING_RULE: `Modifying rule policy`<br/>- DELETING_RULE: `Deleting rule policy`<br/>- APPLYING_DEFAULT_RULE: `Applying default rule` |
-| dbSecurityGroup.rules                 | Body | Array    | DB security group rule list                                                                                                                                                                                                                                              |
-| dbSecurityGroup.rules.ruleId          | Body | UUID     | DB security group rule identifier                                                                                                                                                                                                                                        |
-| dbSecurityGroup.rules.description     | Body | String   | Additional information on the DB security group rule                                                                                                                                                                                                                     |
-| dbSecurityGroup.rules.direction       | Body | Enum     | Communication direction<br/>- INGRESS: `Inbound`<br/>- EGRESS: `Outbound`                                                                                                                                                                                               |
-| dbSecurityGroup.rules.etherType       | Body | Enum     | Ether type<br/>- IPV4: `IPv4`<br/>- IPV6: `IPv6`                                                                                                                                                                                                                        |
-| dbSecurityGroup.rules.port            | Body | Object   | Port object                                                                                                                                                                                                                                                              |
-| dbSecurityGroup.rules.port.portType   | Body | Enum     | Port type<br/>- ALL: `All port ranges (not used in the user console)`<br/>- PORT: `Specific port`<br/>- DB_PORT: `DB listening port`<br/>- PORT_RANGE: `Port range`                                                                                                      |
-| dbSecurityGroup.rules.port.minPort    | Body | Number   | Minimum port range                                                                                                                                                                                                                                                       |
-| dbSecurityGroup.rules.port.maxPort    | Body | Number   | Maximum port range                                                                                                                                                                                                                                                       |
-| dbSecurityGroup.rules.cidr            | Body | String   | CIDR                                                                                                                                                                                                                                                                     |
-| dbSecurityGroup.rules.createdYmdt     | Body | DateTime | Created date and time                                                                                                                                                                                                                                                    |
-| dbSecurityGroup.rules.updatedYmdt     | Body | DateTime | Modified date and time                                                                                                                                                                                                                                                   |
-| dbSecurityGroup.createdYmdt           | Body | DateTime | Created date and time                                                                                                                                                                                                                                                    |
-| dbSecurityGroup.updatedYmdt           | Body | DateTime | Modified date and time                                                                                                                                                                                                                                                   |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbSecurityGroup": {
-        "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
-        "dbSecurityGroupName": "dbSecurityGroupName-example",
-        "dbSecurityGroupStatus": "CREATED",
-        "description": "description-example",
-        "progressStatus": "NONE",
-        "rules": [
-            {
-                "ruleId": "550e8400-e29b-41d4-a716-446655440000",
-                "description": "description-example",
-                "direction": "INGRESS",
-                "etherType": "IPV4",
-                "port": {
-                    "portType": "ALL",
-                    "minPort": 1,
-                    "maxPort": 1
-                },
-                "cidr": "192.168.0.0/24",
-                "createdYmdt": "2023-12-31T15:00:00+09:00",
-                "updatedYmdt": "2023-12-31T15:00:00+09:00"
-            }
-        ],
-        "createdYmdt": "2023-12-31T15:00:00+09:00",
-        "updatedYmdt": "2023-12-31T15:00:00+09:00"
-    }
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbSecurityGroup": {
+"dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupName": "dbSecurityGroupName-example",
+"dbSecurityGroupStatus": "CREATED",
+"description": "description-example",
+"progressStatus": "NONE",
+"rules": [
+{
+"ruleId": "550e8400-e29b-41d4-a716-446655440000",
+"description": "description-example",
+"direction": "INGRESS",
+"etherType": "IPV4",
+"port": {
+"portType": "ALL",
+"minPort": 1,
+"maxPort": 1
+},
+"cidr": "192.168.0.0/24",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| dbSecurityGroup | Object | DB security group |
+| dbSecurityGroup.dbSecurityGroupId | UUID | DB security group identifier |
+| dbSecurityGroup.dbSecurityGroupName | String | Name to identify the DB security group |
+| dbSecurityGroup.dbSecurityGroupStatus | Enum | Current status of the DB security group<br/>- CREATED: `Created`<br/>- DELETED: `Deleted` |
+| dbSecurityGroup.description | String | Additional information on the DB security group |
+| dbSecurityGroup.progressStatus | Enum | Current progress status of the DB security group<br/>- NONE: `No work in progress`<br/>- CREATING_RULE: `Creating rule policy`<br/>- UPDATING_RULE: `Modifying rule policy`<br/>- DELETING_RULE: `Deleting rule policy`<br/>- APPLYING_DEFAULT_RULE: `Applying default rule` |
+| dbSecurityGroup.rules | Array | DB security group rule list |
+| dbSecurityGroup.rules.ruleId | UUID | DB security group rule identifier |
+| dbSecurityGroup.rules.description | String | Additional information on the DB security group rule |
+| dbSecurityGroup.rules.direction | Enum | Communication direction<br/>- INGRESS: `Inbound`<br/>- EGRESS: `Outbound` |
+| dbSecurityGroup.rules.etherType | Enum | Ether type<br/>- IPV4: `IPv4`<br/>- IPV6: `IPv6` |
+| dbSecurityGroup.rules.port | Object | Port object |
+| dbSecurityGroup.rules.port.portType | Enum | Port type<br/>- ALL: `All port ranges (not used in the user console)`<br/>- PORT: `Specific port`<br/>- DB_PORT: `DB listening port`<br/>- PORT_RANGE: `Port range` |
+| dbSecurityGroup.rules.port.minPort | Number | Minimum port range |
+| dbSecurityGroup.rules.port.maxPort | Number | Maximum port range |
+| dbSecurityGroup.rules.cidr | String | CIDR |
+| dbSecurityGroup.rules.createdYmdt | DateTime | Created date and time |
+| dbSecurityGroup.rules.updatedYmdt | DateTime | Modified date and time |
+| dbSecurityGroup.createdYmdt | DateTime | Created date and time |
+| dbSecurityGroup.updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### Modify DB Security Group
 
-```http
-PUT /v1.0/db-security-groups/{dbSecurityGroupId}
-```
+#### Required Permission
 
-#### Required permissions
-
-| Permission Name                         | Description              |
-|-----------------------------------------|--------------------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforPostgreSQL:DbSecurityGroup.Modify | Modify DB Security Group |
 
 #### Request
 
-| Name                | Type | Format | Required | Description                                     |
-|---------------------|------|--------|----------|-------------------------------------------------|
-| dbSecurityGroupId   | URL  | UUID   | O        |                                                 |
-| dbSecurityGroupName | Body | String | O        | Name to identify the DB security group          |
-| description         | Body | String | X        | Additional information on the DB security group |
+```http
+PUT /v1.0/db-security-groups/{dbSecurityGroupId}
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "dbSecurityGroupName": "dbSecurityGroupName-example",
-    "description": "description-example"
+"dbSecurityGroupName": "dbSecurityGroupName-example",
+"description": "description-example"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbSecurityGroupName | String | Y | Name to identify the DB security group |
+| description | String | N | Additional information on the DB security group |
 
 #### Response
 
@@ -4254,201 +4521,211 @@ This API does not return a response body.
 
 ### Delete DB Security Group Rule
 
-```http
-DELETE /v1.0/db-security-groups/{dbSecurityGroupId}/rules
-```
+#### Required Permission
 
-#### Required permissions
-
-| Permission Name                             | Description                  |
-|---------------------------------------------|------------------------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforPostgreSQL:DbSecurityGroupRule.Delete | Delete DB Security Group Rule |
 
 #### Request
 
-This API does not require a request body.
+```http
+DELETE /v1.0/db-security-groups/{dbSecurityGroupId}/rules
+```
 
-| Name              | Type  | Format | Required | Description                        |
-|-------------------|-------|--------|----------|------------------------------------|
-| dbSecurityGroupId | URL   | UUID   | O        |                                    |
-| ruleIds           | Query | String | O        | DB security group rule ID list     |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+| ruleIds | Query | String | Y | DB security group rule ID list |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Create DB Security Group Rule
 
-```http
-POST /v1.0/db-security-groups/{dbSecurityGroupId}/rules
-```
+#### Required Permission
 
-#### Required permissions
-
-| Permission Name                             | Description                  |
-|---------------------------------------------|------------------------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforPostgreSQL:DbSecurityGroupRule.Create | Create DB Security Group Rule |
 
 #### Request
 
-| Name              | Type | Format | Required | Description                                                                                                                                                                                                          |
-|-------------------|------|--------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId | URL  | UUID   | O        |                                                                                                                                                                                                                      |
-| direction         | Body | Enum   | O        | Communication direction<br/>- INGRESS: `Inbound`<br/>- EGRESS: `Outbound`                                                                                                                                            |
-| etherType         | Body | Enum   | O        | Ether type<br/>- IPV4: `IPv4`<br/>- IPV6: `IPv6`                                                                                                                                                                     |
-| port              | Body | Object | O        | Port information                                                                                                                                                                                                     |
-| port.portType     | Body | Enum   | O        | Port type<br/>- ALL: `All port ranges (not used in the user console)`<br/>- PORT: `Specific port`<br/>- DB_PORT: `DB listening port`<br/>- PORT_RANGE: `Port range`                                                   |
-| port.minPort      | Body | Number | X        | Minimum port range<br/>- Minimum value: `1`                                                                                                                                                                          |
-| port.maxPort      | Body | Number | X        | Maximum port range<br/>- Maximum value: `65535`                                                                                                                                                                      |
-| cidr              | Body | String | O        | CIDR                                                                                                                                                                                                                 |
-| description       | Body | String | X        | Additional information on the DB security group rule                                                                                                                                                                 |
+```http
+POST /v1.0/db-security-groups/{dbSecurityGroupId}/rules
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "direction": "INGRESS",
-    "etherType": "IPV4",
-    "port": {
-        "portType": "ALL",
-        "minPort": 1,
-        "maxPort": 1
-    },
-    "cidr": "192.168.0.0/24",
-    "description": "description-example"
+"direction": "INGRESS",
+"etherType": "IPV4",
+"port": {
+"portType": "ALL",
+"minPort": 1,
+"maxPort": 1
+},
+"cidr": "192.168.0.0/24",
+"description": "description-example"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| direction | Enum | Y | Communication direction<br/>- INGRESS: `Inbound`<br/>- EGRESS: `Outbound` |
+| etherType | Enum | Y | Ether type<br/>- IPV4: `IPv4`<br/>- IPV6: `IPv6` |
+| port | Object | Y | Port information |
+| port.portType | Enum | Y | Port type<br/>- ALL: `All port ranges (not used in the user console)`<br/>- PORT: `Specific port`<br/>- DB_PORT: `DB listening port`<br/>- PORT_RANGE: `Port range` |
+| port.minPort | Number | N | Minimum port range<br/>- Minimum value: `1` |
+| port.maxPort | Number | N | Maximum port range<br/>- Maximum value: `65535` |
+| cidr | String | Y | CIDR |
+| description | String | N | Additional information on the DB security group rule |
 
 #### Response
 
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Modify DB Security Group Rule
 
-```http
-PUT /v1.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
-```
+#### Required Permission
 
-#### Required permissions
-
-| Permission Name                             | Description                  |
-|---------------------------------------------|------------------------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforPostgreSQL:DbSecurityGroupRule.Modify | Modify DB Security Group Rule |
 
 #### Request
 
-| Name              | Type | Format | Required | Description                                                                                                                                                                                                          |
-|-------------------|------|--------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId | URL  | UUID   | O        |                                                                                                                                                                                                                      |
-| ruleId            | URL  | UUID   | O        |                                                                                                                                                                                                                      |
-| direction         | Body | Enum   | O        | Communication direction<br/>- INGRESS: `Inbound`<br/>- EGRESS: `Outbound`                                                                                                                                            |
-| etherType         | Body | Enum   | O        | Ether type<br/>- IPV4: `IPv4`<br/>- IPV6: `IPv6`                                                                                                                                                                     |
-| port              | Body | Object | O        | Port information                                                                                                                                                                                                     |
-| port.portType     | Body | Enum   | O        | Port type<br/>- ALL: `All port ranges (not used in the user console)`<br/>- PORT: `Specific port`<br/>- DB_PORT: `DB listening port`<br/>- PORT_RANGE: `Port range`                                                   |
-| port.minPort      | Body | Number | X        | Minimum port range<br/>- Minimum value: `1`                                                                                                                                                                          |
-| port.maxPort      | Body | Number | X        | Maximum port range<br/>- Maximum value: `65535`                                                                                                                                                                      |
-| cidr              | Body | String | O        | CIDR                                                                                                                                                                                                                 |
-| description       | Body | String | X        | Additional information on the DB security group rule                                                                                                                                                                 |
+```http
+PUT /v1.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+| ruleId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "direction": "INGRESS",
-    "etherType": "IPV4",
-    "port": {
-        "portType": "ALL",
-        "minPort": 1,
-        "maxPort": 1
-    },
-    "cidr": "192.168.0.0/24",
-    "description": "description-example"
+"direction": "INGRESS",
+"etherType": "IPV4",
+"port": {
+"portType": "ALL",
+"minPort": 1,
+"maxPort": 1
+},
+"cidr": "192.168.0.0/24",
+"description": "description-example"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| direction | Enum | Y | Communication direction<br/>- INGRESS: `Inbound`<br/>- EGRESS: `Outbound` |
+| etherType | Enum | Y | Ether type<br/>- IPV4: `IPv4`<br/>- IPV6: `IPv6` |
+| port | Object | Y | Port information |
+| port.portType | Enum | Y | Port type<br/>- ALL: `All port ranges (not used in the user console)`<br/>- PORT: `Specific port`<br/>- DB_PORT: `DB listening port`<br/>- PORT_RANGE: `Port range` |
+| port.minPort | Number | N | Minimum port range<br/>- Minimum value: `1` |
+| port.maxPort | Number | N | Maximum port range<br/>- Maximum value: `65535` |
+| cidr | String | Y | CIDR |
+| description | String | N | Additional information on the DB security group rule |
 
 #### Response
 
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
+
 ---
+
 ## Parameter group
 
 ### List Parameter Groups
 
-```http
-GET /v1.0/parameter-groups
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -4456,57 +4733,58 @@ GET /v1.0/parameter-groups
 
 #### Request
 
+```http
+GET /v1.0/parameter-groups
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| parameterGroups | Body | Array | Parameter groups |
-| parameterGroups.parameterGroupId | Body | UUID | Parameter group identifier |
-| parameterGroups.parameterGroupName | Body | String | Name to identify parameter groups |
-| parameterGroups.description | Body | String | Additional information on parameter group |
-| parameterGroups.dbVersion | Body | Enum | DB version information |
-| parameterGroups.parameterGroupStatus | Body | Enum | Parameter group current status<br/>- STABLE: `Applied`<br/>- NEED_TO_APPLY: `Need to apply`<br/>- DELETED: `Deleted` |
-| parameterGroups.createdYmdt | Body | DateTime | Created date and time |
-| parameterGroups.updatedYmdt | Body | DateTime | Modified date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroups": [
-        {
-            "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-            "parameterGroupName": "parameterGroupName-example",
-            "description": "description-example",
-            "dbVersion": "POSTGRESQL_V14_17",
-            "parameterGroupStatus": "STABLE",
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"parameterGroups": [
+{
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"parameterGroupName": "parameterGroupName-example",
+"description": "description-example",
+"dbVersion": "POSTGRESQL_V14_17",
+"parameterGroupStatus": "STABLE",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| parameterGroups | Array | Parameter groups |
+| parameterGroups.parameterGroupId | UUID | Parameter group identifier |
+| parameterGroups.parameterGroupName | String | Name to identify parameter groups |
+| parameterGroups.description | String | Additional information on parameter group |
+| parameterGroups.dbVersion | String | DB version information |
+| parameterGroups.parameterGroupStatus | Enum | Parameter group current status<br/>- STABLE: `Applied`<br/>- NEED_TO_APPLY: `Need to apply`<br/>- DELETED: `Deleted` |
+| parameterGroups.createdYmdt | DateTime | Created date and time |
+| parameterGroups.updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### Create Parameter Group
 
-```http
-POST /v1.0/parameter-groups
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -4514,58 +4792,58 @@ POST /v1.0/parameter-groups
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| parameterGroupName | Body | String | O | Name to identify parameter groups |
-| description | Body | String | X | Additional information on parameter group |
-| dbVersion | Body | Enum | O | DB version information |
+```http
+POST /v1.0/parameter-groups
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "parameterGroupName": "parameterGroupName-example",
-    "description": "description-example",
-    "dbVersion": "POSTGRESQL_V14_17"
+"parameterGroupName": "parameterGroupName-example",
+"description": "description-example",
+"dbVersion": "POSTGRESQL_V14_17"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| parameterGroupName | String | Y | Name to identify parameter groups |
+| description | String | N | Additional information on parameter group |
+| dbVersion | String | Y | DB version information |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| parameterGroupId | Body | UUID | Parameter group identifier |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| parameterGroupId | UUID | Parameter group identifier |
 
 ---
 
 ### Delete Parameter Group
 
-```http
-DELETE /v1.0/parameter-groups/{parameterGroupId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -4573,11 +4851,19 @@ DELETE /v1.0/parameter-groups/{parameterGroupId}
 
 #### Request
 
-This API does not require a request body.
+```http
+DELETE /v1.0/parameter-groups/{parameterGroupId}
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O | Parameter group identifier |
+| parameterGroupId | URL | UUID | Y | Parameter group identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
@@ -4587,11 +4873,7 @@ This API does not return a response body.
 
 ### List Parameter Group Details
 
-```http
-GET /v1.0/parameter-groups/{parameterGroupId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -4599,81 +4881,89 @@ GET /v1.0/parameter-groups/{parameterGroupId}
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v1.0/parameter-groups/{parameterGroupId}
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O | Parameter group identifier |
+| parameterGroupId | URL | UUID | Y | Parameter group identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| parameterGroupId | Body | UUID | Parameter group identifier |
-| parameterGroupName | Body | String | Name to identify parameter groups |
-| description | Body | String | Additional information on parameter group |
-| dbVersion | Body | Enum | DB version information |
-| parameterGroupStatus | Body | Enum | Parameter group current status<br/>- STABLE: `Applied`<br/>- NEED_TO_APPLY: `Need to apply`<br/>- DELETED: `Deleted` |
-| parameters | Body | Array | Parameter list |
-| parameters.parameterCategory | Body | String | Parameter category |
-| parameters.parameterName | Body | String | Parameter name |
-| parameters.value | Body | String | Current value |
-| parameters.valueUnit | Body | String | Unit of the current value (byte: B,kB,MB,GB,TB, time: us,ms,s,min,h,d) |
-| parameters.defaultValue | Body | String | Default value |
-| parameters.allowedValue | Body | String | Permitted values |
-| parameters.valueType | Body | Enum | Value type<br/>- BOOLEAN: `Boolean type`<br/> `* ex) on, off, true, false, yes, no, 1, 0`<br/>- STRING: `String type`<br/>- NUMERIC: `Integer and floating-point types`<br/>- NUMERIC_WITH_BYTE_UNIT: `Numeric type with byte unit`<br/> `* ex) 120kB, 100MB`<br/> `* Allowed byte units: B (bytes), kB (kilobytes), MB (megabytes), GB (gigabytes), and TB (terabytes)`<br/>- NUMERIC_WITH_TIME_UNIT: `Numeric type with time unit`<br/> `* ex) 120ms, 100s, 1d`<br/> `* Allowed time units: us (microseconds), ms (milliseconds), s (seconds), min (minutes), h (hours), and d (days)`<br/>- ENUMERATED: `Enter one of the values declared in Allowed Values (separated by commas (,))`<br/>- MULTI_ENUMERATED: `Enter multiple of the values declared in Allowed Values (separated by commas (,))` |
-| parameters.updateType | Body | Enum | Modification type<br/>- VARIABLE: `Modifiable any time`<br/>- CONSTANT: `Not modifiable` |
-| parameters.applyType | Body | Enum | Applied type<br/>- BOTH: `Apply session and setting file`<br/>- SESSION: `Apply session only`<br/>- FILE: `Apply setting file only` |
-| parameters.expressionAvailable | Body | Boolean | Allow formulas or not |
-| createdYmdt | Body | DateTime | Created date and time |
-| updatedYmdt | Body | DateTime | Modified date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "parameterGroupName": "parameterGroupName-example",
-    "description": "description-example",
-    "dbVersion": "POSTGRESQL_V14_17",
-    "parameterGroupStatus": "STABLE",
-    "parameters": [
-        {
-            "parameterCategory": "parameterCategory-example",
-            "parameterName": "parameterName-example",
-            "value": "value-example",
-            "valueUnit": "valueUnit-example",
-            "defaultValue": "defaultValue-example",
-            "allowedValue": "allowedValue-example",
-            "valueType": "BOOLEAN",
-            "updateType": "VARIABLE",
-            "applyType": "BOTH",
-            "expressionAvailable": false
-        }
-    ],
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"parameterGroupName": "parameterGroupName-example",
+"description": "description-example",
+"dbVersion": "POSTGRESQL_V14_17",
+"parameterGroupStatus": "STABLE",
+"valueUnit": "valueUnit-example",
+{
+"allowedValue": "allowedValue-example",
+"valueType": "BOOLEAN",
+"updateType": "VARIABLE",
+"applyType": "BOTH",
+"expressionAvailable": false
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| parameterGroupId | UUID | Parameter group identifier |
+| parameterGroupName | String | Name to identify parameter groups |
+| description | String | Additional information on parameter group |
+| dbVersion | String | DB version information |
+| parameterGroupStatus | Enum | Parameter group current status<br/>- STABLE: `Applied`<br/>- NEED_TO_APPLY: `Need to apply`<br/>- DELETED: `Deleted` |
+| parameters | Array | Parameter list |
+| parameters.parameterCategory | String | Parameter category |
+| parameters.parameterName | String | Parameter name |
+| parameters.value | String | Current value |
+| parameters.valueUnit | String | Unit of the current value (byte: B,kB,MB,GB,TB, time: us,ms,s,min,h,d) |
+| parameters.defaultValue | String | Default value |
+| parameters.allowedValue | String | Permitted values |
+| parameters.valueType | Enum | Value type<br/>- BOOLEAN: `Boolean type`<br/> `* ex) on, off, true, false, yes, no, 1, 0`<br/>- STRING: `String type`<br/>- NUMERIC: `Integer and floating-point types`<br/>- NUMERIC_WITH_BYTE_UNIT: `Numeric type with byte unit`<br/> `* ex) 120kB, 100MB`<br/> `* Allowed byte units: B (bytes), kB (kilobytes), MB (megabytes), GB (gigabytes), and TB (terabytes)`<br/>- NUMERIC_WITH_TIME_UNIT: `Numeric type with time unit`<br/> `* ex) 120ms, 100s, 1d`<br/> `* Allowed time units: us (microseconds), ms (milliseconds), s (seconds), min (minutes), h (hours), and d (days)`<br/>- ENUMERATED: `Enter one of the values declared in Allowed Values (separated by commas (,))`<br/>- MULTI_ENUMERATED: `Enter multiple of the values declared in Allowed Values (separated by commas (,))` |
+<p>
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+| parameters.updateType | Enum | Modification type<br/>- VARIABLE: `Modifiable any time`<br/>- CONSTANT: `Not modifiable` |
+| parameters.applyType | Enum | Applied type<br/>- BOTH: `Apply session and setting file`<br/>- SESSION: `Apply session only`<br/>- FILE: `Apply setting file only` |
+| parameters.expressionAvailable | Boolean | Allow formulas or not |
+| createdYmdt | DateTime | Created date and time |
+| updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### Modify Parameter Group
 
-```http
-PUT /v1.0/parameter-groups/{parameterGroupId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -4681,24 +4971,34 @@ PUT /v1.0/parameter-groups/{parameterGroupId}
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O | Parameter group identifier |
-| parameterGroupName | Body | String | X | Name to identify parameter groups |
-| description | Body | String | X | Additional information on parameter group |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "parameterGroupName": "parameterGroupName-example",
-    "description": "description-example"
+```http
 }
 ```
 
-</p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y | Parameter group identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"parameterGroupName": "parameterGroupName-example",
+"description": "description-example"
+}
+```
+
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| parameterGroupName | String | N | Name to identify parameter groups |
+| description | String | N | Additional information on parameter group |
 
 #### Response
 
@@ -4708,11 +5008,7 @@ This API does not return a response body.
 
 ### Copy Parameter Group
 
-```http
-POST /v1.0/parameter-groups/{parameterGroupId}/copy
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -4720,57 +5016,62 @@ POST /v1.0/parameter-groups/{parameterGroupId}/copy
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O | Parameter group identifier |
-| parameterGroupName | Body | String | O | Name to identify parameter groups |
-| description | Body | String | X | Additional information on parameter group |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "parameterGroupName": "parameterGroupName-example",
-    "description": "description-example"
+```http
 }
 ```
 
-</p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y | Parameter group identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"parameterGroupName": "parameterGroupName-example",
+"description": "description-example"
+}
+```
+
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| parameterGroupName | String | Y | Name to identify parameter groups |
+| description | String | N | Additional information on parameter group |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| parameterGroupId | Body | UUID | Parameter group identifier |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| parameterGroupId | UUID | Parameter group identifier |
 
 ---
 
 ### Modify Parameter
 
-```http
-PUT /v1.0/parameter-groups/{parameterGroupId}/parameters
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -4778,29 +5079,39 @@ PUT /v1.0/parameter-groups/{parameterGroupId}/parameters
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O | Parameter group identifier |
-| modifiedParameters | Body | Array | O | Parameters to change |
-| modifiedParameters.parameterName | Body | String | O | Parameter name |
-| modifiedParameters.value | Body | String | O | Parameter value to change |
+```http
+"parameterName": "parameterName-example",
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y | Parameter group identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "modifiedParameters": [
-        {
-            "parameterName": "parameterName-example",
-            "value": "value-example"
-        }
-    ]
+]
+{
+"valueType": "BOOLEAN",
+This API does not return a response body.
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| modifiedParameters | Array | Y | Parameters to change |
+| modifiedParameters.parameterName | String | Y | Parameter name |
+| modifiedParameters.value | String | Y | Parameter value to change |
 
 #### Response
 
@@ -4810,11 +5121,7 @@ This API does not return a response body.
 
 ### Reset Parameter Group
 
-```http
-PUT /v1.0/parameter-groups/{parameterGroupId}/reset
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -4822,26 +5129,31 @@ PUT /v1.0/parameter-groups/{parameterGroupId}/reset
 
 #### Request
 
+```http
 This API does not require a request body.
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O | Parameter group identifier |
+| parameterGroupId | URL | UUID | Y | Parameter group identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
 This API does not return a response body.
 
 ---
+
 ## User Group
 
 ### List User Groups
 
-```http
-GET /v1.0/user-groups
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -4849,53 +5161,54 @@ GET /v1.0/user-groups
 
 #### Request
 
+```http
+"resultCode": 0,
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| userGroups | Body | Array | User Groups |
-| userGroups.userGroupId | Body | UUID | User group identifier |
-| userGroups.userGroupName | Body | String | Name to identify user groups |
-| userGroupStatus | Body | Enum | Current status of user groups<br/>- CREATED<br/>- DELETED |
-| userGroups.createdYmdt | Body | DateTime | Created date and time |
-| userGroups.updatedYmdt | Body | DateTime | Modified date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "userGroups": [
-        {
-            "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
-            "userGroupName": "userGroupName-example",
-            "userGroupStatus": "CREATED",
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+{
+}
+]
+}
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| userGroups | Array | User Groups |
+| userGroups.userGroupId | UUID | User group identifier |
+| userGroups.userGroupName | String | Name to identify user groups |
+| userGroups.userGroupStatus | Enum | Current status of user groups<br/>- CREATED<br/>- DELETED |
+| userGroups.createdYmdt | DateTime | Created date and time |
+| userGroups.updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### Create User Group
 
-```http
-POST /v1.0/user-groups
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -4903,58 +5216,58 @@ POST /v1.0/user-groups
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| userGroupName | Body | String | O | Name to identify user groups |
-| memberIds | Body | Array | O | List of project member identifiers |
-| selectAllYN | Body | Boolean | O | All project members or not<br/>- Default: `false` |
+```http
+"selectAllYN": false
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "userGroupName": "userGroupName-example",
-    "memberIds": [],
-    "selectAllYN": false
+]
+{
+"header": {
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| userGroupName | String | Y | Name to identify user groups |
+| memberIds | Array | Y | List of project member identifiers |
+| selectAllYN | Boolean | Y | All project members or not<br/>- Default: `false` |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| userGroupId | Body | UUID | User group identifier |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "userGroupId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+This API does not require a request body.
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| userGroupId | UUID | User group identifier |
 
 ---
 
 ### Delete User Group
 
-```http
-DELETE /v1.0/user-groups/{userGroupId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -4962,11 +5275,19 @@ DELETE /v1.0/user-groups/{userGroupId}
 
 #### Request
 
+```http
 This API does not require a request body.
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| userGroupId | URL | UUID | O | User group identifier |
+| userGroupId | URL | UUID | Y | User group identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
@@ -4976,11 +5297,7 @@ This API does not return a response body.
 
 ### List User Group Details
 
-```http
-GET /v1.0/user-groups/{userGroupId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -4988,61 +5305,64 @@ GET /v1.0/user-groups/{userGroupId}
 
 #### Request
 
-This API does not require a request body.
+```http
+"resultCode": 0,
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| userGroupId | URL | UUID | O | User group identifier |
+| userGroupId | URL | UUID | Y | User group identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| userGroupId | Body | UUID | User group identifier |
-| userGroupName | Body | String | Name to identify user groups |
-| userGroupTypeCode | Body | Enum | User group type<br/>- ENTIRE: `All project members`<br/>- INDIVIDUAL_MEMBER: `Custom` |
-| userGroupStatus | Body | Enum | Current status of user groups<br/>- CREATED<br/>- DELETED |
-| members | Body | Array | Project member list |
-| members.memberId | Body | UUID | Project member identifier |
-| createdYmdt | Body | DateTime | Created date and time |
-| updatedYmdt | Body | DateTime | Modified date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "userGroupName": "userGroupName-example",
-    "userGroupTypeCode": "ENTIRE",
-    "userGroupStatus": "CREATED",
-    "members": [
-        {
-            "memberId": "550e8400-e29b-41d4-a716-446655440000"
-        }
-    ],
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+}
+]
+}
+}
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+{
+}
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| userGroupId | UUID | User group identifier |
+| userGroupName | String | Name to identify user groups |
+| userGroupTypeCode | Enum | User group type<br/>- ENTIRE: `All project members`<br/>- INDIVIDUAL_MEMBER: `Custom` |
+| userGroupStatus | Enum | Current status of user groups<br/>- CREATED<br/>- DELETED |
+| members | Array | Project member list |
+| members.memberId | UUID | Project member identifier |
+| createdYmdt | DateTime | Created date and time |
+| updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### Modify User Group
 
-```http
-PUT /v1.0/user-groups/{userGroupId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -5050,41 +5370,48 @@ PUT /v1.0/user-groups/{userGroupId}
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| userGroupId | URL | UUID | O | User group identifier |
-| userGroupName | Body | String | X | Name to identify user groups |
-| memberIds | Body | Array | X | List of project member identifiers |
-| selectAllYN | Body | Boolean | O | All project members or not<br/>- Default: `false` |
+```http
+"selectAllYN": false
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | Y | User group identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "userGroupName": "userGroupName-example",
-    "memberIds": [],
-    "selectAllYN": false
+]
+{
+"header": {
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| userGroupName | String | N | Name to identify user groups |
+| memberIds | Array | N | List of project member identifiers |
+| selectAllYN | Boolean | Y | All project members or not<br/>- Default: `false` |
 
 #### Response
 
 This API does not return a response body.
 
 ---
+
 ## Notification Groups
 
 ### List Notification Groups
 
-```http
-GET /v1.0/notification-groups
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -5092,59 +5419,60 @@ GET /v1.0/notification-groups
 
 #### Request
 
+```http
+"resultCode": 0,
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| notificationGroups | Body | Array |  |
-| notificationGroups.notificationGroupId | Body | UUID | Notification group identifier |
-| notificationGroups.notificationGroupName | Body | String | Name to identify notification groups |
-| notificationGroups.notificationGroupStatus | Body | Enum | Current status of notification groups<br/>- CREATED: `Created`<br/>- DELETED: `Deleted` |
-| notificationGroups.notifyEmail | Body | Boolean | Whether to be notified by email |
-| notificationGroups.notifySms | Body | Boolean | Whether to be notified by SMS |
-| notificationGroups.isEnabled | Body | Boolean | Whether it is enabled |
-| notificationGroups.createdYmdt | Body | DateTime | Created date and time |
-| notificationGroups.updatedYmdt | Body | DateTime | Modified date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "notificationGroups": [
-        {
-            "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
-            "notificationGroupName": "notificationGroupName-example",
-            "notificationGroupStatus": "CREATED",
-            "notifyEmail": false,
-            "notifySms": false,
-            "isEnabled": false,
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"notifyEmail": false,
+{
+"isEnabled": false,
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
+}
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| notificationGroups | Array |  |
+| notificationGroups.notificationGroupId | UUID | Notification group identifier |
+| notificationGroups.notificationGroupName | String | Name to identify notification groups |
+| notificationGroups.notificationGroupStatus | Enum | Current status of notification groups<br/>- CREATED: `Created`<br/>- DELETED: `Deleted` |
+| notificationGroups.notifyEmail | Boolean | Whether to be notified by email |
+| notificationGroups.notifySms | Boolean | Whether to be notified by SMS |
+| notificationGroups.isEnabled | Boolean | Whether it is enabled |
+| notificationGroups.createdYmdt | DateTime | Created date and time |
+| notificationGroups.updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### Create Notification Group
 
-```http
-POST /v1.0/notification-groups
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -5152,76 +5480,84 @@ POST /v1.0/notification-groups
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| notificationGroupName | Body | String | O | Name to identify notification groups |
-| notifyEmail | Body | Boolean | X | Whether to be notified by email<br/>- Default: `true` |
-| notifySms | Body | Boolean | X | Whether to be notified by SMS<br/>- Default: `true` |
-| isEnabled | Body | Boolean | X | Whether it is enabled<br/>- Default: `true` |
-| dbInstanceIds | Body | Array | O | List of identifiers of DB instances to monitor |
-| userGroupIds | Body | Array | O | List of user group identifiers |
+```http
+"notifySms": true,
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "notificationGroupName": "notificationGroupName-example",
-    "notifyEmail": true,
-    "notifySms": true,
-    "isEnabled": true,
-    "dbInstanceIds": [],
-    "userGroupIds": []
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+}
+</p>
+<p>
+{
+"header": {
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| notificationGroupName | String | Y | Name to identify notification groups |
+| notifyEmail | Boolean | N | Whether to be notified by email<br/>- Default: `true` |
+| notifySms | Boolean | N | Whether to be notified by SMS<br/>- Default: `true` |
+| isEnabled | Boolean | N | Whether it is enabled<br/>- Default: `true` |
+| dbInstanceIds | Array | Y | List of identifiers of DB instances to monitor |
+| userGroupIds | Array | Y | List of user group identifiers |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| notificationGroupId | Body | UUID | Notification group identifier |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+This API does not require a request body.
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| notificationGroupId | UUID | Notification group identifier |
 
 ---
 
-### Delete Notification Group
+### Delete Watch Setting
 
-```http
-DELETE /v1.0/notification-groups/{notificationGroupId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
-| RDSforPostgreSQL:NotificationGroup.Delete | Delete Notification Group |
+| RDSforPostgreSQL:NotificationGroup.Delete | Delete Watch Setting |
 
 #### Request
 
+```http
 This API does not require a request body.
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| notificationGroupId | URL | UUID | O | Notification group identifier |
+| notificationGroupId | URL | UUID | Y | Notification group identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
@@ -5231,11 +5567,7 @@ This API does not return a response body.
 
 ### View Notification Group Details
 
-```http
-GET /v1.0/notification-groups/{notificationGroupId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -5243,76 +5575,79 @@ GET /v1.0/notification-groups/{notificationGroupId}
 
 #### Request
 
-This API does not require a request body.
+```http
+"resultCode": 0,
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| notificationGroupId | URL | UUID | O | Notification group identifier |
+| notificationGroupId | URL | UUID | Y | Notification group identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| notificationGroupId | Body | UUID | Notification group identifier |
-| notificationGroupName | Body | String | Name to identify notification groups |
-| notificationGroupStatus | Body | Enum | Current status of notification groups<br/>- CREATED: `Created`<br/>- DELETED: `Deleted` |
-| notifyEmail | Body | Boolean | Whether to be notified by email |
-| notifySms | Body | Boolean | Whether to be notified by SMS |
-| isEnabled | Body | Boolean | Whether it is enabled |
-| dbInstances | Body | Array | List of DB instances to monitor |
-| dbInstances.dbInstanceId | Body | UUID | DB instance identifier |
-| dbInstances.dbInstanceName | Body | String | Name to identify DB instances |
-| userGroups | Body | Array | List of user groups |
-| userGroups.userGroupId | Body | UUID | User group identifier |
-| userGroups.userGroupName | Body | String | Name to identify user groups |
-| createdYmdt | Body | DateTime | Created date and time |
-| updatedYmdt | Body | DateTime | Modified date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "notificationGroupName": "notificationGroupName-example",
-    "notificationGroupStatus": "CREATED",
-    "notifyEmail": false,
-    "notifySms": false,
-    "isEnabled": false,
-    "dbInstances": [
-        {
-            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbInstanceName": "dbInstanceName-example"
-        }
-    ],
-    "userGroups": [
-        {
-            "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
-            "userGroupName": "userGroupName-example"
-        }
-    ],
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"isEnabled": false,
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
+}
+"dbInstances": [
+{
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+{
+}
+}
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| notificationGroupId | UUID | Notification group identifier |
+| notificationGroupName | String | Name to identify notification groups |
+| notificationGroupStatus | Enum | Current status of notification groups<br/>- CREATED: `Created`<br/>- DELETED: `Deleted` |
+| notifyEmail | Boolean | Whether to be notified by email |
+| notifySms | Boolean | Whether to be notified by SMS |
+| isEnabled | Boolean | Whether it is enabled |
+| dbInstances | Array | List of DB instances to monitor |
+| dbInstances.dbInstanceId | UUID | DB instance identifier |
+| dbInstances.dbInstanceName | String | Name to identify DB instances |
+| userGroups | Array | List of user groups |
+| userGroups.userGroupId | UUID | User group identifier |
+| userGroups.userGroupName | String | Name to identify user groups |
+| createdYmdt | DateTime | Created date and time |
+| updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### Modify Notification Group
 
-```http
-PUT /v1.0/notification-groups/{notificationGroupId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -5320,32 +5655,42 @@ PUT /v1.0/notification-groups/{notificationGroupId}
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| notificationGroupId | URL | UUID | O | Notification group identifier |
-| notificationGroupName | Body | String | X | Name to identify notification groups |
-| notifyEmail | Body | Boolean | X | Whether to be notified by email<br/>- Default: `false` |
-| notifySms | Body | Boolean | X | Whether to be notified by SMS<br/>- Default: `false` |
-| isEnabled | Body | Boolean | X | Whether it is enabled<br/>- Default: `false` |
-| dbInstanceIds | Body | Array | O | List of identifiers of DB instances to monitor |
-| userGroupIds | Body | Array | O | List of user group identifiers |
+```http
+"notifySms": false,
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | Y | Notification group identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "notificationGroupName": "notificationGroupName-example",
-    "notifyEmail": false,
-    "notifySms": false,
-    "isEnabled": false,
-    "dbInstanceIds": [],
-    "userGroupIds": []
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+}
+]
+}
+{
+"header": {
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| notificationGroupName | String | N | Name to identify notification groups |
+| notifyEmail | Boolean | N | Whether to be notified by email<br/>- Default: `false` |
+| notifySms | Boolean | N | Whether to be notified by SMS<br/>- Default: `false` |
+| isEnabled | Boolean | N | Whether it is enabled<br/>- Default: `false` |
+| dbInstanceIds | Array | Y | List of identifiers of DB instances to monitor |
+| userGroupIds | Array | Y | List of user group identifiers |
 
 #### Response
 
@@ -5355,11 +5700,7 @@ This API does not return a response body.
 
 ### List Watch Settings
 
-```http
-GET /v1.0/notification-groups/{notificationGroupId}/watchdogs
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -5367,59 +5708,62 @@ GET /v1.0/notification-groups/{notificationGroupId}/watchdogs
 
 #### Request
 
-This API does not require a request body.
+```http
+"resultCode": 0,
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| notificationGroupId | URL | UUID | O | Notification group identifier |
+| notificationGroupId | URL | UUID | Y | Notification group identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| notificationWatchdogs | Body | Array | Watch setting information |
-| notificationWatchdogs.watchdogId | Body | UUID | Watch setting identifier |
-| notificationWatchdogs.metricName | Body | String | Performance metrics to watch |
-| notificationWatchdogs.comparisonOperator | Body | Enum | Comparison method for watch target<br/>- LE: `<=`<br/>- LT: `<`<br/>- GE: `>=`<br/>- GT: `>` |
-| notificationWatchdogs.threshold | Body | Number | Threshold for watch target |
-| notificationWatchdogs.duration | Body | Number | Duration for watch target |
-| notificationWatchdogs.createdYmdt | Body | DateTime | Created date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "notificationWatchdogs": [
-        {
-            "watchdogId": "550e8400-e29b-41d4-a716-446655440000",
-            "metricName": "metricName-example",
-            "comparisonOperator": "LE",
-            "threshold": 1,
-            "duration": 1,
-            "createdYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"threshold": 1,
+{
+"createdYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
+}
+</p>
+---
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| notificationWatchdogs | Array | Watch setting information |
+| notificationWatchdogs.watchdogId | UUID | Watch setting identifier |
+| notificationWatchdogs.metricName | String | Performance metrics to watch |
+| notificationWatchdogs.comparisonOperator | Enum | Comparison method for watch target<br/>- LE: `<=`<br/>- LT: `<`<br/>- GE: `>=`<br/>- GT: `>` |
+| notificationWatchdogs.threshold | Number | Threshold for watch target |
+| notificationWatchdogs.duration | Number | Duration for watch target |
+| notificationWatchdogs.createdYmdt | DateTime | Created date and time |
 
 ---
 
 ### Create Watch Setting
 
-```http
-POST /v1.0/notification-groups/{notificationGroupId}/watchdogs
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -5427,74 +5771,87 @@ POST /v1.0/notification-groups/{notificationGroupId}/watchdogs
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| notificationGroupId | URL | UUID | O | Notification group identifier |
-| metricName | Body | String | O | Performance metrics to watch |
-| comparisonOperator | Body | Enum | O | Comparison method for watch target<br/>- LE: `<=`<br/>- LT: `<`<br/>- GE: `>=`<br/>- GT: `>` |
-| threshold | Body | Number | O | Threshold for watch target<br/>- Minimum value: `0` |
-| duration | Body | Number | O | Duration for watch target (minutes)<br/>- Minimum value: `0` |
+```http
+"threshold": 0,
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | Y | Notification group identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "metricName": "metricName-example",
-    "comparisonOperator": "LE",
-    "threshold": 0,
-    "duration": 0
+}
+]
+{
+"header": {
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| metricName | String | Y | Performance metrics to watch |
+| comparisonOperator | Enum | Y | Comparison method for watch target<br/>- LE: `<=`<br/>- LT: `<`<br/>- GE: `>=`<br/>- GT: `>` |
+| threshold | Number | Y | Threshold for watch target<br/>- Minimum value: `0` |
+| duration | Number | Y | Duration for watch target (minutes)<br/>- Minimum value: `0` |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| watchdogId | Body | UUID | Watch setting identifier |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "watchdogId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+This API does not require a request body.
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| watchdogId | UUID | Watch setting identifier |
 
 ---
 
-### Delete Notification Group
+### Delete Watch Setting
 
-```http
-DELETE /v1.0/notification-groups/{notificationGroupId}/watchdogs/{watchdogId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
-| RDSforPostgreSQL:NotificationWatchdog.Delete | Delete Notification Group |
+| RDSforPostgreSQL:NotificationWatchdog.Delete | Delete Watch Setting |
 
 #### Request
 
-This API does not require a request body.
+```http
+<p>
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| notificationGroupId | URL | UUID | O | Notification group identifier |
-| watchdogId | URL | UUID | O | Watch setting identifier |
+| notificationGroupId | URL | UUID | Y | Notification group identifier |
+| watchdogId | URL | UUID | Y | Watch setting identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
@@ -5504,11 +5861,7 @@ This API does not return a response body.
 
 ### Modify Watch Setting
 
-```http
-PUT /v1.0/notification-groups/{notificationGroupId}/watchdogs/{watchdogId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -5516,50 +5869,63 @@ PUT /v1.0/notification-groups/{notificationGroupId}/watchdogs/{watchdogId}
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| notificationGroupId | URL | UUID | O | Notification group identifier |
-| watchdogId | URL | UUID | O | Watch setting identifier |
-| metricName | Body | String | O | Performance metrics to watch |
-| comparisonOperator | Body | Enum | O | Comparison method for watch target<br/>- LE: `<=`<br/>- LT: `<`<br/>- GE: `>=`<br/>- GT: `>` |
-| threshold | Body | Number | O | Threshold for watch target<br/>- Minimum value: `0` |
-| duration | Body | Number | O | Duration for watch target (minutes)<br/>- Minimum value: `0` |
+```http
+"threshold": 0,
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | Y | Notification group identifier |
+| watchdogId | URL | UUID | Y | Watch setting identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "metricName": "metricName-example",
-    "comparisonOperator": "LE",
-    "threshold": 0,
-    "duration": 0
+}
+]
+{
+"header": {
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| metricName | String | Y | Performance metrics to watch |
+| comparisonOperator | Enum | Y | Comparison method for watch target<br/>- LE: `<=`<br/>- LT: `<`<br/>- GE: `>=`<br/>- GT: `>` |
+| threshold | Number | Y | Threshold for watch target<br/>- Minimum value: `0` |
+| duration | Number | Y | Duration for watch target (minutes)<br/>- Minimum value: `0` |
 
 #### Response
 
 This API does not return a response body.
 
 ---
+
 ## Monitoring
 
 ### View stats
 
-```http
-GET /v1.0/metric-statistics
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
 | RDSforPostgreSQL:Metric.List | View stats |
 
 #### Request
+
+```http
+This API does not require a request body.
+```
+
+#### Request Body
 
 This API does not require a request body.
 
@@ -5571,11 +5937,7 @@ This API does not return a response body.
 
 ### View a list of performance metrics
 
-```http
-GET /v1.0/metrics
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -5583,62 +5945,63 @@ GET /v1.0/metrics
 
 #### Request
 
+```http
+"resultCode": 0,
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| metrics | Body | Array | List of performance metrics |
-| metrics.metricName | Body | String | Performance metric types |
-| metrics.unit | Body | String | Measure unit |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "metrics": [
-        {
-            "metricName": "metricName-example",
-            "unit": "unit-example"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+]
+{
+}
+---
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| metrics | Array | List of performance metrics |
+| metrics.metricName | String | Performance metric types |
+| metrics.unit | String | Measure unit |
 
 ---
 
 ## Event
 
-### Event categories
+### Event category
 
-Events can be classified by category as follows.
+"header": {
 
 | Event category | Description |
 |-------------|---------|
-| ALL         | All |
-| BACKUP      | Backup |
+| ALL | All |
+| BACKUP | Backup |
 | DB_INSTANCE | DB instance |
-| JOB         | Job |
-| TENANT      | Tenant |
-| MONITORING  | Monitoring |
+| JOB | Job |
+| TENANT | Tenant |
+| MONITORING | Monitoring |
 
 ### List subscribable event codes
 
-```http
-GET /v1.0/event-codes
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -5646,47 +6009,48 @@ GET /v1.0/event-codes
 
 #### Request
 
+```http
+"resultCode": 0,
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| eventCodes | Body | Array | Event codes |
-| eventCodes.eventCode | Body | Enum | Event code |
-| eventCodes.eventCategoryType | Body | Enum | Event category type<br/>- ALL: `All`<br/>- DB_INSTANCE: `Events generated from DB instance`<br/>- DB_SECURITY_GROUP: `Events generated from DB security group`<br/>- MONITORING: `Events generated from monitoring`<br/>- JOB: `Events generated from JOB`<br/>- BACKUP: `Events generated from backup`<br/>- TENANT: `Events generated from tenant` |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "eventCodes": [
-        {
-            "eventCode": "ENUM_VALUE",
-            "eventCategoryType": "ALL"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+]
+{
+</p>
+---
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| eventCodes | Array | Event codes |
+| eventCodes.eventCode | Enum | Event code |
+| eventCodes.eventCategoryType | Enum | Event category type<br/>- ALL: `All`<br/>- DB_INSTANCE: `Events generated from DB instance`<br/>- DB_SECURITY_GROUP: `Events generated from DB security group`<br/>- MONITORING: `Events generated from monitoring`<br/>- JOB: `Events generated from JOB`<br/>- BACKUP: `Events generated from backup`<br/>- TENANT: `Events generated from tenant` |
 
 ---
 
 ### View the list of events
 
-```http
-GET /v1.0/events
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -5694,53 +6058,58 @@ GET /v1.0/events
 
 #### Request
 
+```http
+"resultCode": 0,
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | Total number of events |
-| events | Body | Array | Events |
-| events.eventCategoryType | Body | Enum | Event category type<br/>- ALL: `All`<br/>- DB_INSTANCE: `Events generated from DB instance`<br/>- DB_SECURITY_GROUP: `Events generated from DB security group`<br/>- MONITORING: `Events generated from monitoring`<br/>- JOB: `Events generated from JOB`<br/>- BACKUP: `Events generated from backup`<br/>- TENANT: `Events generated from tenant` |
-| events.eventCode | Body | Enum | Occurred event type |
-| events.sourceId | Body | UUID | Event source identifier |
-| events.sourceName | Body | String | Name to identify event sources |
-| events.messages | Body | Array | Event messages |
-| events.messages.langCode | Body | Enum | Language code<br/>- KO<br/>- EN<br/>- JA<br/>- ZH |
-| events.messages.message | Body | String | Event message |
-| events.eventYmdt | Body | DateTime | Event occurred date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 1,
-    "events": [
-        {
-            "eventCategoryType": "ALL",
-            "eventCode": "ENUM_VALUE",
-            "sourceId": "550e8400-e29b-41d4-a716-446655440000",
-            "sourceName": "sourceName-example",
-            "messages": [
-                {
-                    "langCode": "KO",
-                    "message": "message-example"
-                }
-            ],
-            "eventYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"totalCounts": 1,
+"sourceName": "sourceName-example",
+{
+{
+</p>
+"message": "message-example"
+}
+],
+{
+}
+]
+}
+],
+---
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| totalCounts | Number | Total number of events |
+| events | Array | Events |
+| events.eventCategoryType | Enum | Event category type<br/>- ALL: `All`<br/>- DB_INSTANCE: `Events generated from DB instance`<br/>- DB_SECURITY_GROUP: `Events generated from DB security group`<br/>- MONITORING: `Events generated from monitoring`<br/>- JOB: `Events generated from JOB`<br/>- BACKUP: `Events generated from backup`<br/>- TENANT: `Events generated from tenant` |
+| events.eventCode | Enum | Occurred event type |
+| events.sourceId | UUID | Event source identifier |
+| events.sourceName | String | Name to identify event sources |
+| events.messages | Array | Event messages |
+| events.messages.langCode | Enum | Language code<br/>- KO<br/>- EN<br/>- JA<br/>- ZH |
+| events.messages.message | String | Event message |
+| events.eventYmdt | DateTime | Event occurred date and time |
 
 ---

--- a/ja/api-guide-v1.0.md
+++ b/ja/api-guide-v1.0.md
@@ -1567,7 +1567,8 @@ POST /v1.0/db-instances/{dbInstanceId}/backup
 
 ```json
 {
-"backupName": "backupName-example"
+"backupName": "backupName-example",
+"backupMethodType": "FULL"
 }
 ```
 
@@ -1576,6 +1577,7 @@ POST /v1.0/db-instances/{dbInstanceId}/backup
 | 名前 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|
 | backupName | String | Y | バックアップを識別できる名前 |
+| backupMethodType | Enum | N | バックアップ方式<br/>- FULL<br/>- SNAPSHOT |
 
 #### レスポンス
 
@@ -3539,7 +3541,7 @@ GET /v1.0/db-instances/{dbInstanceId}/restoration-info
 | restorableBackups.dbInstanceId | UUID | 原本DBインスタンスの識別子 |
 | restorableBackups.dbInstanceName | String | 原本DBインスタンス名 |
 | restorableBackups.dbVersion | String | DBエンジンタイプ |
-| restorableBackups.backupType | Enum | バックアップタイプ<br/>- AUTO<br/>- MANUAL |
+| restorableBackups.backupType | Enum | バックアップタイプ<br/>- AUTO: `自動バックアップ`<br/>- MANUAL: `手動バックアップ` |
 | restorableBackups.backupSize | Number | バックアップサイズ |
 | restorableBackups.failoverCount | Number | フェイルオーバー回数 |
 | restorableBackups.walFileName | String | WALファイル名 |
@@ -3961,7 +3963,7 @@ GET /v1.0/backups
 | backups.backupStatus | Enum | バックアップの現在状態<br/>- BACKING_UP: `バックアップ中(スピナー)`<br/>- VERIFYING: `検証中(スピナー)`<br/>- COMPLETED: `使用可能(緑アイコン)`<br/>- DELETING: `削除中(スピナー)`<br/>- DELETED: `削除済み(グレーアイコン)`<br/>- ERROR: `エラー(赤アイコン)` |
 | backups.dbInstanceId | UUID | 原本DBインスタンスの識別子 |
 | backups.dbVersion | String | DBバージョン情報 |
-| backups.backupType | Enum | バックアップタイプ<br/>- AUTO<br/>- MANUAL |
+| backups.backupType | Enum | バックアップタイプ<br/>- AUTO: `自動バックアップ`<br/>- MANUAL: `手動バックアップ` |
 | backups.backupSize | Number | バックアップのサイズ(バイト) |
 | backups.startYmdt | DateTime | 開始日時 |
 | backups.createdYmdt | DateTime | 作成日時 |

--- a/ja/api-guide-v1.0.md
+++ b/ja/api-guide-v1.0.md
@@ -1,68 +1,83 @@
-## Database > RDS for PostgreSQL > APIガイド > API v1.0ガイド
+## RDS for PostgreSQL API ガイド
+
+**Database > RDS for PostgreSQL > API v1.0 ガイド**
 
 ## RDS for PostgreSQL API 共通情報
 
-### API エンドポイント
+### APIエンドポイント
 
-| リージョン         | エンドポイント                                          |
-|---------------|--------------------------------------------------|
+| リージョン | エンドポイント |
+|------|----------|
 | 韓国(パンギョ)リージョン | https://kr1-rds-postgres.api.nhncloudservice.com |
+| 韓国(ピョンチョン)リージョン | https://kr2-rds-postgres.api.nhncloudservice.com |
+
 
 ### 認証および権限
 
 RDS for PostgreSQLは、API呼び出し時の認証/認可のためにUser Access Keyトークンを使用します。User Access Keyトークンは、User Access Keyに基づいて発行されるBearerタイプの一時的なアクセストークンです。User Access Keyトークンの発行及び使用に関する詳細は、[User Access Keyトークン](/nhncloud/ja/public-api/user-access-key-token)を参照してください。
 発行されたトークンはAppkeyと共にリクエストHeaderに含める必要があります。
 
-| 名前                  | 種類     | 形式     | 必須 | 説明                                             |
-|---------------------|--------|--------|----|------------------------------------------------|
-| X-TC-APP-KEY        | Header | String | O  | RDS for PostgreSQLサービスのAppkeyまたはプロジェクト統合Appkey |
-| X-NHN-AUTHORIZATION | Header | String | O  | Public APIで発行されたBearerタイプトークン                  |
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| X-TC-APP-KEY | Header | String | Y | RDS for PostgreSQLサービスのAppkeyまたはプロジェクト統合Appkey |
+| X-NHN-AUTHORIZATION | Header | String | Y | Public APIで発行されたBearerタイプトークン |
 
 また、プロジェクト権限によって呼び出せるAPIが制限されます。`RDS for PostgreSQL ADMIN`、`RDS for PostgreSQL VIEWER`のロールには、次のような基本権限が付与されており、プロジェクト内のロールグループ管理メニューで必要な権限のみを付与できます。
 
 * `RDS for PostgreSQL ADMIN`のロールには、API実行に必要なすべての権限が付与されます。
 * `RDS for PostgreSQL VIEWER`のロールには、情報を照会する権限のみ付与されます。
-    * DBインスタンスを作成、修正、削除およびDBインスタンスを対象とするいかなる機能も使用できません。
-    * ただし、通知グループとユーザーグループに関連する機能は使用できます。
+* DBインスタンスを作成、修正、削除およびDBインスタンスを対象とするいかなる機能も使用できません。
+* ただし、通知グループとユーザーグループに関連する機能は使用できます。
 
 APIリクエスト時、認証に失敗または権限がない場合、次のようなエラーが発生します。
 
-| resultCode | resultMessage | 説明         |
-|------------|---------------|------------|
-| 80401      | Unauthorized  | 認証に失敗しました。 |
-| 80403      | Forbidden     | 権限がありません。  |
+| resultCode | resultMessage | 説明 |
+|------------|---------------|-----|
+| 80401 | Unauthorized | 認証に失敗しました。 |
+| 80403 | Forbidden | 権限がありません。 |
 
 ### レスポンス共通情報
 
 すべてのAPIリクエストに`200 OK`でレスポンスします。詳しいレスポンス結果はレスポンス本文のヘッダを参照してください。
 
-#### レスポンス本文
+<details>
+  <summary><strong>成功レスポンス</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+}
 }
 ```
 
-#### フィールド
+</details>
 
-| 名前            | データ型    | 説明                 |
-|---------------|---------|--------------------|
-| resultCode    | Number  | 結果コード(成功:0、その他:失敗) |
-| resultMessage | String  | 結果メッセージ            |
-| successful    | Boolean | 成否                 |
+<details>
+  <summary><strong>失敗レスポンス</strong></summary>
 
+```json
+{
+"header": {
+        "resultCode": -1,
+        "resultMessage": "FAIL",
+        "isSuccessful": false
+}
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| resultCode | Number | 結果コード(成功:0、その他:失敗) |
+| resultMessage | String | 結果メッセージ |
+| isSuccessful | Boolean | 成否 |
 ## DBバージョン
 
 ### DBバージョンリストを表示
-
-```http
-GET /v1.0/db-versions
-```
 
 #### 必要権限
 
@@ -72,51 +87,52 @@ GET /v1.0/db-versions
 
 #### リクエスト
 
+```http
+GET /v1.0/db-versions
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| dbVersions | Body | Array | DBバージョン情報 |
-| dbVersions.dbVersionCode | Body | Enum | DBバージョンコード<br/>- MYSQL_V5633<br/>- MYSQL_V5715<br/>- MYSQL_V5719<br/>- MYSQL_V5726<br/>- MYSQL_V5731<br/>- MYSQL_V5733<br/>- MYSQL_V5737<br/>- MYSQL_V8018<br/>- MYSQL_V8023<br/>- MYSQL_V8028<br/>- MYSQL_V8032<br/>- MYSQL_V8033<br/>- MYSQL_V8034<br/>- MYSQL_V8035<br/>- MYSQL_V8036<br/>- MYSQL_V8040<br/>- MYSQL_V8041<br/>- MYSQL_V8042<br/>- MYSQL_V8043<br/>- MYSQL_V8044<br/>- MYSQL_V8045<br/>- MYSQL_V8405<br/>- MYSQL_V8406<br/>- MYSQL_V8407<br/>- MYSQL_V8408<br/>- MYSQL_V8409<br/>- MARIADB_V10330<br/>- MARIADB_V10611<br/>- MARIADB_V10612<br/>- MARIADB_V10616<br/>- MARIADB_V10622<br/>- MARIADB_V10625<br/>- MARIADB_V101107<br/>- MARIADB_V101108<br/>- MARIADB_V101113<br/>- MARIADB_V101116<br/>- MARIADB_V11407<br/>- MARIADB_V11410<br/>- MARIADB_V11806<br/>- POSTGRESQL_V14_6<br/>- POSTGRESQL_V14_15<br/>- POSTGRESQL_V14_17<br/>- POSTGRESQL_V14_19<br/>- POSTGRESQL_V17_2<br/>- POSTGRESQL_V17_4<br/>- POSTGRESQL_V17_6 |
-| dbVersions.dbMajorVersionCode | Body | Enum | DBメジャーバージョンコード<br/>- MYSQL_V56<br/>- MYSQL_V57<br/>- MYSQL_V80<br/>- MYSQL_V84<br/>- MARIADB_V103<br/>- MARIADB_V106<br/>- MARIADB_V1011<br/>- MARIADB_V114<br/>- MARIADB_V118<br/>- POSTGRES_V14<br/>- POSTGRES_V17 |
-| dbVersions.name | Body | String | DBバージョン名 |
-| dbVersions.canCreate | Body | Boolean | 新規作成可能かどうか |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbVersions": [
-        {
-            "dbVersionCode": "MYSQL_V5633",
-            "dbMajorVersionCode": "MYSQL_V56",
-            "name": "PostgreSQL V14.6",
-            "canCreate": false
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbVersions": [
+{
+            "dbVersionCode": "dbVersionCode-example",
+            "dbMajorVersionCode": "dbMajorVersionCode-example",
+"name": "PostgreSQL V14.6",
+"canCreate": false
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbVersions | Array | DBバージョン情報 |
+| dbVersions.dbVersionCode | String | DBバージョンコード |
+| dbVersions.dbMajorVersionCode | String | DBメジャーバージョンコード |
+| dbVersions.name | String | DBバージョン名 |
+| dbVersions.canCreate | Boolean | 新規作成可能かどうか |
 
 ---
 
 ## DBインスタンス仕様
 
 ### DBインスタンス仕様リストを表示
-
-```http
-GET /v1.0/db-flavors
-```
 
 #### 必要権限
 
@@ -126,51 +142,52 @@ GET /v1.0/db-flavors
 
 #### リクエスト
 
+```http
+GET /v1.0/db-flavors
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| dbFlavors | Body | Array | DBインスタンス仕様情報 |
-| dbFlavors.dbFlavorId | Body | UUID | DBインスタンス仕様の識別子 |
-| dbFlavors.dbFlavorName | Body | String | DBインスタンス仕様名 |
-| dbFlavors.ram | Body | Number | メモリ容量(MB) |
-| dbFlavors.vcpus | Body | Number | CPUコア数 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbFlavors": [
-        {
-            "dbFlavorId": "289e34e9-cd8a-4baf-82e3-a3d013c5186b",
-            "dbFlavorName": "r2.c2m4",
-            "ram": 4096,
-            "vcpus": 2
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbFlavors": [
+{
+"dbFlavorId": "289e34e9-cd8a-4baf-82e3-a3d013c5186b",
+"dbFlavorName": "r2.c2m4",
+"ram": 4096,
+"vcpus": 2
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbFlavors | Array | DBインスタンス仕様情報 |
+| dbFlavors.dbFlavorId | UUID | DBインスタンス仕様の識別子 |
+| dbFlavors.dbFlavorName | String | DBインスタンス仕様名 |
+| dbFlavors.ram | Number | メモリ容量(MB) |
+| dbFlavors.vcpus | Number | CPUコア数 |
 
 ---
 
 ## プロジェクト情報
 
 ### プロジェクトメンバーリストを表示
-
-```http
-GET /v1.0/project/members
-```
 
 #### 必要権限
 
@@ -180,49 +197,50 @@ GET /v1.0/project/members
 
 #### リクエスト
 
+```http
+GET /v1.0/project/members
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| projectMembers | Body | Array | プロジェクトメンバー情報 |
-| projectMembers.memberId | Body | UUID | プロジェクトメンバーの識別子 |
-| projectMembers.memberName | Body | String | プロジェクトメンバーの名前 |
-| projectMembers.emailAddress | Body | String | プロジェクトメンバーのメールアドレス |
-| projectMembers.phoneNumber | Body | String | プロジェクトメンバーの電話番号 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "projectMembers": [
-        {
-            "memberId": "550e8400-e29b-41d4-a716-446655440000",
-            "memberName": "memberName-example",
-            "emailAddress": "user@example.com",
-            "phoneNumber": "010-1234-5678"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"projectMembers": [
+{
+"memberId": "550e8400-e29b-41d4-a716-446655440000",
+"memberName": "memberName-example",
+"emailAddress": "user@example.com",
+"phoneNumber": "010-1234-5678"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| projectMembers | Array | プロジェクトメンバー情報 |
+| projectMembers.memberId | UUID | プロジェクトメンバーの識別子 |
+| projectMembers.memberName | String | プロジェクトメンバーの名前 |
+| projectMembers.emailAddress | String | プロジェクトメンバーのメールアドレス |
+| projectMembers.phoneNumber | String | プロジェクトメンバーの電話番号 |
 
 ---
 
 ### リージョンリストを表示
-
-```http
-GET /v1.0/project/regions
-```
 
 #### 必要権限
 
@@ -232,47 +250,48 @@ GET /v1.0/project/regions
 
 #### リクエスト
 
+```http
+GET /v1.0/project/regions
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| regions | Body | Array | リージョン情報 |
-| regions.regionCode | Body | Enum | リージョンコード<br/>- KR1: `韓国(パンギョ)`<br/>- KR2: `韓国(ピョンチョン)` |
-| regions.isEnabled | Body | Boolean | リージョンが有効かどうか |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "regions": [
-        {
-            "regionCode": "KR1",
-            "isEnabled": false
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"regions": [
+{
+"regionCode": "KR1",
+"isEnabled": false
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| regions | Array | リージョン情報 |
+| regions.regionCode | Enum | リージョンコード<br/>- KR1: `韓国(パンギョ)`<br/>- KR2: `韓国(ピョンチョン)` |
+| regions.isEnabled | Boolean | リージョンが有効かどうか |
 
 ---
 
 ## ネットワーク
 
 ### サブネットリストを表示
-
-```http
-GET /v1.0/network/subnets
-```
 
 #### 必要権限
 
@@ -282,53 +301,54 @@ GET /v1.0/network/subnets
 
 #### リクエスト
 
+```http
+GET /v1.0/network/subnets
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| subnets | Body | Array | サブネット情報 |
-| subnets.subnetId | Body | UUID | サブネットの識別子 |
-| subnets.subnetName | Body | String | サブネットを識別できる名前 |
-| subnets.subnetCidr | Body | String | サブネットのCIDR |
-| subnets.usingGateway | Body | Boolean | ゲートウェイ使用有無 |
-| subnets.availableIpCount | Body | Number | 使用可能なIP数 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "subnets": [
-        {
-            "subnetId": "550e8400-e29b-41d4-a716-446655440000",
-            "subnetName": "subnetName-example",
-            "subnetCidr": "192.168.0.0/24",
-            "usingGateway": false,
-            "availableIpCount": 1
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"subnets": [
+{
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"subnetName": "subnetName-example",
+"subnetCidr": "192.168.0.0/24",
+"usingGateway": false,
+"availableIpCount": 1
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| subnets | Array | サブネットオブジェクト |
+| subnets.subnetId | UUID | サブネットの識別子 |
+| subnets.subnetName | String | サブネットを識別できる名前 |
+| subnets.subnetCidr | String | サブネットのCIDR |
+| subnets.usingGateway | Boolean | ゲートウェイ使用有無 |
+| subnets.availableIpCount | Number | 使用可能なIP数 |
 
 ---
 
 ## ストレージ
 
 ### ストレージタイプリストを表示
-
-```http
-GET /v1.0/storage-types
-```
 
 #### 必要権限
 
@@ -338,33 +358,38 @@ GET /v1.0/storage-types
 
 #### リクエスト
 
+```http
+GET /v1.0/storage-types
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| storageTypes | Body | Array | ストレージタイプリスト |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "storageTypes": [
-        "General SSD",
-        "General HDD"
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"storageTypes": [
+"General SSD",
+"General HDD"
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| storageTypes | Array | ストレージタイプリスト |
 
 ---
 
@@ -389,10 +414,6 @@ GET /v1.0/storage-types
 
 ### 作業情報の詳細を表示
 
-```http
-GET /v1.0/jobs/{jobId}
-```
-
 #### 必要権限
 
 | 権限名 | 説明 |
@@ -401,58 +422,62 @@ GET /v1.0/jobs/{jobId}
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v1.0/jobs/{jobId}
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| jobId | URL | UUID | O |  |
+| jobId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 作業の識別子 |
-| jobStatus | Body | Enum | 作業の現在状態<br/>- DELETED<br/>- CANNOT_PROGRESS<br/>- FAILED<br/>- ERROR<br/>- CANCELED<br/>- INTERRUPTED<br/>- COMPLETED<br/>- COMPLETED_WITH_ERROR<br/>- RUNNING<br/>- PREPARING<br/>- READY<br/>- CREATED<br/>- FAIL_TO_READY<br/>- REGISTERED<br/>- FAIL_TO_REGISTER<br/>- WAIT_TO_REGISTER |
-| resourceRelations | Body | Array | 関連リソースリスト |
-| resourceRelations.resourceType | Body | String | 関連リソースタイプ |
-| resourceRelations.resourceId | Body | String | 関連リソースの識別子 |
-| createdYmdt | Body | DateTime | 作成日時 |
-| updatedYmdt | Body | DateTime | 修正日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000",
-    "jobStatus": "DELETED",
-    "resourceRelations": [
-        {
-            "resourceType": "resourceType-example",
-            "resourceId": "resourceId-example"
-        }
-    ],
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000",
+"jobStatus": "DELETED",
+"resourceRelations": [
+{
+"resourceType": "resourceType-example",
+"resourceId": "resourceId-example"
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
 
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
+| jobStatus | Enum | 作業の現在状態<br/>- DELETED<br/>- CANNOT_PROGRESS<br/>- FAILED<br/>- ERROR<br/>- CANCELED<br/>- INTERRUPTED<br/>- COMPLETED<br/>- COMPLETED_WITH_ERROR<br/>- RUNNING<br/>- PREPARING<br/>- READY<br/>- CREATED<br/>- FAIL_TO_READY<br/>- REGISTERED<br/>- FAIL_TO_REGISTER<br/>- WAIT_TO_REGISTER |
+| resourceRelations | Array | 関連リソースリスト |
+| resourceRelations.resourceType | String | 関連リソースタイプ |
+| resourceRelations.resourceId | String | 関連リソースの識別子 |
+| createdYmdt | DateTime | 作成日時 |
+| updatedYmdt | DateTime | 修正日時 |
+
 ---
+
 ## DBインスタンスグループ
 
 ### DBインスタンスグループリストを表示
-
-```http
-GET /v1.0/db-instance-groups
-```
 
 #### 必要権限
 
@@ -462,51 +487,52 @@ GET /v1.0/db-instance-groups
 
 #### リクエスト
 
+```http
+GET /v1.0/db-instance-groups
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| dbInstanceGroups | Body | Array | DBインスタンスグループ情報 |
-| dbInstanceGroups.dbInstanceGroupId | Body | UUID | DBインスタンスグループの識別子 |
-| dbInstanceGroups.dbInstanceGroupStatus | Body | Enum | DBインスタンスグループの現在状態<br/>- CREATED: `作成済み`<br/>- DELETED: `削除済み` |
-| dbInstanceGroups.replicationType | Body | Enum | DBインスタンスグループのレプリケーションタイプ<br/>- STANDALONE: `高可用性を使用しない`<br/>- HIGH_AVAILABILITY: `高可用性を使用する` |
-| dbInstanceGroups.createdYmdt | Body | DateTime | 作成日時 |
-| dbInstanceGroups.updatedYmdt | Body | DateTime | 修正日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceGroups": [
-        {
-            "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbInstanceGroupStatus": "CREATED",
-            "replicationType": "STANDALONE",
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbInstanceGroups": [
+{
+"dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceGroupStatus": "CREATED",
+"replicationType": "STANDALONE",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbInstanceGroups | Array | DBインスタンスグループ情報 |
+| dbInstanceGroups.dbInstanceGroupId | UUID | DBインスタンスグループの識別子 |
+| dbInstanceGroups.dbInstanceGroupStatus | Enum | DBインスタンスグループの現在状態<br/>- CREATED: `作成済み`<br/>- DELETED: `削除済み` |
+| dbInstanceGroups.replicationType | Enum | DBインスタンスグループのレプリケーションタイプ<br/>- STANDALONE: `高可用性を使用しない`<br/>- HIGH_AVAILABILITY: `高可用性を使用する` |
+| dbInstanceGroups.createdYmdt | DateTime | 作成日時 |
+| dbInstanceGroups.updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### DBインスタンスグループ詳細を表示
-
-```http
-GET /v1.0/db-instance-groups/{dbInstanceGroupId}
-```
 
 #### 必要権限
 
@@ -516,61 +542,64 @@ GET /v1.0/db-instance-groups/{dbInstanceGroupId}
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v1.0/db-instance-groups/{dbInstanceGroupId}
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceGroupId | URL | UUID | O |  |
+| dbInstanceGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| dbInstanceGroupId | Body | UUID | DBインスタンスグループの識別子 |
-| dbInstanceGroupStatus | Body | Enum | DBインスタンスグループの現在状態<br/>- CREATED: `作成済み`<br/>- DELETED: `削除済み` |
-| replicationType | Body | Enum | DBインスタンスグループのレプリケーションタイプ<br/>- STANDALONE: `高可用性を使用しない`<br/>- HIGH_AVAILABILITY: `高可用性を使用する` |
-| dbInstances | Body | Array | DBインスタンスグループに属するDBインスタンスリスト |
-| dbInstances.dbInstanceId | Body | UUID | DBインスタンスの識別子 |
-| dbInstances.dbInstanceType | Body | Enum | DBインスタンスのロールタイプ<br/>- MASTER: `マスター`<br/>- FAILED_MASTER: `フェイルオーバーされたマスター`<br/>- CANDIDATE_MASTER: `予備マスター`<br/>- READ_ONLY_SLAVE: `リードレプリカ` |
-| dbInstances.dbInstanceStatus | Body | Enum | DBインスタンスの現在状態<br/>- BEFORE_CREATE: `作成前(グレー)`<br/>- AVAILABLE: `使用可能(緑)`<br/>- STORAGE_FULL: `容量不足(赤)`<br/>- FAIL_TO_CREATE: `作成失敗(赤)`<br/>- FAIL_TO_CONNECT: `接続失敗(赤)`<br/>- REPLICATION_STOP: `複製中断(赤)`<br/>- REPLICATION_DELAY: `複製遅延(黄)`<br/>- FAILOVER: `フェイルオーバー完了(赤)`<br/>- SHUTDOWN: `停止済み(グレー)`<br/>- DELETED: `削除済み(グレー)` |
-| createdYmdt | Body | DateTime | 作成日時 |
-| updatedYmdt | Body | DateTime | 修正日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbInstanceGroupStatus": "CREATED",
-    "replicationType": "STANDALONE",
-    "dbInstances": [
-        {
-            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbInstanceType": "MASTER",
-            "dbInstanceStatus": "BEFORE_CREATE"
-        }
-    ],
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceGroupStatus": "CREATED",
+"replicationType": "STANDALONE",
+"dbInstances": [
+{
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceType": "MASTER",
+"dbInstanceStatus": "BEFORE_CREATE"
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbInstanceGroupId | UUID | DBインスタンスグループの識別子 |
+| dbInstanceGroupStatus | Enum | DBインスタンスグループの現在状態<br/>- CREATED: `作成済み`<br/>- DELETED: `削除済み` |
+| replicationType | Enum | DBインスタンスグループのレプリケーションタイプ<br/>- STANDALONE: `高可用性を使用しない`<br/>- HIGH_AVAILABILITY: `高可用性を使用する` |
+| dbInstances | Array | DBインスタンスグループに属するDBインスタンスリスト |
+| dbInstances.dbInstanceId | UUID | DBインスタンスの識別子 |
+| dbInstances.dbInstanceType | Enum | DBインスタンスのロールタイプ<br/>- MASTER: `マスター`<br/>- FAILED_MASTER: `障害マスター`<br/>- CANDIDATE_MASTER: `予備マスター`<br/>- READ_ONLY_SLAVE: `リードレプリカ` |
+| dbInstances.dbInstanceStatus | Enum | DBインスタンスの現在状態<br/>- BEFORE_CREATE: `作成以前(グレー)`<br/>- AVAILABLE: `使用可能(緑)`<br/>- STORAGE_FULL: `容量不足(赤)`<br/>- FAIL_TO_CREATE: `作成失敗(赤)`<br/>- FAIL_TO_CONNECT: `接続失敗(赤)`<br/>- REPLICATION_STOP: `複製中断(赤)`<br/>- REPLICATION_DELAY: `複製遅延(黄色)`<br/>- FAILOVER: `フェイルオーバー完了(赤)`<br/>- SHUTDOWN: `停止済み(グレー)`<br/>- DELETED: `削除済み(グレー)` |
+| createdYmdt | DateTime | 作成日時 |
+| updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### 拡張機能リスト照会
-
-```http
-GET /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions
-```
 
 #### 必要権限
 
@@ -580,70 +609,73 @@ GET /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceGroupId | URL | UUID | O | DBインスタンスグループID |
+| dbInstanceGroupId | URL | UUID | Y | DBインスタンスグループID |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| extensions | Body | Array | 拡張機能情報 |
-| extensions.extensionId | Body | UUID | 拡張機能の識別子 |
-| extensions.extensionName | Body | String | 拡張機能名 |
-| extensions.extensionStatus | Body | Enum | 拡張機能の状態<br/>- AVAILABLE: `使用可能`<br/>- NEED_TO_APPLY: `適用必要`<br/>- APPLYING: `適用中` |
-| extensions.databases | Body | Array | データベース情報 |
-| extensions.databases.dbInstanceGroupExtensionId | Body | UUID | DBインスタンスグループ内の拡張機能の識別子 |
-| extensions.databases.databaseId | Body | UUID | データベースの識別子 |
-| extensions.databases.databaseName | Body | String | データベース名 |
-| extensions.databases.dbInstanceGroupExtensionStatus | Body | Enum | データベースへの拡張機能インストール状態<br/>- CREATED: `作成済み`<br/>- INSTALLED: `インストール済み`<br/>- INSTALLING: `インストール中`<br/>- INSTALL_ERROR: `インストールエラー`<br/>- DELETED: `削除済み`<br/>- DELETING: `削除中`<br/>- DELETE_ERROR: `削除エラー` |
-| extensions.databases.reservedAction | Body | Enum | 予約タスク<br/>- NONE: `なし`<br/>- INSTALL: `インストール予約(適用必要)`<br/>- INSTALL_WITH_CASCADE: `強制インストール予約(適用必要)`<br/>- DELETE: `削除予約(適用必要)`<br/>- DELETE_WITH_CASCADE: `強制削除予約(適用必要)` |
-| extensions.databases.errorReason | Body | String | エラー原因 |
-| isNeedToApply | Body | Boolean | 変更事項の適用が必要かどうか |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "extensions": [
-        {
-            "extensionId": "550e8400-e29b-41d4-a716-446655440000",
-            "extensionName": "extensionName-example",
-            "extensionStatus": "AVAILABLE",
-            "databases": [
-                {
-                    "dbInstanceGroupExtensionId": "550e8400-e29b-41d4-a716-446655440000",
-                    "databaseId": "550e8400-e29b-41d4-a716-446655440000",
-                    "databaseName": "databaseName-example",
-                    "dbInstanceGroupExtensionStatus": "CREATED",
-                    "reservedAction": "NONE",
-                    "errorReason": "errorReason-example"
-                }
-            ]
-        }
-    ],
-    "isNeedToApply": false
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"extensions": [
+{
+"extensionId": "550e8400-e29b-41d4-a716-446655440000",
+"extensionName": "extensionName-example",
+"extensionStatus": "AVAILABLE",
+"databases": [
+{
+"dbInstanceGroupExtensionId": "550e8400-e29b-41d4-a716-446655440000",
+"databaseId": "550e8400-e29b-41d4-a716-446655440000",
+"databaseName": "databaseName-example",
+"dbInstanceGroupExtensionStatus": "CREATED",
+"reservedAction": "NONE",
+"errorReason": "errorReason-example"
+}
+]
+}
+],
+"isNeedToApply": false
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| extensions | Array | 拡張機能情報 |
+| extensions.extensionId | UUID | 拡張機能の識別子 |
+| extensions.extensionName | String | 拡張機能名 |
+| extensions.extensionStatus | Enum | 拡張機能の状態<br/>- AVAILABLE: `使用可能`<br/>- NEED_TO_APPLY: `適用必要`<br/>- APPLYING: `適用中` |
+| extensions.databases | Array | データベース情報 |
+| extensions.databases.dbInstanceGroupExtensionId | UUID | DBインスタンスグループ内の拡張機能の識別子 |
+| extensions.databases.databaseId | UUID | データベースID |
+| extensions.databases.databaseName | String | データベース名 |
+| extensions.databases.dbInstanceGroupExtensionStatus | Enum | データベースへの拡張機能インストール状態<br/>- CREATED: `作成済み`<br/>- INSTALLED: `インストール済み`<br/>- INSTALLING: `インストール中`<br/>- INSTALL_ERROR: `インストールエラー`<br/>- DELETED: `削除済み`<br/>- DELETING: `削除中`<br/>- DELETE_ERROR: `削除エラー` |
+| extensions.databases.reservedAction | Enum | 予約タスク<br/>- NONE: `なし`<br/>- INSTALL: `インストール予約(適用必要)`<br/>- INSTALL_WITH_CASCADE: `強制インストール予約(適用必要)`<br/>- DELETE: `削除予約(適用必要)`<br/>- DELETE_WITH_CASCADE: `強制削除予約(適用必要)` |
+| extensions.databases.errorReason | String | エラー原因 |
+| isNeedToApply | Boolean | 変更事項の適用が必要かどうか |
 
 ---
 
 ### 拡張機能変更事項適用
-
-```http
-POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/apply
-```
 
 #### 必要権限
 
@@ -653,42 +685,45 @@ POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/apply
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/apply
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceGroupId | URL | UUID | O | DBインスタンスグループID |
+| dbInstanceGroupId | URL | UUID | Y | DBインスタンスグループID |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### 拡張機能の同期
-
-```http
-POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/sync
-```
 
 #### 必要権限
 
@@ -698,42 +733,45 @@ POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/sync
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/sync
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceGroupId | URL | UUID | O | DBインスタンスグループID |
+| dbInstanceGroupId | URL | UUID | Y | DBインスタンスグループID |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### 拡張機能の削除(キャンセル)
-
-```http
-DELETE /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{dbInstanceGroupExtensionId}
-```
 
 #### 必要権限
 
@@ -743,13 +781,21 @@ DELETE /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{dbInstanceGroupE
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+DELETE /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{dbInstanceGroupExtensionId}
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceGroupId | URL | UUID | O | DBインスタンスグループID |
-| dbInstanceGroupExtensionId | URL | UUID | O | DBインスタンスグループ内の拡張機能の識別子 |
-| withCascade | Query | Boolean | O | 強制削除するかどうか |
+| dbInstanceGroupId | URL | UUID | Y | DBインスタンスグループID |
+| dbInstanceGroupExtensionId | URL | UUID | Y | DBインスタンスグループ内の拡張機能の識別子 |
+| withCascade | Query | Boolean | Y | 強制削除するかどうか |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
@@ -759,10 +805,6 @@ DELETE /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{dbInstanceGroupE
 
 ### 拡張機能のインストール
 
-```http
-POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{extensionId}
-```
-
 #### 必要権限
 
 | 権限名 | 説明 |
@@ -771,85 +813,92 @@ POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{extensionId}
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceGroupId | URL | UUID | O | DBインスタンスグループID |
-| extensionId | URL | UUID | O | 拡張機能の識別子 |
-| databaseId | Body | UUID | O | データベースの識別子 |
-| schemaName | Body | String | O | スキーマ名 |
-| withCascade | Body | Boolean | X | 関連情報を自動的にインストールするかどうか<br/>- デフォルト値: `false` |
+```http
+POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{extensionId}
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | Y | DBインスタンスグループID |
+| extensionId | URL | UUID | Y | 拡張機能の識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "databaseId": "550e8400-e29b-41d4-a716-446655440000",
-    "schemaName": "schemaName-example",
-    "withCascade": false
+"databaseId": "550e8400-e29b-41d4-a716-446655440000",
+"schemaName": "schemaName-example",
+"withCascade": false
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| databaseId | UUID | Y | データベースID |
+| schemaName | String | Y | スキーマ名 |
+| withCascade | Boolean | N | 関連情報を自動的にインストールするかどうか<br/>- デフォルト値: `false` |
 
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
 
 ---
+
 ## DBインスタンス
 
 ### DBインスタンスの状態
 
-| 状態                  | 説明                           |
+| 状態 | 説明 |
 |---------------------|------------------------------|
-| `AVAILABLE`         | DBインスタンスが使用可能な場合           |
-| `BEFORE_CREATE`     | DBインスタンス作成前の場合            |
-| `STORAGE_FULL`      | DBインスタンスの容量が不足している場合          |
-| `FAIL_TO_CREATE`    | DBインスタンス作成に失敗した場合           |
-| `FAIL_TO_CONNECT`   | DBインスタンス接続に失敗した場合           |
-| `REPLICATION_STOP`  | DBインスタンスの複製が中断された場合          |
-| `FAILOVER`          | 高可用性DBインスタンスのフェイルオーバーが完了した場合      |
-| `SHUTDOWN`          | DBインスタンスが中止された場合              |
-| `DELETED`           | DBインスタンスが削除された場合              |
+| `AVAILABLE` | DBインスタンスが使用可能な場合 |
+| `BEFORE_CREATE` | DBインスタンス作成前の場合 |
+| `STORAGE_FULL` | DBインスタンスの容量が不足している場合 |
+| `FAIL_TO_CREATE` | DBインスタンス作成に失敗した場合 |
+| `FAIL_TO_CONNECT` | DBインスタンス接続に失敗した場合 |
+| `REPLICATION_STOP` | DBインスタンスの複製が中断された場合 |
+| `FAILOVER` | 高可用性DBインスタンスのフェイルオーバーが完了した場合 |
+| `SHUTDOWN` | DBインスタンスが中止された場合 |
+| `DELETED` | DBインスタンスが削除された場合 |
 
 ### DBインスタンスの進行状態
 
-| 状態                         | 説明           |
+| 状態 | 説明 |
 |----------------------------|--------------|
 | `APPLYING_PARAMETER_GROUP` | パラメータグループ適用中 |
-| `BACKING_UP`               | バックアップ中         |
-| `CANCELING`                | キャンセル中         |
-| `CREATING`                 | 作成中         |
-| `CREATING_SCHEMA`          | スキーマ作成中  |
-| `CREATING_USER`            | ユーザー作成中     |
-| `DELETING`                 | 削除中         |
-| `DELETING_SCHEMA`          | スキーマ削除中  |
-| `DELETING_USER`            | ユーザー削除中     |
-| `EXPORTING_BACKUP`         | バックアップをエクスポート中   |
-| `FAILING_OVER`             | フェイルオーバー中      |
-| `MIGRATING`                | マイグレーション中         |
-| `MODIFYING`                | 修正中         |
-| `PREPARING`                | 準備中         |
-| `PROMOTING`                | 昇格中         |
-| `REBUILDING`               | 再構築中        |
-| `REPAIRING`                | 復旧中         |
-| `REPLICATING`              | 複製中         |
-| `RESTARTING`               | 再起動中         |
-| `RESTARTING_FORCIBLY`      | 強制再起動中     |
-| `RESTORING`                | 復元中         |
-| `STARTING`                 | 起動中         |
-| `STOPPING`                 | 停止中         |
-| `SYNCING_SCHEMA`           | スキーマ同期中 |
-| `SYNCING_USER`             | ユーザー同期中    |
-| `UPDATING_USER`            | ユーザー修正中     |
+| `BACKING_UP` | バックアップ中 |
+| `CANCELING` | キャンセル中 |
+| `CREATING` | 作成中 |
+| `CREATING_SCHEMA` | スキーマ作成中 |
+| `CREATING_USER` | ユーザー作成中 |
+| `DELETING` | 削除中 |
+| `DELETING_SCHEMA` | スキーマ削除中 |
+| `DELETING_USER` | ユーザー削除中 |
+| `EXPORTING_BACKUP` | バックアップをエクスポート中 |
+| `FAILING_OVER` | フェイルオーバー中 |
+| `MIGRATING` | マイグレーション中 |
+| `MODIFYING` | 修正中 |
+| `PREPARING` | 準備中 |
+| `PROMOTING` | 昇格中 |
+| `REBUILDING` | 再構築中 |
+| `REPAIRING` | 復旧中 |
+| `REPLICATING` | 複製中 |
+| `RESTARTING` | 再起動中 |
+| `RESTARTING_FORCIBLY` | 強制再起動中 |
+| `RESTORING` | 復元中 |
+| `STARTING` | 起動中 |
+| `STOPPING` | 停止中 |
+| `SYNCING_SCHEMA` | スキーマ同期中 |
+| `SYNCING_USER` | ユーザー同期中 |
+| `UPDATING_USER` | ユーザー修正中 |
 
 ### DBインスタンスリストを表示
-
-```http
-GET /v1.0/db-instances
-```
 
 #### 必要権限
 
@@ -859,63 +908,64 @@ GET /v1.0/db-instances
 
 #### リクエスト
 
+```http
+GET /v1.0/db-instances
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| dbInstances | Body | Array | DBインスタンスリスト |
-| dbInstances.dbInstanceId | Body | UUID | DBインスタンスの識別子 |
-| dbInstances.dbInstanceGroupId | Body | UUID | DBインスタンスグループの識別子 |
-| dbInstances.dbInstanceName | Body | String | DBインスタンスを識別できる名前 |
-| dbInstances.description | Body | String | DBインスタンスの追加情報 |
-| dbInstances.dbVersion | Body | Enum | DBバージョン情報 |
-| dbInstances.dbPort | Body | Number | DBポート |
-| dbInstances.dbInstanceType | Body | Enum | DBインスタンスのロールタイプ<br/>- MASTER: `マスター`<br/>- FAILED_MASTER: `フェイルオーバーされたマスター`<br/>- CANDIDATE_MASTER: `予備マスター`<br/>- READ_ONLY_SLAVE: `リードレプリカ` |
-| dbInstances.dbInstanceStatus | Body | Enum | DBインスタンスの現在状態<br/>- BEFORE_CREATE: `作成前(グレー)`<br/>- AVAILABLE: `使用可能(グリーン)`<br/>- STORAGE_FULL: `容量不足(レッド)`<br/>- FAIL_TO_CREATE: `作成失敗(レッド)`<br/>- FAIL_TO_CONNECT: `接続失敗(レッド)`<br/>- REPLICATION_STOP: `複製中断(レッド)`<br/>- REPLICATION_DELAY: `複製遅延(イエロー)`<br/>- FAILOVER: `フェイルオーバー完了(レッド)`<br/>- SHUTDOWN: `停止済み(グレー)`<br/>- DELETED: `削除済み(グレー)` |
-| dbInstances.progressStatus | Body | String | DBインスタンスの現在進行状態 |
-| dbInstances.createdYmdt | Body | DateTime | 作成日時 |
-| dbInstances.updatedYmdt | Body | DateTime | 修正日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstances": [
-        {
-            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbInstanceName": "dbInstanceName-example",
-            "description": "description-example",
-            "dbVersion": "POSTGRESQL_V14_17",
-            "dbPort": 1,
-            "dbInstanceType": "MASTER",
-            "dbInstanceStatus": "BEFORE_CREATE",
-            "progressStatus": "progressStatus-example",
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbInstances": [
+{
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceName": "dbInstanceName-example",
+"description": "description-example",
+"dbVersion": "POSTGRESQL_V14_17",
+"dbPort": 1,
+"dbInstanceType": "MASTER",
+"dbInstanceStatus": "BEFORE_CREATE",
+"progressStatus": "progressStatus-example",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbInstances | Array | DBインスタンスリスト |
+| dbInstances.dbInstanceId | UUID | DBインスタンスの識別子 |
+| dbInstances.dbInstanceGroupId | UUID | DBインスタンスグループの識別子 |
+| dbInstances.dbInstanceName | String | DBインスタンスを識別できる名前 |
+| dbInstances.description | String | DBインスタンスの追加情報 |
+| dbInstances.dbVersion | String | DBエンジンタイプ |
+| dbInstances.dbPort | Number | DBポート |
+| dbInstances.dbInstanceType | Enum | DBインスタンスのロールタイプ<br/>- MASTER: `マスター`<br/>- FAILED_MASTER: `障害マスター`<br/>- CANDIDATE_MASTER: `予備マスター`<br/>- READ_ONLY_SLAVE: `リードレプリカ` |
+| dbInstances.dbInstanceStatus | Enum | DBインスタンスの現在状態<br/>- BEFORE_CREATE: `作成以前(グレー)`<br/>- AVAILABLE: `使用可能(緑)`<br/>- STORAGE_FULL: `容量不足(赤)`<br/>- FAIL_TO_CREATE: `作成失敗(赤)`<br/>- FAIL_TO_CONNECT: `接続失敗(赤)`<br/>- REPLICATION_STOP: `複製中断(赤)`<br/>- REPLICATION_DELAY: `複製遅延(黄色)`<br/>- FAILOVER: `フェイルオーバー完了(赤)`<br/>- SHUTDOWN: `停止済み(グレー)`<br/>- DELETED: `削除済み(グレー)` |
+| dbInstances.progressStatus | String | DBインスタンスの現在の作業進行状態 |
+| dbInstances.createdYmdt | DateTime | 作成日時 |
+| dbInstances.updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### DBインスタンスを作成する
-
-```http
-POST /v1.0/db-instances
-```
 
 #### 必要権限
 
@@ -925,115 +975,116 @@ POST /v1.0/db-instances
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceName | Body | String | O | DBインスタンスを識別できる名前 |
-| dbInstanceCandidateName | Body | String | X | DBインスタンスを識別できる予備マスター名 |
-| description | Body | String | X | DBインスタンスの追加情報 |
-| dbFlavorId | Body | UUID | O | DBインスタンス仕様の識別子 |
-| dbVersion | Body | Enum | O | DBバージョン情報 |
-| dbPort | Body | Number | O | DBポート<br/>- 最小値: 5432、最大値: 45432 |
-| databaseName | Body | String | O | データベース名 |
-| dbUserName | Body | String | O | DBユーザーアカウント名 |
-| dbPassword | Body | String | O | DBユーザーアカウントのパスワード |
-| parameterGroupId | Body | UUID | O | パラメータグループの識別子 |
-| dbSecurityGroupIds | Body | Array | X | DBセキュリティグループの識別子リスト |
-| userGroupIds | Body | Array | X | ユーザーグループの識別子リスト |
-| useHighAvailability | Body | Boolean | X | 高可用性の使用有無<br/>- デフォルト値: `false` |
-| useDefaultNotification | Body | Boolean | X | 基本通知の使用有無<br/>- デフォルト値: `false` |
-| useDeletionProtection | Body | Boolean | X | 削除保護の有無<br/>- デフォルト値: `false` |
-| pingInterval | Body | Number | X | Ping間隔(秒)<br/>- 最小値: `1`<br/>- 最大値: `600` |
-| failoverReplWaitingTime | Body | Number | X | フェイルオーバー複製遅延待機時間(秒)<br/>- 最小値: `-1` |
-| network | Body | Object | O | ネットワーク情報オブジェクト |
-| network.subnetId | Body | UUID | O | サブネットの識別子 |
-| network.usePublicAccess | Body | Boolean | X | 外部接続可否<br/>- デフォルト値: `false` |
-| network.availabilityZone | Body | Enum | X | DBインスタンスを作成するアベイラビリティゾーン |
-| storage | Body | Object | O | ストレージ情報オブジェクト |
-| storage.storageType | Body | Enum | O | データストレージタイプ |
-| storage.storageSize | Body | Number | O | データストレージサイズ(GB)<br/>- 最小値: `20` |
-| backup | Body | Object | O | バックアップ情報オブジェクト |
-| backup.backupPeriod | Body | Number | O | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
-| backup.backupRetryCount | Body | Number | X | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
-| backup.backupSchedules | Body | Array | O | バックアップスケジュール情報 |
-| backup.backupSchedules.backupWndBgnTime | Body | Time | O | バックアップ開始時間 |
-| backup.backupSchedules.backupWndDuration | Body | Enum | O | バックアップWindow<br/>バックアップ開始時間から設定された期間内に自動バックアップが実行されます。<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+```http
+POST /v1.0/db-instances
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "dbInstanceName": "dbInstanceName-example",
-    "dbInstanceCandidateName": "dbInstanceCandidateName-example",
-    "description": "description-example",
-    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbVersion": "POSTGRESQL_V14_17",
-    "dbPort": 1,
-    "databaseName": "databaseName-example",
-    "dbUserName": "dbUserName-example",
-    "dbPassword": "dbPassword-example",
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbSecurityGroupIds": [],
-    "userGroupIds": [],
-    "useHighAvailability": false,
-    "useDefaultNotification": false,
-    "useDeletionProtection": false,
-    "pingInterval": 1,
-    "failoverReplWaitingTime": 1,
-    "network": {
-        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
-        "usePublicAccess": false,
-        "availabilityZone": "kr-pub-a"
-    },
-    "storage": {
-        "storageType": "General SSD",
-        "storageSize": 20
-    },
-    "backup": {
-        "backupPeriod": 0,
-        "backupRetryCount": 0,
-        "backupSchedules": [
-            {
-                "backupWndBgnTime": "00:00:00",
-                "backupWndDuration": "HALF_AN_HOUR"
-            }
-        ]
-    }
+"dbInstanceName": "dbInstanceName-example",
+"dbInstanceCandidateName": "dbInstanceCandidateName-example",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbVersion": "POSTGRESQL_V14_17",
+"dbPort": 1,
+"databaseName": "databaseName-example",
+"dbUserName": "dbUserName-example",
+"dbPassword": "dbPassword-example",
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useHighAvailability": false,
+"useDefaultNotification": false,
+"useDeletionProtection": false,
+"pingInterval": 1,
+"failoverReplWaitingTime": 1,
+"network": {
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
+},
+"storage": {
+"storageType": "General SSD",
+"storageSize": 20
+},
+"backup": {
+"backupPeriod": 0,
+"backupRetryCount": 0,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
+}
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | DBインスタンスを識別できる名前 |
+| dbInstanceCandidateName | String | N | DBインスタンスを識別できる予備マスター名 |
+| description | String | N | DBインスタンスの追加情報 |
+| dbFlavorId | UUID | Y | DBインスタンス仕様の識別子 |
+| dbVersion | String | Y | DBエンジンタイプ |
+| dbPort | Number | Y | DBポート<br/>- 最小値: 5432、最大値: 45432 |
+| databaseName | String | Y | データベース名 |
+| dbUserName | String | Y | DBユーザーアカウント名 |
+| dbPassword | String | Y | DBユーザーアカウントパスワード |
+| parameterGroupId | UUID | Y | パラメータグループの識別子 |
+| dbSecurityGroupIds | Array | N | DBセキュリティグループの識別子リスト |
+| userGroupIds | Array | N | ユーザーグループの識別子リスト |
+| useHighAvailability | Boolean | N | 高可用性の使用有無<br/>- デフォルト値: `false` |
+| useDefaultNotification | Boolean | N | 基本通知の使用有無<br/>- デフォルト値: `false` |
+| useDeletionProtection | Boolean | N | 削除保護の有無<br/>- デフォルト値: `false` |
+| pingInterval | Number | N | Ping間隔(秒)<br/>- 最小値: `1`<br/>- 最大値: `600` |
+| failoverReplWaitingTime | Number | N | フェイルオーバー複製遅延待機時間(秒)<br/>- 最小値: `-1` |
+| network | Object | Y | ネットワーク情報オブジェクト |
+| network.subnetId | UUID | Y | サブネットの識別子 |
+| network.usePublicAccess | Boolean | N | 外部接続可否<br/>- デフォルト値: `false` |
+| network.availabilityZone | Enum | N | DBインスタンスを作成するアベイラビリティゾーン |
+| storage | Object | Y | ストレージ情報オブジェクト |
+| storage.storageType | Enum | Y | ストレージタイプ |
+| storage.storageSize | Number | Y | データストレージサイズ(GB)<br/>- 最小値: `20` |
+| backup | Object | Y | バックアップ情報オブジェクト |
+| backup.backupPeriod | Number | Y | バックアップの保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| backup.backupRetryCount | Number | N | バックアップの再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| backup.backupSchedules | Array | Y | バックアップスケジュール情報 |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | バックアップ開始時刻 |
+| backup.backupSchedules.backupWndDuration | Enum | Y | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
----
-### オブジェクトストレージにあるバックアップからDBインスタンスを復元する
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
-```http
-POST /v1.0/db-instances/restore-from-obs
-```
+---
+
+### オブジェクトストレージにあるバックアップからDBインスタンスを復元する
 
 #### 必要権限
 
@@ -1043,127 +1094,127 @@ POST /v1.0/db-instances/restore-from-obs
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceName | Body | String | X | DBインスタンスを識別できる名前<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
-| dbInstanceCandidateName | Body | String | X | DBインスタンスを識別できる予備マスターの名前 |
-| description | Body | String | X | DBインスタンスの追加情報<br/>- 最大長さ: `100` |
-| dbFlavorId | Body | UUID | O | DBインスタンス仕様の識別子 |
-| dbPort | Body | Number | X | DBポート<br/>- 最小値: 5432、最大値: 45432 |
-| dbVersion | Body | Enum | O | DBエンジンタイプ |
-| useHighAvailability | Body | Boolean | X | 高可用性の使用有無<br/>- デフォルト値: `false` |
-| imageId | Body | UUID | X | イメージの識別子 |
-| pingInterval | Body | Number | X | 高可用性使用時のPing間隔(秒)<br/>- 最小値: `1`<br/>- 最大値: `600` |
-| failoverReplWaitingTime | Body | Number | X | フェイルオーバー複製遅延待機時間(秒)<br/>- 最小値: `-1` |
-| storage | Body | Object | O | ストレージ情報オブジェクト |
-| storage.storageType | Body | Enum | O | ストレージタイプ |
-| storage.storageSize | Body | Number | O | データストレージサイズ(GB)<br/>- 最小値: `20` |
-| network | Body | Object | O | ネットワーク情報オブジェクト |
-| network.subnetId | Body | UUID | O | サブネットの識別子 |
-| network.usePublicAccess | Body | Boolean | X | 外部接続の可否<br/>- デフォルト値: `false` |
-| network.availabilityZone | Body | Enum | X | DBインスタンスを作成するアベイラビリティゾーン |
-| backup | Body | Object | O | バックアップ情報オブジェクト |
-| backup.backupPeriod | Body | Number | O | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
-| backup.backupRetryCount | Body | Number | X | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
-| backup.replicationRegion | Body | Enum | X | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)`<br/>- KR2: `韓国(ピョンチョン)` |
-| backup.backupSchedules | Body | Array | O | バックアップスケジュールリスト |
-| backup.backupSchedules.backupWndBgnTime | Body | Time | O | バックアップ開始時刻 |
-| backup.backupSchedules.backupWndDuration | Body | Enum | O | バックアップ期間<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
-| restore | Body | Object | O | 復元情報オブジェクト |
-| restore.tenantId | Body | String | O | バックアップが保存されているオブジェクトストレージのテナントID |
-| restore.username | Body | String | O | NHN CloudアカウントまたはIAMメンバーID |
-| restore.password | Body | String | O | バックアップが保存されているオブジェクトストレージのAPIパスワード |
-| restore.targetContainer | Body | String | O | バックアップが保存されているオブジェクトストレージのコンテナ |
-| restore.objectPath | Body | String | O | コンテナに保存されているバックアップのパス |
-| useDefaultNotification | Body | Boolean | X | デフォルト通知の使用有無<br/>- デフォルト値: `false` |
-| parameterGroupId | Body | UUID | O | パラメータグループの識別子 |
-| dbSecurityGroupIds | Body | Array | X | DBセキュリティグループの識別子リスト |
-| userGroupIds | Body | Array | X | ユーザーグループの識別子リスト |
-| useDeletionProtection | Body | Boolean | X | 削除保護の有無<br/>- デフォルト値: `false` |
+```http
+POST /v1.0/db-instances/restore-from-obs
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "dbInstanceName": "dbInstanceName",
-    "dbInstanceCandidateName": "dbInstanceCandidateName-example",
-    "description": "description-example",
-    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbPort": 1,
-    "dbVersion": "POSTGRESQL_V14_17",
-    "useHighAvailability": false,
-    "imageId": "550e8400-e29b-41d4-a716-446655440000",
-    "pingInterval": 3,
-    "failoverReplWaitingTime": 60,
-    "storage": {
-        "storageType": "General SSD",
-        "storageSize": 20
-    },
-    "network": {
-        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
-        "usePublicAccess": false,
-        "availabilityZone": "kr-pub-a"
-    },
-    "backup": {
-        "backupPeriod": 0,
-        "backupRetryCount": 0,
-        "replicationRegion": "KR1",
-        "backupSchedules": [
-            {
-                "backupWndBgnTime": "00:00:00",
-                "backupWndDuration": "HALF_AN_HOUR"
-            }
-        ]
-    },
-    "restore": {
-        "tenantId": "0123456789abcdef0123456789abcdef",
-        "username": "username-example",
-        "password": "password-example",
-        "targetContainer": "targetContainer-example",
-        "objectPath": "objectPath-example"
-    },
-    "useDefaultNotification": false,
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbSecurityGroupIds": [],
-    "userGroupIds": [],
-    "useDeletionProtection": false
+"dbInstanceName": "dbInstanceName",
+"dbInstanceCandidateName": "dbInstanceCandidateName-example",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbPort": 1,
+"dbVersion": "POSTGRESQL_V14_17",
+"useHighAvailability": false,
+"imageId": "550e8400-e29b-41d4-a716-446655440000",
+"pingInterval": 3,
+"failoverReplWaitingTime": 60,
+"storage": {
+"storageType": "General SSD",
+"storageSize": 20
+},
+"network": {
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
+},
+"backup": {
+"backupPeriod": 0,
+"backupRetryCount": 0,
+"replicationRegion": "KR1",
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
+},
+"restore": {
+"tenantId": "0123456789abcdef0123456789abcdef",
+"username": "username-example",
+"password": "password-example",
+"targetContainer": "targetContainer-example",
+"objectPath": "objectPath-example"
+},
+"useDefaultNotification": false,
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useDeletionProtection": false
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | N | DBインスタンスを識別できる名前<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| dbInstanceCandidateName | String | N | DBインスタンスを識別できる予備マスター名 |
+| description | String | N | DBインスタンスの追加情報<br/>- 最大長: `100` |
+| dbFlavorId | UUID | Y | DBインスタンス仕様の識別子 |
+| dbPort | Number | N | DBポート<br/>- 最小値: 5432、最大値: 45432 |
+| dbVersion | String | Y | DBエンジンタイプ |
+| useHighAvailability | Boolean | N | 高可用性の使用有無<br/>- デフォルト値: `false` |
+| imageId | UUID | N | イメージの識別子 |
+| pingInterval | Number | N | 高可用性使用時のPing間隔(秒)<br/>- 最小値: `1`<br/>- 最大値: `600` |
+| failoverReplWaitingTime | Number | N | フェイルオーバー複製遅延待機時間(秒)<br/>- 最小値: `-1` |
+| storage | Object | Y | ストレージ情報オブジェクト |
+| storage.storageType | Enum | Y | ストレージタイプ |
+| storage.storageSize | Number | Y | データストレージサイズ(GB)<br/>- 最小値: `20` |
+| network | Object | Y | ネットワーク情報オブジェクト |
+| network.subnetId | UUID | Y | サブネットの識別子 |
+| network.usePublicAccess | Boolean | N | 外部接続可否<br/>- デフォルト値: `false` |
+| network.availabilityZone | Enum | N | DBインスタンスを作成するアベイラビリティゾーン |
+| backup | Object | Y | バックアップ情報オブジェクト |
+| backup.backupPeriod | Number | Y | バックアップの保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| backup.backupRetryCount | Number | N | バックアップの再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| backup.replicationRegion | Enum | N | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)`<br/>- KR2: `韓国(ピョンチョン)` |
+| backup.backupSchedules | Array | Y | バックアップスケジュールリスト |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | バックアップ開始時刻 |
+| backup.backupSchedules.backupWndDuration | Enum | Y | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+| restore | Object | Y | 復元情報オブジェクト |
+| restore.tenantId | String | Y | バックアップが保存されているオブジェクトストレージのテナントID |
+| restore.username | String | Y | NHN CloudアカウントまたはIAMメンバーID |
+| restore.password | String | Y | バックアップが保存されているオブジェクトストレージのAPIパスワード |
+| restore.targetContainer | String | Y | バックアップが保存されているオブジェクトストレージのコンテナ |
+| restore.objectPath | String | Y | コンテナに保存されているバックアップのパス |
+| useDefaultNotification | Boolean | N | 基本通知の使用有無<br/>- デフォルト値: `false` |
+| parameterGroupId | UUID | Y | パラメータグループの識別子 |
+| dbSecurityGroupIds | Array | N | DBセキュリティグループの識別子リスト |
+| userGroupIds | Array | N | ユーザーグループの識別子リスト |
+| useDeletionProtection | Boolean | N | 削除保護の有無<br/>- デフォルト値: `false` |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### DBインスタンスの削除
-
-```http
-DELETE /v1.0/db-instances/{dbInstanceId}
-```
 
 #### 必要権限
 
@@ -1173,42 +1224,45 @@ DELETE /v1.0/db-instances/{dbInstanceId}
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+DELETE /v1.0/db-instances/{dbInstanceId}
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### DBインスタンス詳細を表示
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}
-```
 
 #### 必要権限
 
@@ -1218,82 +1272,85 @@ GET /v1.0/db-instances/{dbInstanceId}
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v1.0/db-instances/{dbInstanceId}
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| dbInstanceId | Body | UUID | DBインスタンスの識別子 |
-| dbInstanceGroupId | Body | UUID | DBインスタンスグループの識別子 |
-| dbInstanceName | Body | String | DBインスタンスを識別できる名前 |
-| description | Body | String | DBインスタンスの追加情報 |
-| dbVersion | Body | Enum | DBエンジンタイプ |
-| dbPort | Body | Number | DBポート |
-| dbInstanceType | Body | Enum | DBインスタンスのロールタイプ<br/>- MASTER: `マスター`<br/>- FAILED_MASTER: `フェイルオーバーされたマスター`<br/>- CANDIDATE_MASTER: `予備マスター`<br/>- READ_ONLY_SLAVE: `リードレプリカ` |
-| dbInstanceStatus | Body | Enum | DBインスタンスの現在状態<br/>- BEFORE_CREATE: `作成以前(グレー)`<br/>- AVAILABLE: `使用可能(緑)`<br/>- STORAGE_FULL: `容量不足(赤)`<br/>- FAIL_TO_CREATE: `作成失敗(赤)`<br/>- FAIL_TO_CONNECT: `接続失敗(赤)`<br/>- REPLICATION_STOP: `複製中断(赤)`<br/>- REPLICATION_DELAY: `複製遅延(黄色)`<br/>- FAILOVER: `フェイルオーバー完了(赤)`<br/>- SHUTDOWN: `停止済み(グレー)`<br/>- DELETED: `削除済み(グレー)` |
-| progressStatus | Body | String | DBインスタンスの現在の作業進行状態 |
-| dbFlavorId | Body | UUID | DBインスタンス仕様の識別子 |
-| parameterGroupId | Body | UUID | DBインスタンスに適用されたパラメータグループの識別子 |
-| dbSecurityGroupIds | Body | Array | DBインスタンスに適用されたDBセキュリティグループの識別子リスト |
-| notificationGroupIds | Body | Array | DBインスタンスに適用された通知グループの識別子リスト |
-| useDeletionProtection | Body | Boolean | DBインスタンスの削除保護の有無 |
-| needToApplyParameterGroup | Body | Boolean | 最新パラメータグループの適用可否 |
-| needMigration | Body | Boolean | マイグレーションの要否 |
-| osVersion | Body | String | OSバージョン |
-| createdYmdt | Body | DateTime | 作成日時 |
-| updatedYmdt | Body | DateTime | 修正日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbInstanceName": "dbInstanceName-example",
-    "description": "description-example",
-    "dbVersion": "POSTGRESQL_V14_17",
-    "dbPort": 1,
-    "dbInstanceType": "MASTER",
-    "dbInstanceStatus": "BEFORE_CREATE",
-    "progressStatus": "progressStatus-example",
-    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbSecurityGroupIds": [
-        "550e8400-e29b-41d4-a716-446655440000"
-    ],
-    "notificationGroupIds": [
-        "550e8400-e29b-41d4-a716-446655440000"
-    ],
-    "useDeletionProtection": false,
-    "needToApplyParameterGroup": false,
-    "needMigration": false,
-    "osVersion": "osVersion-example",
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceName": "dbInstanceName-example",
+"description": "description-example",
+"dbVersion": "POSTGRESQL_V14_17",
+"dbPort": 1,
+"dbInstanceType": "MASTER",
+"dbInstanceStatus": "BEFORE_CREATE",
+"progressStatus": "progressStatus-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [
+"550e8400-e29b-41d4-a716-446655440000"
+],
+"notificationGroupIds": [
+"550e8400-e29b-41d4-a716-446655440000"
+],
+"useDeletionProtection": false,
+"needToApplyParameterGroup": false,
+"needMigration": false,
+"osVersion": "osVersion-example",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbInstanceId | UUID | DBインスタンスの識別子 |
+| dbInstanceGroupId | UUID | DBインスタンスグループの識別子 |
+| dbInstanceName | String | DBインスタンスを識別できる名前 |
+| description | String | DBインスタンスの追加情報 |
+| dbVersion | String | DBエンジンタイプ |
+| dbPort | Number | DBポート |
+| dbInstanceType | Enum | DBインスタンスのロールタイプ<br/>- MASTER: `マスター`<br/>- FAILED_MASTER: `障害マスター`<br/>- CANDIDATE_MASTER: `予備マスター`<br/>- READ_ONLY_SLAVE: `リードレプリカ` |
+| dbInstanceStatus | Enum | DBインスタンスの現在状態<br/>- BEFORE_CREATE: `作成以前(グレー)`<br/>- AVAILABLE: `使用可能(緑)`<br/>- STORAGE_FULL: `容量不足(赤)`<br/>- FAIL_TO_CREATE: `作成失敗(赤)`<br/>- FAIL_TO_CONNECT: `接続失敗(赤)`<br/>- REPLICATION_STOP: `複製中断(赤)`<br/>- REPLICATION_DELAY: `複製遅延(黄色)`<br/>- FAILOVER: `フェイルオーバー完了(赤)`<br/>- SHUTDOWN: `停止済み(グレー)`<br/>- DELETED: `削除済み(グレー)` |
+| progressStatus | String | DBインスタンスの現在の作業進行状態 |
+| dbFlavorId | UUID | DBインスタンス仕様の識別子 |
+| parameterGroupId | UUID | DBインスタンスに適用されたパラメータグループの識別子 |
+| dbSecurityGroupIds | Array | DBインスタンスに適用されたDBセキュリティグループの識別子リスト |
+| notificationGroupIds | Array | DBインスタンスに適用された通知グループの識別子リスト |
+| useDeletionProtection | Boolean | DBインスタンスの削除保護の有無 |
+| needToApplyParameterGroup | Boolean | 最新パラメータグループの適用可否 |
+| needMigration | Boolean | マイグレーションの要否 |
+| osVersion | String | OSバージョン |
+| createdYmdt | DateTime | 作成日時 |
+| updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### DBインスタンスを修正する
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}
-```
 
 #### 必要権限
 
@@ -1303,75 +1360,80 @@ PUT /v1.0/db-instances/{dbInstanceId}
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| dbInstanceName | Body | String | X | DBインスタンスを識別できる名前 |
-| dbInstanceCandidateName | Body | String | X | DBインスタンスを識別できる予備マスターの名前 |
-| description | Body | String | X | DBインスタンスの追加情報<br/>- 最大長さ: `100` |
-| dbPort | Body | Number | X | DBポート<br/>- 最小値: 5432、最大値: 45432 |
-| dbFlavorId | Body | UUID | X | DBインスタンス仕様の識別子 |
-| parameterGroupId | Body | UUID | X | パラメータグループの識別子 |
-| dbVersion | Body | Enum | X | DBエンジンバージョンコード |
-| dbSecurityGroupIds | Body | Array | X | DBセキュリティグループの識別子リスト |
-| executeBackup | Body | Boolean | X | 現時点バックアップを実行するかどうか<br/>- デフォルト値: `false` |
-| useOnlineFailover | Body | Boolean | X | フェイルオーバーを利用した再起動の有無<br/>- デフォルト値: `false` |
-| waitReplicationDelay | Body | Boolean | X | 複製遅延の解消を待機するかどうか<br/>- デフォルト値: `false` |
-| useReadOnly | Body | Boolean | X | 書き込み負荷のブロック<br/>- デフォルト値: `false` |
+```http
+PUT /v1.0/db-instances/{dbInstanceId}
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "dbInstanceName": "dbInstanceName-example",
-    "dbInstanceCandidateName": "dbInstanceCandidateName-example",
-    "description": "description-example",
-    "dbPort": 1,
-    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbVersion": "POSTGRESQL_V14_17",
-    "dbSecurityGroupIds": [],
-    "executeBackup": false,
-    "useOnlineFailover": false,
-    "waitReplicationDelay": false,
-    "useReadOnly": false
+"dbInstanceName": "dbInstanceName-example",
+"dbInstanceCandidateName": "dbInstanceCandidateName-example",
+"description": "description-example",
+"dbPort": 1,
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbVersion": "POSTGRESQL_V14_17",
+"dbSecurityGroupIds": [],
+"executeBackup": false,
+"useOnlineFailover": false,
+"waitReplicationDelay": false,
+"useReadOnly": false
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | N | DBインスタンスを識別できる名前 |
+| dbInstanceCandidateName | String | N | DBインスタンスを識別できる予備マスター名 |
+| description | String | N | DBインスタンスの追加情報<br/>- 最大長: `100` |
+| dbPort | Number | N | DBポート<br/>- 最小値: 5432、最大値: 45432 |
+| dbFlavorId | UUID | N | DBインスタンス仕様の識別子 |
+| parameterGroupId | UUID | N | パラメータグループの識別子 |
+| dbVersion | String | N | DBエンジンバージョンコード |
+| dbSecurityGroupIds | Array | N | DBセキュリティグループの識別子リスト |
+| executeBackup | Boolean | N | 現時点バックアップを実行するかどうか<br/>- デフォルト値: `false` |
+| useOnlineFailover | Boolean | N | フェイルオーバーを利用した再起動の有無<br/>- デフォルト値: `false` |
+| waitReplicationDelay | Boolean | N | 複製遅延の解消を待機するかどうか<br/>- デフォルト値: `false` |
+| useReadOnly | Boolean | N | 書き込み負荷のブロック<br/>- デフォルト値: `false` |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### DBインスタンスの最新パラメータグループを適用する
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/apply-recent-parameter-group
-```
 
 #### 必要権限
 
@@ -1381,41 +1443,45 @@ POST /v1.0/db-instances/{dbInstanceId}/apply-recent-parameter-group
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+POST /v1.0/db-instances/{dbInstanceId}/apply-recent-parameter-group
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
----
-### 現在のDBインスタンスで選択可能なDBバージョンの照会
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
-```http
-GET /v1.0/db-instances/{dbInstanceId}/available-db-versions
-```
+---
+
+### 現在のDBインスタンスで選択可能なDBバージョンの照会
 
 #### 必要権限
 
@@ -1425,53 +1491,56 @@ GET /v1.0/db-instances/{dbInstanceId}/available-db-versions
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v1.0/db-instances/{dbInstanceId}/available-db-versions
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| availableDbVersions | Body | Array | DBバージョン情報 |
-| availableDbVersions.dbVersionCode | Body | Enum | DBバージョンコード<br/>- MYSQL_V5633<br/>- MYSQL_V5715<br/>- MYSQL_V5719<br/>- MYSQL_V5726<br/>- MYSQL_V5731<br/>- MYSQL_V5733<br/>- MYSQL_V5737<br/>- MYSQL_V8018<br/>- MYSQL_V8023<br/>- MYSQL_V8028<br/>- MYSQL_V8032<br/>- MYSQL_V8033<br/>- MYSQL_V8034<br/>- MYSQL_V8035<br/>- MYSQL_V8036<br/>- MYSQL_V8040<br/>- MYSQL_V8041<br/>- MYSQL_V8042<br/>- MYSQL_V8043<br/>- MYSQL_V8044<br/>- MYSQL_V8045<br/>- MYSQL_V8405<br/>- MYSQL_V8406<br/>- MYSQL_V8407<br/>- MYSQL_V8408<br/>- MYSQL_V8409<br/>- MARIADB_V10330<br/>- MARIADB_V10611<br/>- MARIADB_V10612<br/>- MARIADB_V10616<br/>- MARIADB_V10622<br/>- MARIADB_V10625<br/>- MARIADB_V101107<br/>- MARIADB_V101108<br/>- MARIADB_V101113<br/>- MARIADB_V101116<br/>- MARIADB_V11407<br/>- MARIADB_V11410<br/>- MARIADB_V11806<br/>- POSTGRESQL_V14_6<br/>- POSTGRESQL_V14_15<br/>- POSTGRESQL_V14_17<br/>- POSTGRESQL_V14_19<br/>- POSTGRESQL_V17_2<br/>- POSTGRESQL_V17_4<br/>- POSTGRESQL_V17_6 |
-| availableDbVersions.dbMajorVersionCode | Body | Enum | DBメジャーバージョンコード<br/>- MYSQL_V56<br/>- MYSQL_V57<br/>- MYSQL_V80<br/>- MYSQL_V84<br/>- MARIADB_V103<br/>- MARIADB_V106<br/>- MARIADB_V1011<br/>- MARIADB_V114<br/>- MARIADB_V118<br/>- POSTGRES_V14<br/>- POSTGRES_V17 |
-| availableDbVersions.name | Body | String | DBバージョン名 |
-| availableDbVersions.canCreate | Body | Boolean | 新規作成可能かどうか |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "availableDbVersions": [
-        {
-            "dbVersionCode": "MYSQL_V5633",
-            "dbMajorVersionCode": "MYSQL_V56",
-            "name": "PostgreSQL V14.6",
-            "canCreate": false
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"availableDbVersions": [
+{
+            "dbVersionCode": "dbVersionCode-example",
+            "dbMajorVersionCode": "dbMajorVersionCode-example",
+"name": "PostgreSQL V14.6",
+"canCreate": false
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| availableDbVersions | Array | DBバージョン情報 |
+| availableDbVersions.dbVersionCode | String | DBバージョンコード |
+| availableDbVersions.dbMajorVersionCode | String | DBメジャーバージョンコード |
+| availableDbVersions.name | String | DBバージョン名 |
+| availableDbVersions.canCreate | Boolean | 新規作成可能かどうか |
 
 ---
 
 ### DBインスタンスのバックアップ
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/backup
-```
 
 #### 必要権限
 
@@ -1481,53 +1550,58 @@ POST /v1.0/db-instances/{dbInstanceId}/backup
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| backupName | Body | String | O | バックアップを識別できる名前 |
+```http
+POST /v1.0/db-instances/{dbInstanceId}/backup
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "backupName": "backupName-example"
+"backupName": "backupName-example"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| backupName | String | Y | バックアップを識別できる名前 |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### DBインスタンスバックアップ情報の照会
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}/backup-info
-```
 
 #### 必要権限
 
@@ -1537,57 +1611,60 @@ GET /v1.0/db-instances/{dbInstanceId}/backup-info
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v1.0/db-instances/{dbInstanceId}/backup-info
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| allowAutoBackup | Body | Boolean | 自動バックアップを許可するかどうか |
-| usePeriodicAutoBackup | Body | Boolean | 予定された自動バックアップを使用するかどうか |
-| backupPeriod | Body | Number | バックアップの保管期間(日) |
-| backupRetryCount | Body | Number | バックアップの再試行回数 |
-| backupSchedules | Body | Array | バックアップスケジュールリスト |
-| backupSchedules.backupWndBgnTime | Body | Time | バックアップ開始時間 |
-| backupSchedules.backupWndDuration | Body | Enum | バックアップWindows<br/>バックアップ開始時間から設定された期間内に自動バックアップが実行されます。<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "allowAutoBackup": false,
-    "usePeriodicAutoBackup": false,
-    "backupPeriod": 1,
-    "backupRetryCount": 1,
-    "backupSchedules": [
-        {
-            "backupWndBgnTime": "00:00:00",
-            "backupWndDuration": "HALF_AN_HOUR"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"allowAutoBackup": false,
+"usePeriodicAutoBackup": false,
+"backupPeriod": 1,
+"backupRetryCount": 1,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| allowAutoBackup | Boolean | 自動バックアップを許可するかどうか |
+| usePeriodicAutoBackup | Boolean | 予定された自動バックアップを使用するかどうか |
+| backupPeriod | Number | バックアップの保管期間(日) |
+| backupRetryCount | Number | バックアップの再試行回数 |
+| backupSchedules | Array | バックアップスケジュールリスト |
+| backupSchedules.backupWndBgnTime | Time | バックアップ開始時刻 |
+| backupSchedules.backupWndDuration | Enum | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
 
 ---
 
 ### DBインスタンスバックアップ情報の修正
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/backup-info
-```
 
 #### 必要権限
 
@@ -1597,68 +1674,73 @@ PUT /v1.0/db-instances/{dbInstanceId}/backup-info
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| allowAutoBackup | Body | Boolean | X | 自動バックアップを許可するかどうか |
-| usePeriodicAutoBackup | Body | Boolean | X | 予定された自動バックアップを使用するかどうか |
-| backupPeriod | Body | Number | X | バックアップの保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
-| backupRetryCount | Body | Number | X | バックアップの再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
-| backupSchedules | Body | Array | X | バックアップスケジュールリスト |
-| backupSchedules.backupWndBgnTime | Body | Time | O | バックアップ開始時間 |
-| backupSchedules.backupWndDuration | Body | Enum | O | バックアップWindows<br/>バックアップ開始時間から設定された期間内に自動バックアップが実行されます。<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/backup-info
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "allowAutoBackup": false,
-    "usePeriodicAutoBackup": false,
-    "backupPeriod": 0,
-    "backupRetryCount": 0,
-    "backupSchedules": [
-        {
-            "backupWndBgnTime": "00:00:00",
-            "backupWndDuration": "HALF_AN_HOUR"
-        }
-    ]
+"allowAutoBackup": false,
+"usePeriodicAutoBackup": false,
+"backupPeriod": 0,
+"backupRetryCount": 0,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| allowAutoBackup | Boolean | N | 自動バックアップを許可するかどうか |
+| usePeriodicAutoBackup | Boolean | N | 予定された自動バックアップを使用するかどうか |
+| backupPeriod | Number | N | バックアップの保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| backupRetryCount | Number | N | バックアップの再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| backupSchedules | Array | N | バックアップスケジュールリスト |
+| backupSchedules.backupWndBgnTime | Time | Y | バックアップ開始時刻 |
+| backupSchedules.backupWndDuration | Enum | Y | バックアップWindows<br/>バックアップ開始時間から設定された期間内に自動バックアップが実行されます。<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### DBインスタンスバックアップ後にオブジェクトストレージへエクスポート
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/backup-to-object-storage
-```
 
 #### 必要権限
 
@@ -1668,60 +1750,66 @@ POST /v1.0/db-instances/{dbInstanceId}/backup-to-object-storage
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| tenantId | Body | String | O | バックアップが保存されるオブジェクトストレージのテナントID<br/>- 最小長さ: `32`<br/>- 最大長さ: `32` |
-| username | Body | String | O | NHN CloudアカウントまたはIAMメンバーID |
-| password | Body | String | O | バックアップが保存されるオブジェクトストレージのAPIパスワード |
-| targetContainer | Body | String | O | バックアップが保存されるオブジェクトストレージのコンテナ |
-| objectPath | Body | String | O | コンテナに保存されるバックアップのパス |
+```http
+POST /v1.0/db-instances/{dbInstanceId}/backup-to-object-storage
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "tenantId": "0123456789abcdef0123456789abcdef",
-    "username": "username-example",
-    "password": "password-example",
-    "targetContainer": "targetContainer-example",
-    "objectPath": "objectPath-example"
+"tenantId": "0123456789abcdef0123456789abcdef",
+"username": "username-example",
+"password": "password-example",
+"targetContainer": "targetContainer-example",
+"objectPath": "objectPath-example"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| tenantId | String | Y | バックアップが保存されるオブジェクトストレージのテナントID<br/>- 最小長: `32`<br/>- 最大長: `32` |
+| username | String | Y | NHN CloudアカウントまたはIAMメンバーID |
+| password | String | Y | バックアップが保存されるオブジェクトストレージのAPIパスワード |
+| targetContainer | String | Y | バックアップが保存されるオブジェクトストレージのコンテナ |
+| objectPath | String | Y | コンテナに保存されるバックアップのパス |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
----
-### データベースリスト表示
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
-```http
-GET /v1.0/db-instances/{dbInstanceId}/databases
-```
+---
+
+### データベースリスト表示
 
 #### 必要権限
 
@@ -1731,64 +1819,67 @@ GET /v1.0/db-instances/{dbInstanceId}/databases
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v1.0/db-instances/{dbInstanceId}/databases
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| databases | Body | Array | データベース情報 |
-| databases.databaseId | Body | UUID | データベースの識別子 |
-| databases.databaseName | Body | String | データベース名 |
-| databases.databaseStatus | Body | Enum | データベースの現在状態<br/>- STABLE: `使用可能`<br/>- CREATING: `作成中`<br/>- MODIFYING: `修正中`<br/>- DELETING: `削除中`<br/>- DELETED: `削除済み`<br/>- SYNCING: `同期中`<br/>- DELETE_ERROR: `削除失敗` |
-| databases.createdYmdt | Body | DateTime | 作成日時 |
-| databases.updatedYmdt | Body | DateTime | 修正日時 |
-| databases.schemas | Body | Array | スキーマ情報 |
-| databases.schemas.schemaName | Body | String | スキーマ名 |
-| databases.errorReason | Body | String | 削除失敗の原因 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "databases": [
-        {
-            "databaseId": "550e8400-e29b-41d4-a716-446655440000",
-            "databaseName": "databaseName-example",
-            "databaseStatus": "STABLE",
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00",
-            "schemas": [
-                {
-                    "schemaName": "schemaName-example"
-                }
-            ],
-            "errorReason": "errorReason-example"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"databases": [
+{
+"databaseId": "550e8400-e29b-41d4-a716-446655440000",
+"databaseName": "databaseName-example",
+"databaseStatus": "STABLE",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00",
+"schemas": [
+{
+"schemaName": "schemaName-example"
+}
+],
+"errorReason": "errorReason-example"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| databases | Array | データベース情報 |
+| databases.databaseId | UUID | データベースの識別子 |
+| databases.databaseName | String | データベース名 |
+| databases.databaseStatus | Enum | データベースの現在状態<br/>- STABLE: `使用可能`<br/>- CREATING: `作成中`<br/>- MODIFYING: `修正中`<br/>- DELETING: `削除中`<br/>- DELETED: `削除済み`<br/>- SYNCING: `同期中`<br/>- DELETE_ERROR: `削除失敗` |
+| databases.createdYmdt | DateTime | 作成日時 |
+| databases.updatedYmdt | DateTime | 修正日時 |
+| databases.schemas | Array | スキーマ情報 |
+| databases.schemas.schemaName | String | スキーマ名 |
+| databases.errorReason | String | 削除失敗の原因 |
 
 ---
 
 ### データベース作成
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/databases
-```
 
 #### 必要権限
 
@@ -1798,53 +1889,58 @@ POST /v1.0/db-instances/{dbInstanceId}/databases
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| databaseName | Body | String | O | データベース名 |
+```http
+POST /v1.0/db-instances/{dbInstanceId}/databases
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "databaseName": "databaseName-example"
+"databaseName": "databaseName-example"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| databaseName | String | Y | データベース名 |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### データベース削除
-
-```http
-DELETE /v1.0/db-instances/{dbInstanceId}/databases/{databaseId}
-```
 
 #### 必要権限
 
@@ -1854,43 +1950,46 @@ DELETE /v1.0/db-instances/{dbInstanceId}/databases/{databaseId}
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+DELETE /v1.0/db-instances/{dbInstanceId}/databases/{databaseId}
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| databaseId | URL | UUID | O | データベースの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+| databaseId | URL | UUID | Y | データベースの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### データベースの修正
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/databases/{databaseId}
-```
 
 #### 必要権限
 
@@ -1900,55 +1999,61 @@ PUT /v1.0/db-instances/{dbInstanceId}/databases/{databaseId}
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| databaseId | URL | UUID | O | データベースの識別子 |
-| applyHbaRulesImmediately | Body | Boolean | X | 関連するアクセス制御ルールを即時適用するかどうか<br/>- デフォルト値: `false` |
-| databaseName | Body | String | O | データベース名 |
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/databases/{databaseId}
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+| databaseId | URL | UUID | Y | データベースの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "applyHbaRulesImmediately": false,
-    "databaseName": "databaseName-example"
+"applyHbaRulesImmediately": false,
+"databaseName": "databaseName-example"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| applyHbaRulesImmediately | Boolean | N | 関連するアクセス制御ルールを即時適用するかどうか<br/>- デフォルト値: `false` |
+| databaseName | String | Y | データベース名 |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
----
-### ユーザーリスト表示
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
-```http
-GET /v1.0/db-instances/{dbInstanceId}/db-users
-```
+---
+
+### ユーザーリスト表示
 
 #### 必要権限
 
@@ -1958,57 +2063,60 @@ GET /v1.0/db-instances/{dbInstanceId}/db-users
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v1.0/db-instances/{dbInstanceId}/db-users
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| dbUsers | Body | Array | DBユーザーリスト |
-| dbUsers.dbUserId | Body | UUID | DBユーザーの識別子 |
-| dbUsers.dbUserName | Body | String | DBユーザーアカウント名 |
-| dbUsers.authorityType | Body | Enum | DBユーザー権限タイプ<br/>- CUSTOM: `カスタム権限`<br/>- READ: `READ権限(読み取り専用権限)`<br/>- CRUD: `CRUD権限(読み取り権限を含む)`<br/>- DDL: `DDL権限(CRUD権限を含む)` |
-| dbUsers.dbUserStatus | Body | Enum | DBユーザーの現在状態<br/>- STABLE: `使用可能`<br/>- CREATING: `作成中`<br/>- MODIFYING: `修正中`<br/>- DELETING: `削除中`<br/>- DELETED: `削除済み`<br/>- SYNCING: `同期中`<br/>- DELETE_ERROR: `削除失敗` |
-| dbUsers.createdYmdt | Body | DateTime | 作成日時 |
-| dbUsers.updatedYmdt | Body | DateTime | 修正日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbUsers": [
-        {
-            "dbUserId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbUserName": "dbUserName-example",
-            "authorityType": "CUSTOM",
-            "dbUserStatus": "STABLE",
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbUsers": [
+{
+"dbUserId": "550e8400-e29b-41d4-a716-446655440000",
+"dbUserName": "dbUserName-example",
+"authorityType": "CUSTOM",
+"dbUserStatus": "STABLE",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbUsers | Array | DBユーザーリスト |
+| dbUsers.dbUserId | UUID | DBユーザーの識別子 |
+| dbUsers.dbUserName | String | DBユーザーアカウント名 |
+| dbUsers.authorityType | Enum | DBユーザー権限タイプ<br/>- CUSTOM: `カスタム権限`<br/>- READ: `READ権限(読み取り専用権限)`<br/>- CRUD: `CRUD権限(読み取り権限を含む)`<br/>- DDL: `DDL権限(CRUD権限を含む)` |
+| dbUsers.dbUserStatus | Enum | DBユーザーの現在状態<br/>- STABLE: `使用可能`<br/>- CREATING: `作成中`<br/>- MODIFYING: `修正中`<br/>- DELETING: `削除中`<br/>- DELETED: `削除済み`<br/>- SYNCING: `同期中`<br/>- DELETE_ERROR: `削除失敗` |
+| dbUsers.createdYmdt | DateTime | 作成日時 |
+| dbUsers.updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### ユーザー作成
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/db-users
-```
 
 #### 必要権限
 
@@ -2018,61 +2126,66 @@ POST /v1.0/db-instances/{dbInstanceId}/db-users
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| dbUserName | Body | String | O | DBユーザーアカウント名 |
-| dbPassword | Body | String | O | DBユーザーアカウントパスワード |
-| authorityType | Body | Enum | O | DBユーザー権限タイプ<br/>- CUSTOM: `カスタム権限`<br/>- READ: `読み取り権限`<br/>- CRUD: `CRUD権限`<br/>- DDL: `DDL権限` |
-| createDefaultHbaRules | Body | Boolean | X | 基本アクセス制御ルールの作成可否<br/>- デフォルト値: `false` |
-| address | Body | String | X | 接続アドレス |
+```http
+POST /v1.0/db-instances/{dbInstanceId}/db-users
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "dbUserName": "dbUserName-example",
-    "dbPassword": "dbPassword-example",
-    "authorityType": "CUSTOM",
-    "createDefaultHbaRules": false,
-    "address": "address-example"
+"dbUserName": "dbUserName-example",
+"dbPassword": "dbPassword-example",
+"authorityType": "CUSTOM",
+"createDefaultHbaRules": false,
+"address": "address-example"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbUserName | String | Y | DBユーザーアカウント名 |
+| dbPassword | String | Y | DBユーザーアカウントパスワード |
+| authorityType | Enum | Y | DBユーザー権限タイプ<br/>- CUSTOM: `カスタム権限`<br/>- READ: `読み取り権限`<br/>- CRUD: `CRUD権限`<br/>- DDL: `DDL権限` |
+| createDefaultHbaRules | Boolean | N | 基本アクセス制御ルールの作成可否<br/>- デフォルト値: `false` |
+| address | String | N | 接続アドレス |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### ユーザー削除
-
-```http
-DELETE /v1.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
-```
 
 #### 必要権限
 
@@ -2082,43 +2195,46 @@ DELETE /v1.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+DELETE /v1.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| dbUserId | URL | UUID | O | ユーザーの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+| dbUserId | URL | UUID | Y | ユーザーの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### ユーザー修正
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
-```
 
 #### 必要権限
 
@@ -2128,60 +2244,65 @@ PUT /v1.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| dbUserId | URL | UUID | O | ユーザーの識別子 |
-| dbUserName | Body | String | X | DBユーザーアカウント名 |
-| dbPassword | Body | String | X | DBユーザーアカウントパスワード |
-| authorityType | Body | Enum | X | DBユーザー権限<br/>- CUSTOM: `カスタム権限`<br/>- READ: `読み取り権限`<br/>- CRUD: `CRUD権限`<br/>- DDL: `DDL権限` |
-| applyHbaRulesImmediately | Body | Boolean | X | アクセス制御変更事項の即時適用可否<br/>- デフォルト値: `false` |
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+| dbUserId | URL | UUID | Y | ユーザーの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "dbUserName": "dbUserName-example",
-    "dbPassword": "dbPassword-example",
-    "authorityType": "CUSTOM",
-    "applyHbaRulesImmediately": false
+"dbUserName": "dbUserName-example",
+"dbPassword": "dbPassword-example",
+"authorityType": "CUSTOM",
+"applyHbaRulesImmediately": false
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbUserName | String | N | DBユーザーアカウント名 |
+| dbPassword | String | N | DBユーザーアカウントパスワード |
+| authorityType | Enum | N | DBユーザー権限<br/>- CUSTOM: `カスタム権限`<br/>- READ: `読み取り権限`<br/>- CRUD: `CRUD権限`<br/>- DDL: `DDL権限` |
+| applyHbaRulesImmediately | Boolean | N | アクセス制御変更事項の即時適用可否<br/>- デフォルト値: `false` |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### DBインスタンス削除保護設定の変更
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/deletion-protection
-```
 
 #### 必要権限
 
@@ -2191,22 +2312,32 @@ PUT /v1.0/db-instances/{dbInstanceId}/deletion-protection
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| useDeletionProtection | Body | Boolean | O | 削除保護の有無 |
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/deletion-protection
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "useDeletionProtection": false
+"useDeletionProtection": false
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| useDeletionProtection | Boolean | Y | 削除保護の有無 |
 
 #### レスポンス
 
@@ -2216,10 +2347,6 @@ PUT /v1.0/db-instances/{dbInstanceId}/deletion-protection
 
 ### DBインスタンスの強制再起動
 
-```http
-POST /v1.0/db-instances/{dbInstanceId}/force-restart
-```
-
 #### 必要権限
 
 | 権限名 | 説明 |
@@ -2228,22 +2355,27 @@ POST /v1.0/db-instances/{dbInstanceId}/force-restart
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+POST /v1.0/db-instances/{dbInstanceId}/force-restart
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
 
 ---
-### アクセス制御ルールリストを表示
 
-```http
-GET /v1.0/db-instances/{dbInstanceId}/hba-rules
-```
+### アクセス制御ルールリストを表示
 
 #### 必要権限
 
@@ -2253,83 +2385,86 @@ GET /v1.0/db-instances/{dbInstanceId}/hba-rules
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v1.0/db-instances/{dbInstanceId}/hba-rules
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| hbaRules | Body | Array | アクセス制御ルールリスト |
-| hbaRules.hbaRuleId | Body | UUID | アクセス制御ルールの識別子 |
-| hbaRules.hbaRuleStatus | Body | Enum | アクセス制御ルールの現在状態<br/>- CREATED: `作成済み`<br/>- APPLIED: `適用済み`<br/>- CREATING: `作成中`<br/>- MODIFYING: `修正中`<br/>- DELETING: `削除中`<br/>- DELETED: `削除済み` |
-| hbaRules.databaseApplyType | Body | Enum | データベース適用タイプ<br/>- ENTIRE: `全体`<br/>- USER_CUSTOM: `ユーザー指定` |
-| hbaRules.dbUserApplyTypeCode | Body | Enum | DBユーザー適用タイプ<br/>- ENTIRE: `全体`<br/>- USER_CUSTOM: `ユーザー指定` |
-| hbaRules.databases | Body | Array | ユーザー指定のデータベースリスト |
-| hbaRules.databases.databaseId | Body | UUID | データベースID |
-| hbaRules.databases.databaseName | Body | String | データベース名 |
-| hbaRules.dbUsers | Body | Array | ユーザー指定のDBユーザーリスト |
-| hbaRules.dbUsers.dbUserId | Body | UUID | DBユーザーID |
-| hbaRules.dbUsers.dbUserName | Body | String | DBユーザー名 |
-| hbaRules.address | Body | String | 接続アドレス |
-| hbaRules.authMethod | Body | Enum | 認証方式<br/>- TRUST: `トラスト(パスワード不要)`<br/>- REJECT: `接続ブロック`<br/>- SCRAM_SHA_256: `パスワード(SCRAM-SHA-256)` |
-| hbaRules.reservedAction | Body | Enum | 予約作業<br/>- NONE: `なし`<br/>- CREATE: `作成予約(適用必要)`<br/>- MODIFY: `修正予約(適用必要)`<br/>- DELETE: `削除予約(適用必要)` |
-| hbaRules.order | Body | Number | 適用順序 |
-| hbaRules.applicable | Body | Boolean | 適用可否 |
-| needToApply | Body | Boolean | 変更の適用要否 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "hbaRules": [
-        {
-            "hbaRuleId": "550e8400-e29b-41d4-a716-446655440000",
-            "hbaRuleStatus": "CREATED",
-            "databaseApplyType": "ENTIRE",
-            "dbUserApplyTypeCode": "ENTIRE",
-            "databases": [
-                {
-                    "databaseId": "550e8400-e29b-41d4-a716-446655440000",
-                    "databaseName": "databaseName-example"
-                }
-            ],
-            "dbUsers": [
-                {
-                    "dbUserId": "550e8400-e29b-41d4-a716-446655440000",
-                    "dbUserName": "dbUserName-example"
-                }
-            ],
-            "address": "address-example",
-            "authMethod": "TRUST",
-            "reservedAction": "NONE",
-            "order": 1,
-            "applicable": false
-        }
-    ],
-    "needToApply": false
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"hbaRules": [
+{
+"hbaRuleId": "550e8400-e29b-41d4-a716-446655440000",
+"hbaRuleStatus": "CREATED",
+"databaseApplyType": "ENTIRE",
+"dbUserApplyTypeCode": "ENTIRE",
+"databases": [
+{
+"databaseId": "550e8400-e29b-41d4-a716-446655440000",
+"databaseName": "databaseName-example"
+}
+],
+"dbUsers": [
+{
+"dbUserId": "550e8400-e29b-41d4-a716-446655440000",
+"dbUserName": "dbUserName-example"
+}
+],
+"address": "address-example",
+"authMethod": "TRUST",
+"reservedAction": "NONE",
+"order": 1,
+"applicable": false
+}
+],
+"needToApply": false
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| hbaRules | Array | アクセス制御ルールリスト |
+| hbaRules.hbaRuleId | UUID | アクセス制御ルールの識別子 |
+| hbaRules.hbaRuleStatus | Enum | アクセス制御ルールの現在状態<br/>- CREATED: `作成済み`<br/>- APPLIED: `適用済み`<br/>- CREATING: `作成中`<br/>- MODIFYING: `修正中`<br/>- DELETING: `削除中`<br/>- DELETED: `削除済み` |
+| hbaRules.databaseApplyType | Enum | データベース適用タイプ<br/>- ENTIRE: `全体`<br/>- USER_CUSTOM: `ユーザー指定` |
+| hbaRules.dbUserApplyTypeCode | Enum | DBユーザー適用タイプ<br/>- ENTIRE: `全体`<br/>- USER_CUSTOM: `ユーザー指定` |
+| hbaRules.databases | Array | ユーザー指定のデータベースリスト |
+| hbaRules.databases.databaseId | UUID | データベースID |
+| hbaRules.databases.databaseName | String | データベース名 |
+| hbaRules.dbUsers | Array | ユーザー指定のDBユーザーリスト |
+| hbaRules.dbUsers.dbUserId | UUID | DBユーザーID |
+| hbaRules.dbUsers.dbUserName | String | DBユーザー名 |
+| hbaRules.address | String | 接続アドレス |
+| hbaRules.authMethod | Enum | 認証方式<br/>- TRUST: `トラスト(パスワード不要)`<br/>- REJECT: `接続ブロック`<br/>- SCRAM_SHA_256: `パスワード(SCRAM-SHA-256)` |
+| hbaRules.reservedAction | Enum | 予約作業<br/>- NONE: `なし`<br/>- CREATE: `作成予約(適用必要)`<br/>- MODIFY: `修正予約(適用必要)`<br/>- DELETE: `削除予約(適用必要)` |
+| hbaRules.order | Number | 適用順序 |
+| hbaRules.applicable | Boolean | 適用可否 |
+| needToApply | Boolean | 変更の適用要否 |
 
 ---
 
 ### アクセス制御ルールの追加
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/hba-rules
-```
 
 #### 必要権限
 
@@ -2339,65 +2474,70 @@ POST /v1.0/db-instances/{dbInstanceId}/hba-rules
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| connectionTypeCode | Body | Enum | X | アクセス制御レコードタイプ<br/>- HOST: `TCP/IP接続時に有効`<br/>- HOST_NO_SSL: `SSL暗号化を使用しない接続時のみ有効` |
-| databaseApplyType | Body | Enum | O | データベース適用タイプ<br/>- ENTIRE: `全体`<br/>- USER_CUSTOM: `ユーザー指定` |
-| dbUserApplyType | Body | Enum | O | DBユーザー適用タイプ<br/>- ENTIRE: `全体`<br/>- USER_CUSTOM: `ユーザー指定` |
-| databaseIds | Body | Array | X | データベースの識別子リスト |
-| dbUserIds | Body | Array | X | DBユーザーの識別子リスト |
-| address | Body | String | O | 接続アドレス |
-| authMethod | Body | Enum | O | 認証方式<br/>- TRUST: `トラスト(パスワード不要)`<br/>- REJECT: `接続ブロック`<br/>- SCRAM_SHA_256: `パスワード(SCRAM-SHA-256)` |
+```http
+POST /v1.0/db-instances/{dbInstanceId}/hba-rules
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "connectionTypeCode": "HOST",
-    "databaseApplyType": "ENTIRE",
-    "dbUserApplyType": "ENTIRE",
-    "databaseIds": [],
-    "dbUserIds": [],
-    "address": "address-example",
-    "authMethod": "TRUST"
+"connectionTypeCode": "HOST",
+"databaseApplyType": "ENTIRE",
+"dbUserApplyType": "ENTIRE",
+"databaseIds": [],
+"dbUserIds": [],
+"address": "address-example",
+"authMethod": "TRUST"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| connectionTypeCode | Enum | N | アクセス制御レコードタイプ<br/>- HOST: `TCP/IP接続時に有効`<br/>- HOST_NO_SSL: `SSL暗号化を使用しない接続時のみ有効` |
+| databaseApplyType | Enum | Y | データベース適用タイプ<br/>- ENTIRE: `全体`<br/>- USER_CUSTOM: `ユーザー指定` |
+| dbUserApplyType | Enum | Y | DBユーザー適用タイプ<br/>- ENTIRE: `全体`<br/>- USER_CUSTOM: `ユーザー指定` |
+| databaseIds | Array | N | データベースの識別子リスト |
+| dbUserIds | Array | N | DBユーザーの識別子リスト |
+| address | String | Y | 接続アドレス |
+| authMethod | Enum | Y | 認証方式<br/>- TRUST: `トラスト(パスワード不要)`<br/>- REJECT: `接続ブロック`<br/>- SCRAM_SHA_256: `パスワード(SCRAM-SHA-256)` |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| hbaRuleId | Body | UUID | アクセス制御ルールの識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "hbaRuleId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"hbaRuleId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| hbaRuleId | UUID | アクセス制御ルールの識別子 |
 
 ---
 
 ### アクセス制御ルールを適用
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/hba-rules/apply
-```
 
 #### 必要権限
 
@@ -2407,42 +2547,45 @@ POST /v1.0/db-instances/{dbInstanceId}/hba-rules/apply
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+POST /v1.0/db-instances/{dbInstanceId}/hba-rules/apply
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### アクセス制御ルールの順序調整
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/hba-rules/orders
-```
 
 #### 必要権限
 
@@ -2452,22 +2595,32 @@ PUT /v1.0/db-instances/{dbInstanceId}/hba-rules/orders
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| hbaRuleIds | Body | Array | O | 整列されたアクセス制御ルールIDリスト(リクエストした順序どおりに保存) |
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/hba-rules/orders
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "hbaRuleIds": []
+"hbaRuleIds": []
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| hbaRuleIds | Array | Y | 整列されたアクセス制御ルールIDリスト(リクエストした順序どおりに保存) |
 
 #### レスポンス
 
@@ -2477,10 +2630,6 @@ PUT /v1.0/db-instances/{dbInstanceId}/hba-rules/orders
 
 ### アクセス制御ルールの削除
 
-```http
-DELETE /v1.0/db-instances/{dbInstanceId}/hba-rules/{hbaRuleId}
-```
-
 #### 必要権限
 
 | 権限名 | 説明 |
@@ -2489,12 +2638,20 @@ DELETE /v1.0/db-instances/{dbInstanceId}/hba-rules/{hbaRuleId}
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+DELETE /v1.0/db-instances/{dbInstanceId}/hba-rules/{hbaRuleId}
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| hbaRuleId | URL | UUID | O | アクセス制御ルールの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+| hbaRuleId | URL | UUID | Y | アクセス制御ルールの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
@@ -2504,10 +2661,6 @@ DELETE /v1.0/db-instances/{dbInstanceId}/hba-rules/{hbaRuleId}
 
 ### アクセス制御ルールの修正
 
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/hba-rules/{hbaRuleId}
-```
-
 #### 必要権限
 
 | 権限名 | 説明 |
@@ -2516,46 +2669,53 @@ PUT /v1.0/db-instances/{dbInstanceId}/hba-rules/{hbaRuleId}
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| hbaRuleId | URL | UUID | O | アクセス制御ルールの識別子 |
-| connectionTypeCode | Body | Enum | X | アクセス制御レコードタイプ<br/>- HOST: `TCP/IP接続時に有効`<br/>- HOST_NO_SSL: `SSL暗号化を使用しない接続時のみ有効` |
-| databaseApplyType | Body | Enum | O | データベース適用タイプ<br/>- ENTIRE: `全体`<br/>- USER_CUSTOM: `ユーザー指定` |
-| dbUserApplyType | Body | Enum | O | DBユーザー適用タイプ<br/>- ENTIRE: `全体`<br/>- USER_CUSTOM: `ユーザー指定` |
-| databaseIds | Body | Array | X | データベースの識別子リスト |
-| dbUserIds | Body | Array | X | DBユーザーの識別子リスト |
-| address | Body | String | O | 接続アドレス |
-| authMethod | Body | Enum | O | 認証方式<br/>- TRUST: `トラスト(パスワード不要)`<br/>- REJECT: `接続ブロック`<br/>- SCRAM_SHA_256: `パスワード(SCRAM-SHA-256)` |
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/hba-rules/{hbaRuleId}
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+| hbaRuleId | URL | UUID | Y | アクセス制御ルールの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "connectionTypeCode": "HOST",
-    "databaseApplyType": "ENTIRE",
-    "dbUserApplyType": "ENTIRE",
-    "databaseIds": [],
-    "dbUserIds": [],
-    "address": "address-example",
-    "authMethod": "TRUST"
+"connectionTypeCode": "HOST",
+"databaseApplyType": "ENTIRE",
+"dbUserApplyType": "ENTIRE",
+"databaseIds": [],
+"dbUserIds": [],
+"address": "address-example",
+"authMethod": "TRUST"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| connectionTypeCode | Enum | N | アクセス制御レコードタイプ<br/>- HOST: `TCP/IP接続時に有効`<br/>- HOST_NO_SSL: `SSL暗号化を使用しない接続時のみ有効` |
+| databaseApplyType | Enum | Y | データベース適用タイプ<br/>- ENTIRE: `全体`<br/>- USER_CUSTOM: `ユーザー指定` |
+| dbUserApplyType | Enum | Y | DBユーザー適用タイプ<br/>- ENTIRE: `全体`<br/>- USER_CUSTOM: `ユーザー指定` |
+| databaseIds | Array | N | データベースの識別子リスト |
+| dbUserIds | Array | N | DBユーザーの識別子リスト |
+| address | String | Y | 接続アドレス |
+| authMethod | Enum | Y | 認証方式<br/>- TRUST: `トラスト(パスワード不要)`<br/>- REJECT: `接続ブロック`<br/>- SCRAM_SHA_256: `パスワード(SCRAM-SHA-256)` |
 
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
 
 ---
-### 高可用性情報の照会
 
-```http
-GET /v1.0/db-instances/{dbInstanceId}/high-availability
-```
+### 高可用性情報の照会
 
 #### 必要権限
 
@@ -2565,46 +2725,49 @@ GET /v1.0/db-instances/{dbInstanceId}/high-availability
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v1.0/db-instances/{dbInstanceId}/high-availability
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| haStatus | Body | Enum | 高可用性状態<br/>- CREATED: `作成済み`<br/>- STABLE: `正常`<br/>- PAUSING: `一時停止中`<br/>- DISABLE: `停止`<br/>- DISABLE_MASTER_IN_REPLICATION: `マスター異常複製検知による高可用性停止`<br/>- DISABLE_MHA_PROCESS: `高可用性プロセス停止`<br/>- DISABLE_REPLICATION_STOP: `複製停止による高可用性停止`<br/>- DISABLE_REPLICATION_DELAY: `複製遅延による高可用性停止`<br/>- FAILOVER_STARTED: `フェイルオーバー開始`<br/>- FAILOVER_FAILED: `フェイルオーバー失敗`<br/>- FAILOVER_COMPLETED: `フェイルオーバー完了`<br/>- DELETED: `削除済み`<br/>- PAUSED: `一時停止`<br/>- PAUSED_DUE_TO_TASK: `作業による一時停止`<br/>- MASTER_FAILURE_DETECTION: `マスター障害検知` |
-| pingInterval | Body | Number | Ping間隔(秒) |
-| failoverReplWaitingTime | Body | Number | フェイルオーバー複製遅延待機時間(秒) |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "haStatus": "CREATED",
-    "pingInterval": 1,
-    "failoverReplWaitingTime": 1
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"haStatus": "CREATED",
+"pingInterval": 1,
+"failoverReplWaitingTime": 1
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| haStatus | Enum | 高可用性状態<br/>- CREATED: `作成済み`<br/>- STABLE: `正常`<br/>- PAUSING: `一時停止中`<br/>- DISABLE: `停止`<br/>- DISABLE_MASTER_IN_REPLICATION: `マスター異常複製検知による高可用性停止`<br/>- DISABLE_MHA_PROCESS: `高可用性プロセス停止`<br/>- DISABLE_REPLICATION_STOP: `複製停止による高可用性停止`<br/>- DISABLE_REPLICATION_DELAY: `複製遅延による高可用性停止`<br/>- FAILOVER_STARTED: `フェイルオーバー開始`<br/>- FAILOVER_FAILED: `フェイルオーバー失敗`<br/>- FAILOVER_COMPLETED: `フェイルオーバー完了`<br/>- DELETED: `削除済み`<br/>- PAUSED: `一時停止`<br/>- PAUSED_DUE_TO_TASK: `作業による一時停止`<br/>- MASTER_FAILURE_DETECTION: `マスター障害検知` |
+| pingInterval | Number | Ping間隔(秒) |
+| failoverReplWaitingTime | Number | フェイルオーバー複製遅延待機時間(秒) |
 
 ---
 
 ### 高可用性を修正する
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/high-availability
-```
 
 #### 必要権限
 
@@ -2614,57 +2777,62 @@ PUT /v1.0/db-instances/{dbInstanceId}/high-availability
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| useHighAvailability | Body | Boolean | O | 高可用性の使用有無 |
-| pingInterval | Body | Number | X | Ping間隔(秒)<br/>- 最小値: `1`<br/>- 最大値: `600` |
-| failoverReplWaitingTime | Body | Number | X | フェイルオーバー複製遅延待機時間(秒)<br/>- 最小値: `-1` |
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/high-availability
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "useHighAvailability": false,
-    "pingInterval": 1,
-    "failoverReplWaitingTime": 1
+"useHighAvailability": false,
+"pingInterval": 1,
+"failoverReplWaitingTime": 1
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| useHighAvailability | Boolean | Y | 高可用性の使用有無 |
+| pingInterval | Number | N | Ping間隔(秒)<br/>- 最小値: `1`<br/>- 最大値: `600` |
+| failoverReplWaitingTime | Number | N | フェイルオーバー複製遅延待機時間(秒)<br/>- 最小値: `-1` |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### 高可用性の一時停止
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/high-availability/pause
-```
 
 #### 必要権限
 
@@ -2674,42 +2842,45 @@ POST /v1.0/db-instances/{dbInstanceId}/high-availability/pause
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+POST /v1.0/db-instances/{dbInstanceId}/high-availability/pause
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### 高可用性の復旧
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/high-availability/repair
-```
 
 #### 必要権限
 
@@ -2719,42 +2890,45 @@ POST /v1.0/db-instances/{dbInstanceId}/high-availability/repair
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+POST /v1.0/db-instances/{dbInstanceId}/high-availability/repair
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### 高可用性の再起動
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/high-availability/resume
-```
 
 #### 必要権限
 
@@ -2764,42 +2938,45 @@ POST /v1.0/db-instances/{dbInstanceId}/high-availability/resume
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+POST /v1.0/db-instances/{dbInstanceId}/high-availability/resume
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### 高可用性の分離
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/high-availability/split
-```
 
 #### 必要権限
 
@@ -2809,41 +2986,45 @@ POST /v1.0/db-instances/{dbInstanceId}/high-availability/split
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+POST /v1.0/db-instances/{dbInstanceId}/high-availability/split
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
----
-### DBインスタンスメンテナンス情報照会
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
-```http
-GET /v1.0/db-instances/{dbInstanceId}/maintenance-info
-```
+---
+
+### DBインスタンスメンテナンス情報照会
 
 #### 必要権限
 
@@ -2853,50 +3034,53 @@ GET /v1.0/db-instances/{dbInstanceId}/maintenance-info
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v1.0/db-instances/{dbInstanceId}/maintenance-info
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| allowAutoMaintenance | Body | Boolean | 自動メンテナンスを許可するかどうか |
-| useAutoStorageCleanup | Body | Boolean | 自動ストレージクリーンアップを使用するかどうか |
-| maintWndBgnTime | Body | Time | 自動メンテナンス開始時間 |
-| maintWndDuration | Body | Enum | メンテナンス期間<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
-| logRetentionPeriod | Body | Number | ログ保管期間(日) |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "allowAutoMaintenance": false,
-    "useAutoStorageCleanup": false,
-    "maintWndBgnTime": "00:00:00",
-    "maintWndDuration": "HALF_AN_HOUR",
-    "logRetentionPeriod": 1
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"allowAutoMaintenance": false,
+"useAutoStorageCleanup": false,
+"maintWndBgnTime": "00:00:00",
+"maintWndDuration": "HALF_AN_HOUR",
+"logRetentionPeriod": 1
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| allowAutoMaintenance | Boolean | 自動メンテナンスを許可するかどうか |
+| useAutoStorageCleanup | Boolean | 自動ストレージクリーンアップを使用するかどうか |
+| maintWndBgnTime | Time | 自動メンテナンス開始時間 |
+| maintWndDuration | Enum | メンテナンス期間<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+| logRetentionPeriod | Number | ログ保管期間(日) |
 
 ---
 
 ### DBインスタンスメンテナンス情報修正
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/maintenance-info
-```
 
 #### 必要権限
 
@@ -2906,60 +3090,66 @@ PUT /v1.0/db-instances/{dbInstanceId}/maintenance-info
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| allowAutoMaintenance | Body | Boolean | X | 自動メンテナンスを許可するかどうか |
-| useAutoStorageCleanup | Body | Boolean | X | 自動ストレージクリーンアップを使用するかどうか |
-| maintWndBgnTime | Body | Time | X | 自動メンテナンス開始時間 |
-| maintWndDuration | Body | Enum | X | メンテナンス期間<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
-| logRetentionPeriod | Body | Number | X | ログ保管期間(日)<br/>- 最小値: `1`<br/>- 最大値: `30` |
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/maintenance-info
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "allowAutoMaintenance": false,
-    "useAutoStorageCleanup": false,
-    "maintWndBgnTime": "00:00:00",
-    "maintWndDuration": "HALF_AN_HOUR",
-    "logRetentionPeriod": 1
+"allowAutoMaintenance": false,
+"useAutoStorageCleanup": false,
+"maintWndBgnTime": "00:00:00",
+"maintWndDuration": "HALF_AN_HOUR",
+"logRetentionPeriod": 1
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| allowAutoMaintenance | Boolean | N | 自動メンテナンスを許可するかどうか |
+| useAutoStorageCleanup | Boolean | N | 自動ストレージクリーンアップを使用するかどうか |
+| maintWndBgnTime | Time | N | 自動メンテナンス開始時間 |
+| maintWndDuration | Enum | N | メンテナンス期間<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+| logRetentionPeriod | Number | N | ログ保管期間(日)<br/>- 最小値: `1`<br/>- 最大値: `30` |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
----
-### DBインスタンスネットワーク情報の照会
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
-```http
-GET /v1.0/db-instances/{dbInstanceId}/network-info
-```
+---
+
+### DBインスタンスネットワーク情報の照会
 
 #### 必要権限
 
@@ -2969,64 +3159,67 @@ GET /v1.0/db-instances/{dbInstanceId}/network-info
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v1.0/db-instances/{dbInstanceId}/network-info
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| availabilityZone | Body | Enum | DBインスタンスを作成するアベイラビリティゾーン |
-| subnet | Body | Object | サブネットオブジェクト |
-| subnet.subnetId | Body | UUID | サブネットの識別子 |
-| subnet.subnetName | Body | String | サブネットを識別できる名前 |
-| subnet.subnetCidr | Body | String | サブネットのCIDR |
-| subnet.publicAccessible | Body | Boolean | 外部接続可否 |
-| endPoints | Body | Array | 接続情報リスト |
-| endPoints.domain | Body | String | ドメイン |
-| endPoints.ipAddress | Body | String | IPアドレス |
-| endPoints.endPointType | Body | String | 接続情報タイプ |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "availabilityZone": "kr-pub-a",
-    "subnet": {
-        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
-        "subnetName": "subnetName-example",
-        "subnetCidr": "192.168.0.0/24",
-        "publicAccessible": false
-    },
-    "endPoints": [
-        {
-            "domain": "domain-example",
-            "ipAddress": "192.168.0.1",
-            "endPointType": "https://example.com"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"availabilityZone": "kr-pub-a",
+"subnet": {
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"subnetName": "subnetName-example",
+"subnetCidr": "192.168.0.0/24",
+"publicAccessible": false
+},
+"endPoints": [
+{
+"domain": "domain-example",
+"ipAddress": "192.168.0.1",
+"endPointType": "https://example.com"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| availabilityZone | Enum | DBインスタンスを作成するアベイラビリティゾーン |
+| subnet | Object | サブネットオブジェクト |
+| subnet.subnetId | UUID | サブネットの識別子 |
+| subnet.subnetName | String | サブネットを識別できる名前 |
+| subnet.subnetCidr | String | サブネットのCIDR |
+| subnet.publicAccessible | Boolean | 外部接続可否 |
+| endPoints | Array | 接続情報リスト |
+| endPoints.domain | String | ドメイン |
+| endPoints.ipAddress | String | IPアドレス |
+| endPoints.endPointType | String | 接続情報タイプ |
 
 ---
 
 ### DBインスタンスネットワーク情報の修正
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/network-info
-```
 
 #### 必要権限
 
@@ -3036,53 +3229,58 @@ PUT /v1.0/db-instances/{dbInstanceId}/network-info
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| usePublicAccess | Body | Boolean | O | 外部接続可否 |
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/network-info
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "usePublicAccess": false
+"usePublicAccess": false
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| usePublicAccess | Boolean | Y | 外部接続可否 |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### DBインスタンスの昇格
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/promote
-```
 
 #### 必要権限
 
@@ -3092,41 +3290,45 @@ POST /v1.0/db-instances/{dbInstanceId}/promote
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+POST /v1.0/db-instances/{dbInstanceId}/promote
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
----
-### リードレプリカの作成
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
-```http
-POST /v1.0/db-instances/{dbInstanceId}/replicate
-```
+---
+
+### リードレプリカの作成
 
 #### 必要権限
 
@@ -3136,83 +3338,88 @@ POST /v1.0/db-instances/{dbInstanceId}/replicate
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| dbInstanceName | Body | String | O | DBインスタンスを識別できる名前 |
-| description | Body | String | X | DBインスタンスの追加情報 |
-| dbFlavorId | Body | UUID | X | DBインスタンス仕様の識別子 |
-| dbPort | Body | Number | X | DBポート<br/>- 最小値: 5432、最大値: 45432 |
-| parameterGroupId | Body | UUID | X | パラメータグループの識別子 |
-| dbSecurityGroupIds | Body | Array | X | DBセキュリティグループの識別子リスト |
-| userGroupIds | Body | Array | X | ユーザーグループの識別子リスト |
-| useDefaultNotification | Body | Boolean | X | 基本通知の使用有無<br/>- デフォルト値: `false` |
-| useDeletionProtection | Body | Boolean | X | 削除保護の有無<br/>- デフォルト値: `false` |
-| network | Body | Object | X | ネットワーク情報オブジェクト |
-| network.usePublicAccess | Body | Boolean | X | 外部接続可否<br/>- デフォルト値: `false` |
-| network.availabilityZone | Body | Enum | X | DBインスタンスを作成するアベイラビリティゾーン |
-| storage | Body | Object | X | ストレージ情報オブジェクト |
-| storage.storageType | Body | Enum | X | データストレージタイプ |
-| storage.storageSize | Body | Number | X | データストレージサイズ(GB)<br/>- 最小値: `20`<br/>- 最大値: `2048` |
+```http
+POST /v1.0/db-instances/{dbInstanceId}/replicate
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "dbInstanceName": "dbInstanceName-example",
-    "description": "description-example",
-    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbPort": 1,
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbSecurityGroupIds": [],
-    "userGroupIds": [],
-    "useDefaultNotification": false,
-    "useDeletionProtection": false,
-    "network": {
-        "usePublicAccess": false,
-        "availabilityZone": "kr-pub-a"
-    },
-    "storage": {
-        "storageType": "General SSD",
-        "storageSize": 20
-    }
+"dbInstanceName": "dbInstanceName-example",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbPort": 1,
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useDefaultNotification": false,
+"useDeletionProtection": false,
+"network": {
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
+},
+"storage": {
+"storageType": "General SSD",
+"storageSize": 20
+}
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | DBインスタンスを識別できる名前 |
+| description | String | N | DBインスタンスの追加情報 |
+| dbFlavorId | UUID | N | DBインスタンス仕様の識別子 |
+| dbPort | Number | N | DBポート<br/>- 最小値: 5432、最大値: 45432 |
+| parameterGroupId | UUID | N | パラメータグループの識別子 |
+| dbSecurityGroupIds | Array | N | DBセキュリティグループの識別子リスト |
+| userGroupIds | Array | N | ユーザーグループの識別子リスト |
+| useDefaultNotification | Boolean | N | 基本通知の使用有無<br/>- デフォルト値: `false` |
+| useDeletionProtection | Boolean | N | 削除保護の有無<br/>- デフォルト値: `false` |
+| network | Object | N | ネットワーク情報オブジェクト |
+| network.usePublicAccess | Boolean | N | 外部接続可否<br/>- デフォルト値: `false` |
+| network.availabilityZone | Enum | N | DBインスタンスを作成するアベイラビリティゾーン |
+| storage | Object | N | ストレージ情報オブジェクト |
+| storage.storageType | Enum | N | データストレージタイプ |
+| storage.storageSize | Number | N | データストレージサイズ(GB)<br/>- 最小値: `20`<br/>- 最大値: `2048` |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### DBインスタンスの再起動
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/restart
-```
 
 #### 必要権限
 
@@ -3222,42 +3429,45 @@ POST /v1.0/db-instances/{dbInstanceId}/restart
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+POST /v1.0/db-instances/{dbInstanceId}/restart
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### DBインスタンス復元情報の照会
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}/restoration-info
-```
 
 #### 必要権限
 
@@ -3267,77 +3477,80 @@ GET /v1.0/db-instances/{dbInstanceId}/restoration-info
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v1.0/db-instances/{dbInstanceId}/restoration-info
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| oldestRestorableYmdt | Body | DateTime | 最も古い復元可能時間 |
-| latestRestorableYmdt | Body | DateTime | 最も最新の復元可能時間 |
-| restorableBackups | Body | Array | 復元可能なバックアップリスト |
-| restorableBackups.backupId | Body | UUID | バックアップの識別子 |
-| restorableBackups.backupName | Body | String | バックアップ名 |
-| restorableBackups.backupStatus | Body | Enum | バックアップ状態<br/>- BACKING_UP: `バックアップ中(スピナー)`<br/>- VERIFYING: `検証中(スピナー)`<br/>- COMPLETED: `使用可能(緑色アイコン)`<br/>- DELETING: `削除中(スピナー)`<br/>- DELETED: `削除済み(グレーアイコン)`<br/>- ERROR: `エラー(赤色アイコン)` |
-| restorableBackups.dbInstanceId | Body | UUID | 原本DBインスタンスの識別子 |
-| restorableBackups.dbInstanceName | Body | String | 原本DBインスタンス名 |
-| restorableBackups.dbVersion | Body | Enum | DBエンジンタイプ |
-| restorableBackups.backupType | Body | Enum | バックアップタイプ<br/>- AUTO<br/>- MANUAL |
-| restorableBackups.backupSize | Body | Number | バックアップサイズ |
-| restorableBackups.failoverCount | Body | Number | フェイルオーバー回数 |
-| restorableBackups.walFileName | Body | String | WALファイル名 |
-| restorableBackups.createdYmdt | Body | DateTime | バックアップ作成日時 |
-| restorableBackups.updatedYmdt | Body | DateTime | バックアップ更新日時 |
-| restorableBackups.startYmdt | Body | DateTime | バックアップ開始日時 |
-| restorableBackups.completedYmdt | Body | DateTime | バックアップ完了日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "oldestRestorableYmdt": "2023-12-31T15:00:00+09:00",
-    "latestRestorableYmdt": "2023-12-31T15:00:00+09:00",
-    "restorableBackups": [
-        {
-            "backupId": "550e8400-e29b-41d4-a716-446655440000",
-            "backupName": "backupName-example",
-            "backupStatus": "BACKING_UP",
-            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbInstanceName": "dbInstanceName-example",
-            "dbVersion": "POSTGRESQL_V14_17",
-            "backupType": "AUTO",
-            "backupSize": 1,
-            "failoverCount": 1,
-            "walFileName": "walFileName-example",
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00",
-            "startYmdt": "2023-12-31T15:00:00+09:00",
-            "completedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"oldestRestorableYmdt": "2023-12-31T15:00:00+09:00",
+"latestRestorableYmdt": "2023-12-31T15:00:00+09:00",
+"restorableBackups": [
+{
+"backupId": "550e8400-e29b-41d4-a716-446655440000",
+"backupName": "backupName-example",
+"backupStatus": "BACKING_UP",
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceName": "dbInstanceName-example",
+"dbVersion": "POSTGRESQL_V14_17",
+"backupType": "AUTO",
+"backupSize": 1,
+"failoverCount": 1,
+"walFileName": "walFileName-example",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00",
+"startYmdt": "2023-12-31T15:00:00+09:00",
+"completedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| oldestRestorableYmdt | DateTime | 最も古い復元可能時間 |
+| latestRestorableYmdt | DateTime | 最も最新の復元可能時間 |
+| restorableBackups | Array | 復元可能なバックアップリスト |
+| restorableBackups.backupId | UUID | バックアップの識別子 |
+| restorableBackups.backupName | String | バックアップ名 |
+| restorableBackups.backupStatus | Enum | バックアップ状態<br/>- BACKING_UP: `バックアップ中(スピナー)`<br/>- VERIFYING: `検証中(スピナー)`<br/>- COMPLETED: `使用可能(緑色アイコン)`<br/>- DELETING: `削除中(スピナー)`<br/>- DELETED: `削除済み(グレーアイコン)`<br/>- ERROR: `エラー(赤色アイコン)` |
+| restorableBackups.dbInstanceId | UUID | 原本DBインスタンスの識別子 |
+| restorableBackups.dbInstanceName | String | 原本DBインスタンス名 |
+| restorableBackups.dbVersion | String | DBエンジンタイプ |
+| restorableBackups.backupType | Enum | バックアップタイプ<br/>- AUTO<br/>- MANUAL |
+| restorableBackups.backupSize | Number | バックアップサイズ |
+| restorableBackups.failoverCount | Number | フェイルオーバー回数 |
+| restorableBackups.walFileName | String | WALファイル名 |
+| restorableBackups.createdYmdt | DateTime | バックアップ作成日時 |
+| restorableBackups.updatedYmdt | DateTime | バックアップ更新日時 |
+| restorableBackups.startYmdt | DateTime | バックアップ開始日時 |
+| restorableBackups.completedYmdt | DateTime | バックアップ完了日時 |
 
 ---
 
 ### DBインスタンスの復元
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/restore
-```
 
 #### 必要権限
 
@@ -3347,121 +3560,127 @@ POST /v1.0/db-instances/{dbInstanceId}/restore
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| dbInstanceName | Body | String | X | DBインスタンスを識別できる名前 |
-| dbInstanceCandidateName | Body | String | X | DBインスタンスを識別できる予備マスター名 |
-| description | Body | String | X | DBインスタンスの追加情報<br/>- 最大長: `100` |
-| dbFlavorId | Body | UUID | O | DBインスタンス仕様の識別子 |
-| dbPort | Body | Number | X | DBポート<br/>- 最小値: 5432、最大値: 45432 |
-| useHighAvailability | Body | Boolean | X | 高可用性の使用有無<br/>- デフォルト値: `false` |
-| imageId | Body | UUID | X | イメージの識別子 |
-| pingInterval | Body | Number | X | 高可用性使用時のPing間隔(秒)<br/>- 最小値: `1`<br/>- 最大値: `600` |
-| failoverReplWaitingTime | Body | Number | X | フェイルオーバー複製遅延待機時間(秒)<br/>- 最小値: `-1` |
-| storage | Body | Object | O | ストレージ情報オブジェクト |
-| storage.storageType | Body | Enum | O | ストレージタイプ |
-| storage.storageSize | Body | Number | O | データストレージサイズ(GB)<br/>- 最小値: `20` |
-| network | Body | Object | O | ネットワーク情報オブジェクト |
-| network.subnetId | Body | UUID | O | サブネットの識別子 |
-| network.usePublicAccess | Body | Boolean | X | 外部接続可否<br/>- デフォルト値: `false` |
-| network.availabilityZone | Body | Enum | X | DBインスタンスを作成するアベイラビリティゾーン |
-| backup | Body | Object | O | バックアップ情報オブジェクト |
-| backup.backupPeriod | Body | Number | O | バックアップの保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
-| backup.backupRetryCount | Body | Number | X | バックアップの再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
-| backup.replicationRegion | Body | Enum | X | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)`<br/>- KR2: `韓国(ピョンチョン)` |
-| backup.backupSchedules | Body | Array | O | バックアップスケジュールリスト |
-| backup.backupSchedules.backupWndBgnTime | Body | Time | O | バックアップ開始時刻 |
-| backup.backupSchedules.backupWndDuration | Body | Enum | O | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
-| restore | Body | Object | O | 復元情報オブジェクト |
-| restore.restoreType | Body | Enum | O | 復元タイプ<br/>- BACKUP: `既存のバックアップを利用した復元`<br/>- TIMESTAMP: `復元可能時間内の時間を利用した時点復元` |
-| restore.restoreYmdt | Body | DateTime | X | DBインスタンス復元日時 |
-| restore.backupId | Body | UUID | X | 復元に使用するバックアップの識別子 |
-| useDefaultNotification | Body | Boolean | X | 基本通知の使用有無<br/>- デフォルト値: `false` |
-| parameterGroupId | Body | UUID | O | パラメータグループの識別子 |
-| dbSecurityGroupIds | Body | Array | X | DBセキュリティグループの識別子リスト |
-| userGroupIds | Body | Array | X | ユーザーグループの識別子リスト |
-| useDeletionProtection | Body | Boolean | X | 削除保護の有無<br/>- デフォルト値: `false` |
+```http
+POST /v1.0/db-instances/{dbInstanceId}/restore
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "dbInstanceName": "dbInstanceName-example",
-    "dbInstanceCandidateName": "dbInstanceCandidateName-example",
-    "description": "description-example",
-    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbPort": 1,
-    "useHighAvailability": false,
-    "imageId": "550e8400-e29b-41d4-a716-446655440000",
-    "pingInterval": 3,
-    "failoverReplWaitingTime": 60,
-    "storage": {
-        "storageType": "General SSD",
-        "storageSize": 20
-    },
-    "network": {
-        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
-        "usePublicAccess": false,
-        "availabilityZone": "kr-pub-a"
-    },
-    "backup": {
-        "backupPeriod": 0,
-        "backupRetryCount": 0,
-        "replicationRegion": "KR1",
-        "backupSchedules": [
-            {
-                "backupWndBgnTime": "00:00:00",
-                "backupWndDuration": "HALF_AN_HOUR"
-            }
-        ]
-    },
-    "restore": {
-        "restoreType": "BACKUP",
-        "restoreYmdt": "2023-12-31T15:00:00+09:00",
-        "backupId": "550e8400-e29b-41d4-a716-446655440000"
-    },
-    "useDefaultNotification": false,
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbSecurityGroupIds": [],
-    "userGroupIds": [],
-    "useDeletionProtection": false
+"dbInstanceName": "dbInstanceName-example",
+"dbInstanceCandidateName": "dbInstanceCandidateName-example",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbPort": 1,
+"useHighAvailability": false,
+"imageId": "550e8400-e29b-41d4-a716-446655440000",
+"pingInterval": 3,
+"failoverReplWaitingTime": 60,
+"storage": {
+"storageType": "General SSD",
+"storageSize": 20
+},
+"network": {
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
+},
+"backup": {
+"backupPeriod": 0,
+"backupRetryCount": 0,
+"replicationRegion": "KR1",
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
+},
+"restore": {
+"restoreType": "BACKUP",
+"restoreYmdt": "2023-12-31T15:00:00+09:00",
+"backupId": "550e8400-e29b-41d4-a716-446655440000"
+},
+"useDefaultNotification": false,
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useDeletionProtection": false
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | N | DBインスタンスを識別できる名前 |
+| dbInstanceCandidateName | String | N | DBインスタンスを識別できる予備マスター名 |
+| description | String | N | DBインスタンスの追加情報<br/>- 最大長: `100` |
+| dbFlavorId | UUID | Y | DBインスタンス仕様の識別子 |
+| dbPort | Number | N | DBポート<br/>- 最小値: 5432、最大値: 45432 |
+| useHighAvailability | Boolean | N | 高可用性の使用有無<br/>- デフォルト値: `false` |
+| imageId | UUID | N | イメージの識別子 |
+| pingInterval | Number | N | 高可用性使用時のPing間隔(秒)<br/>- 最小値: `1`<br/>- 最大値: `600` |
+| failoverReplWaitingTime | Number | N | フェイルオーバー複製遅延待機時間(秒)<br/>- 最小値: `-1` |
+| storage | Object | Y | ストレージ情報オブジェクト |
+| storage.storageType | Enum | Y | ストレージタイプ |
+| storage.storageSize | Number | Y | データストレージサイズ(GB)<br/>- 最小値: `20` |
+| network | Object | Y | ネットワーク情報オブジェクト |
+| network.subnetId | UUID | Y | サブネットの識別子 |
+| network.usePublicAccess | Boolean | N | 外部接続可否<br/>- デフォルト値: `false` |
+| network.availabilityZone | Enum | N | DBインスタンスを作成するアベイラビリティゾーン |
+| backup | Object | Y | バックアップ情報オブジェクト |
+| backup.backupPeriod | Number | Y | バックアップの保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| backup.backupRetryCount | Number | N | バックアップの再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| backup.replicationRegion | Enum | N | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)`<br/>- KR2: `韓国(ピョンチョン)` |
+| backup.backupSchedules | Array | Y | バックアップスケジュールリスト |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | バックアップ開始時刻 |
+| backup.backupSchedules.backupWndDuration | Enum | Y | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+| restore | Object | Y | 復元情報オブジェクト |
+| restore.restoreType | Enum | Y | 復元タイプ<br/>- BACKUP: `既存のバックアップを利用した復元`<br/>- TIMESTAMP: `復元可能時間内の時間を利用した時点復元` |
+| restore.restoreYmdt | DateTime | N | DBインスタンス復元日時 |
+| restore.backupId | UUID | N | 復元に使用するバックアップの識別子 |
+| useDefaultNotification | Boolean | N | 基本通知の使用有無<br/>- デフォルト値: `false` |
+| parameterGroupId | UUID | Y | パラメータグループの識別子 |
+| dbSecurityGroupIds | Array | N | DBセキュリティグループの識別子リスト |
+| userGroupIds | Array | N | ユーザーグループの識別子リスト |
+| useDeletionProtection | Boolean | N | 削除保護の有無<br/>- デフォルト値: `false` |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
----
-### DBインスタンス開始
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
-```http
-POST /v1.0/db-instances/{dbInstanceId}/start
-```
+---
+
+### DBインスタンス開始
 
 #### 必要権限
 
@@ -3471,42 +3690,45 @@ POST /v1.0/db-instances/{dbInstanceId}/start
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+POST /v1.0/db-instances/{dbInstanceId}/start
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### DBインスタンス停止
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/stop
-```
 
 #### 必要権限
 
@@ -3516,42 +3738,45 @@ POST /v1.0/db-instances/{dbInstanceId}/stop
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+POST /v1.0/db-instances/{dbInstanceId}/stop
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### DBインスタンスストレージ情報の照会
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}/storage-info
-```
 
 #### 必要権限
 
@@ -3561,46 +3786,49 @@ GET /v1.0/db-instances/{dbInstanceId}/storage-info
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v1.0/db-instances/{dbInstanceId}/storage-info
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| storageType | Body | Enum | データストレージタイプ |
-| storageSize | Body | Number | データストレージサイズ(GB) |
-| storageStatus | Body | Enum | データストレージの現在状態<br/>- DELETED: `削除済み`<br/>- PENDING_DELETION: `削除猶予中`<br/>- DELETION_RESERVED: `削除予約済み（スナップショット整理待ち）`<br/>- DETACHED: `デタッチ`<br/>- ATTACHED: `アタッチ` |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "storageType": "General SSD",
-    "storageSize": 1,
-    "storageStatus": "DELETED"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"storageType": "General SSD",
+"storageSize": 1,
+"storageStatus": "DELETED"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| storageType | Enum | データストレージタイプ |
+| storageSize | Number | データストレージサイズ(GB) |
+| storageStatus | Enum | データストレージの現在状態<br/>- DELETED: `削除済み`<br/>- PENDING_DELETION: `削除猶予中`<br/>- DELETION_RESERVED: `削除予約済み（スナップショット整理待ち）`<br/>- DETACHED: `デタッチ`<br/>- ATTACHED: `アタッチ` |
 
 ---
 
 ### DBインスタンスストレージ情報の修正
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/storage-info
-```
 
 #### 必要権限
 
@@ -3610,64 +3838,70 @@ PUT /v1.0/db-instances/{dbInstanceId}/storage-info
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| storageSize | Body | Number | O | データストレージサイズ(GB)<br/>- 最大値:`2048` |
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/storage-info
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "storageSize": 1
+"storageSize": 1
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| storageSize | Number | Y | データストレージサイズ(GB)<br/>- 最大値:`2048` |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
+
 ---
+
 ## バックアップ
 
 ### バックアップ状態
 
-| 状態           | 説明                   |
-|--------------|----------------------|
-| `BACKING_UP` | バックアップ中の場合            |
-| `COMPLETED`  | バックアップが完了した場合         |
-| `DELETING`   | バックアップが削除中の場合         |
-| `DELETED`    | バックアップが削除された場合        |
-| `ERROR`      | エラーが発生した場合            |
+| 状態 | 説明 |
+|--------------|--------------|
+| `BACKING_UP` | バックアップ中の場合 |
+| `COMPLETED` | バックアップが完了した場合 |
+| `DELETING` | バックアップが削除中の場合 |
+| `DELETED` | バックアップが削除された場合 |
+| `ERROR` | エラーが発生した場合 |
 
 ### バックアップリスト照会
-
-```http
-GET /v1.0/backups
-```
 
 #### 必要権限
 
@@ -3677,65 +3911,66 @@ GET /v1.0/backups
 
 #### リクエスト
 
+```http
+GET /v1.0/backups
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | 全体バックアップリスト数 |
-| backups | Body | Array | バックアップリスト |
-| backups.backupId | Body | UUID | バックアップの識別子 |
-| backups.backupName | Body | String | バックアップを識別できる名前 |
-| backups.backupStatus | Body | Enum | バックアップの現在状態<br/>- BACKING_UP: `バックアップ中(スピナー)`<br/>- VERIFYING: `検証中(スピナー)`<br/>- COMPLETED: `使用可能(緑アイコン)`<br/>- DELETING: `削除中(スピナー)`<br/>- DELETED: `削除済み(グレーアイコン)`<br/>- ERROR: `エラー(赤アイコン)` |
-| backups.dbInstanceId | Body | UUID | 原本DBインスタンスの識別子 |
-| backups.dbVersion | Body | Enum | DBエンジンバージョン |
-| backups.backupType | Body | Enum | バックアップタイプ<br/>- AUTO<br/>- MANUAL |
-| backups.backupSize | Body | Number | バックアップのサイズ(バイト) |
-| backups.startYmdt | Body | DateTime | 開始日時 |
-| backups.createdYmdt | Body | DateTime | 作成日時 |
-| backups.updatedYmdt | Body | DateTime | 修正日時 |
-| backups.completedYmdt | Body | DateTime | 完了日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 1,
-    "backups": [
-        {
-            "backupId": "550e8400-e29b-41d4-a716-446655440000",
-            "backupName": "backupName-example",
-            "backupStatus": "BACKING_UP",
-            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbVersion": "POSTGRESQL_V14_17",
-            "backupType": "AUTO",
-            "backupSize": 1,
-            "startYmdt": "2023-12-31T15:00:00+09:00",
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00",
-            "completedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"totalCounts": 1,
+"backups": [
+{
+"backupId": "550e8400-e29b-41d4-a716-446655440000",
+"backupName": "backupName-example",
+"backupStatus": "BACKING_UP",
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbVersion": "POSTGRESQL_V14_17",
+"backupType": "AUTO",
+"backupSize": 1,
+"startYmdt": "2023-12-31T15:00:00+09:00",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00",
+"completedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| totalCounts | Number | 全体バックアップリスト数 |
+| backups | Array | バックアップリスト |
+| backups.backupId | UUID | バックアップの識別子 |
+| backups.backupName | String | バックアップを識別できる名前 |
+| backups.backupStatus | Enum | バックアップの現在状態<br/>- BACKING_UP: `バックアップ中(スピナー)`<br/>- VERIFYING: `検証中(スピナー)`<br/>- COMPLETED: `使用可能(緑アイコン)`<br/>- DELETING: `削除中(スピナー)`<br/>- DELETED: `削除済み(グレーアイコン)`<br/>- ERROR: `エラー(赤アイコン)` |
+| backups.dbInstanceId | UUID | 原本DBインスタンスの識別子 |
+| backups.dbVersion | String | DBバージョン情報 |
+| backups.backupType | Enum | バックアップタイプ<br/>- AUTO<br/>- MANUAL |
+| backups.backupSize | Number | バックアップのサイズ(バイト) |
+| backups.startYmdt | DateTime | 開始日時 |
+| backups.createdYmdt | DateTime | 作成日時 |
+| backups.updatedYmdt | DateTime | 修正日時 |
+| backups.completedYmdt | DateTime | 完了日時 |
 
 ---
 
 ### バックアップ削除
-
-```http
-DELETE /v1.0/backups/{backupId}
-```
 
 #### 必要権限
 
@@ -3745,42 +3980,45 @@ DELETE /v1.0/backups/{backupId}
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+DELETE /v1.0/backups/{backupId}
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| backupId | URL | UUID | O | バックアップの識別子 |
+| backupId | URL | UUID | Y | バックアップの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### バックアップをエクスポート
-
-```http
-POST /v1.0/backups/{backupId}/export
-```
 
 #### 必要権限
 
@@ -3790,61 +4028,66 @@ POST /v1.0/backups/{backupId}/export
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| backupId | URL | UUID | O | バックアップの識別子 |
-| tenantId | Body | String | O | バックアップが保存されるオブジェクトストレージのテナントID<br/>- 最小長: `32`<br/>- 最大長: `32` |
-| username | Body | String | O | NHN CloudアカウントまたはIAMメンバーID |
-| password | Body | String | O | バックアップが保存されるオブジェクトストレージのAPIパスワード |
-| targetContainer | Body | String | O | バックアップが保存されるオブジェクトストレージのコンテナ |
-| objectPath | Body | String | O | コンテナに保存されるバックアップのパス |
+```http
+POST /v1.0/backups/{backupId}/export
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | Y | バックアップの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "tenantId": "0123456789abcdef0123456789abcdef",
-    "username": "username-example",
-    "password": "password-example",
-    "targetContainer": "targetContainer-example",
-    "objectPath": "objectPath-example"
+"tenantId": "0123456789abcdef0123456789abcdef",
+"username": "username-example",
+"password": "password-example",
+"targetContainer": "targetContainer-example",
+"objectPath": "objectPath-example"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| tenantId | String | Y | バックアップが保存されるオブジェクトストレージのテナントID<br/>- 最小長: `32`<br/>- 最大長: `32` |
+| username | String | Y | NHN CloudアカウントまたはIAMメンバーID |
+| password | String | Y | バックアップが保存されるオブジェクトストレージのAPIパスワード |
+| targetContainer | String | Y | バックアップが保存されるオブジェクトストレージのコンテナ |
+| objectPath | String | Y | コンテナに保存されるバックアップのパス |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### バックアップの復元
-
-```http
-POST /v1.0/backups/{backupId}/restore
-```
 
 #### 必要権限
 
@@ -3854,270 +4097,285 @@ POST /v1.0/backups/{backupId}/restore
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| backupId | URL | UUID | O | バックアップの識別子 |
-| dbInstanceName | Body | String | O | DBインスタンスを識別できる名前 |
-| dbInstanceCandidateName | Body | String | X | DBインスタンスを識別できる予備マスター名 |
-| description | Body | String | X | DBインスタンスの追加情報 |
-| dbFlavorId | Body | UUID | O | DBインスタンス仕様の識別子 |
-| dbPort | Body | Number | O | DBポート<br/>- 最小値: 5432、最大値: 45432 |
-| parameterGroupId | Body | UUID | O | パラメータグループの識別子 |
-| dbSecurityGroupIds | Body | Array | X | DBセキュリティグループの識別子リスト |
-| userGroupIds | Body | Array | X | ユーザーグループの識別子リスト |
-| useHighAvailability | Body | Boolean | X | 高可用性の使用有無<br/>- デフォルト値: `false` |
-| useDefaultNotification | Body | Boolean | X | 基本通知の使用有無<br/>- デフォルト値: `false` |
-| useDeletionProtection | Body | Boolean | X | 削除保護の有無<br/>- デフォルト値: `false` |
-| pingInterval | Body | Number | X | Ping間隔(秒)<br/>- 最小値: `1`<br/>- 最大値: `600` |
-| failoverReplWaitingTime | Body | Number | X | フェイルオーバー複製遅延待機時間(秒)<br/>- 最小値: `-1` |
-| network | Body | Object | O | ネットワーク情報オブジェクト |
-| network.subnetId | Body | UUID | O | サブネットの識別子 |
-| network.usePublicAccess | Body | Boolean | X | 外部接続可否<br/>- デフォルト値: `false` |
-| network.availabilityZone | Body | Enum | X | DBインスタンスを作成するアベイラビリティゾーン |
-| storage | Body | Object | O | ストレージ情報オブジェクト |
-| storage.storageType | Body | Enum | O | ストレージタイプ |
-| storage.storageSize | Body | Number | O | データストレージサイズ(GB)<br/>- 最小値: `20` |
-| backup | Body | Object | O | バックアップ情報オブジェクト |
-| backup.backupPeriod | Body | Number | O | バックアップの保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
-| backup.backupRetryCount | Body | Number | X | バックアップの再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
-| backup.backupSchedules | Body | Array | O | バックアップスケジュールリスト |
-| backup.backupSchedules.backupWndBgnTime | Body | Time | O | バックアップ開始時間 |
-| backup.backupSchedules.backupWndDuration | Body | Enum | O | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+```http
+POST /v1.0/backups/{backupId}/restore
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | Y | バックアップの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "dbInstanceName": "dbInstanceName-example",
-    "dbInstanceCandidateName": "dbInstanceCandidateName-example",
-    "description": "description-example",
-    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbPort": 1,
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbSecurityGroupIds": [],
-    "userGroupIds": [],
-    "useHighAvailability": false,
-    "useDefaultNotification": false,
-    "useDeletionProtection": false,
-    "pingInterval": 1,
-    "failoverReplWaitingTime": 1,
-    "network": {
-        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
-        "usePublicAccess": false,
-        "availabilityZone": "kr-pub-a"
-    },
-    "storage": {
-        "storageType": "General SSD",
-        "storageSize": 20
-    },
-    "backup": {
-        "backupPeriod": 0,
-        "backupRetryCount": 0,
-        "backupSchedules": [
-            {
-                "backupWndBgnTime": "00:00:00",
-                "backupWndDuration": "HALF_AN_HOUR"
-            }
-        ]
-    }
+"dbInstanceName": "dbInstanceName-example",
+"dbInstanceCandidateName": "dbInstanceCandidateName-example",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbPort": 1,
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useHighAvailability": false,
+"useDefaultNotification": false,
+"useDeletionProtection": false,
+"pingInterval": 1,
+"failoverReplWaitingTime": 1,
+"network": {
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
+},
+"storage": {
+"storageType": "General SSD",
+"storageSize": 20
+},
+"backup": {
+"backupPeriod": 0,
+"backupRetryCount": 0,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
+}
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | DBインスタンスを識別できる名前 |
+| dbInstanceCandidateName | String | N | DBインスタンスを識別できる予備マスター名 |
+| description | String | N | DBインスタンスの追加情報 |
+| dbFlavorId | UUID | Y | DBインスタンス仕様の識別子 |
+| dbPort | Number | Y | DBポート<br/>- 最小値: 5432、最大値: 45432 |
+| parameterGroupId | UUID | Y | パラメータグループの識別子 |
+| dbSecurityGroupIds | Array | N | DBセキュリティグループの識別子リスト |
+| userGroupIds | Array | N | ユーザーグループの識別子リスト |
+| useHighAvailability | Boolean | N | 高可用性の使用有無<br/>- デフォルト値: `false` |
+| useDefaultNotification | Boolean | N | 基本通知の使用有無<br/>- デフォルト値: `false` |
+| useDeletionProtection | Boolean | N | 削除保護の有無<br/>- デフォルト値: `false` |
+| pingInterval | Number | N | Ping間隔(秒)<br/>- 最小値: `1`<br/>- 最大値: `600` |
+| failoverReplWaitingTime | Number | N | フェイルオーバー複製遅延待機時間(秒)<br/>- 最小値: `-1` |
+| network | Object | Y | ネットワーク情報オブジェクト |
+| network.subnetId | UUID | Y | サブネットの識別子 |
+| network.usePublicAccess | Boolean | N | 外部接続可否<br/>- デフォルト値: `false` |
+| network.availabilityZone | Enum | N | DBインスタンスを作成するアベイラビリティゾーン |
+| storage | Object | Y | ストレージ情報オブジェクト |
+| storage.storageType | Enum | Y | ストレージタイプ |
+| storage.storageSize | Number | Y | データストレージサイズ(GB)<br/>- 最小値: `20` |
+| backup | Object | Y | バックアップ情報オブジェクト |
+| backup.backupPeriod | Number | Y | バックアップの保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| backup.backupRetryCount | Number | N | バックアップの再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| backup.backupSchedules | Array | Y | バックアップスケジュールリスト |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | バックアップ開始時間 |
+| backup.backupSchedules.backupWndDuration | Enum | Y | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
+
 ---
+
 ## DBセキュリティグループ
 
 ### DBセキュリティグループの進行状態
 
-| 状態              | 説明                     |
-|-----------------|--------------------------|
-| `NONE`          | 進行中の作業なし           |
-| `CREATING_RULE` | ルールポリシー作成中       |
-| `UPDATING_RULE` | ルールポリシー修正中       |
-| `DELETING_RULE` | ルールポリシー削除中       |
+| 状態 | 説明 |
+|-----------------|--------------|
+| `NONE` | 進行中の作業なし |
+| `CREATING_RULE` | ルールポリシー作成中 |
+| `UPDATING_RULE` | ルールポリシー修正中 |
+| `DELETING_RULE` | ルールポリシー削除中 |
 
 ### DBセキュリティグループリストを表示
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbSecurityGroup.List | DBセキュリティグループリストを表示 |
+
+#### リクエスト
 
 ```http
 GET /v1.0/db-security-groups
 ```
 
-#### 必要権限
-
-| 権限名                                  | 説明                       |
-|---------------------------------------|--------------------------|
-| RDSforPostgreSQL:DbSecurityGroup.List | DBセキュリティグループリストを表示 |
-
-#### リクエスト
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前                                    | 種類  | 形式      | 説明                                                                                                                                                                                                                                                              |
-|----------------------------------------|------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroups                       | Body | Array    | DBセキュリティグループリスト                                                                                                                                                                                                                                              |
-| dbSecurityGroups.dbSecurityGroupId     | Body | UUID     | DBセキュリティグループの識別子                                                                                                                                                                                                                                            |
-| dbSecurityGroups.dbSecurityGroupName   | Body | String   | DBセキュリティグループを識別できる名前                                                                                                                                                                                                                                    |
-| dbSecurityGroups.dbSecurityGroupStatus | Body | Enum     | DBセキュリティグループの現在状態<br/>- CREATED: `作成済み`<br/>- DELETED: `削除済み`                                                                                                                                                                                       |
-| dbSecurityGroups.description           | Body | String   | DBセキュリティグループの追加情報                                                                                                                                                                                                                                         |
-| dbSecurityGroups.progressStatus        | Body | Enum     | DBセキュリティグループの現在の進行状態<br/>- NONE: `進行中の作業なし`<br/>- CREATING_RULE: `ルールポリシー作成中`<br/>- UPDATING_RULE: `ルールポリシー修正中`<br/>- DELETING_RULE: `ルールポリシー削除中`<br/>- APPLYING_DEFAULT_RULE: `基本ルール適用中` |
-| dbSecurityGroups.createdYmdt           | Body | DateTime | 作成日時                                                                                                                                                                                                                                                          |
-| dbSecurityGroups.updatedYmdt           | Body | DateTime | 修正日時                                                                                                                                                                                                                                                          |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbSecurityGroups": [
-        {
-            "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbSecurityGroupName": "dbSecurityGroupName-example",
-            "dbSecurityGroupStatus": "CREATED",
-            "description": "description-example",
-            "progressStatus": "NONE",
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbSecurityGroups": [
+{
+"dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupName": "dbSecurityGroupName-example",
+"dbSecurityGroupStatus": "CREATED",
+"description": "description-example",
+"progressStatus": "NONE",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbSecurityGroups | Array | DBセキュリティグループリスト |
+| dbSecurityGroups.dbSecurityGroupId | UUID | DBセキュリティグループの識別子 |
+| dbSecurityGroups.dbSecurityGroupName | String | DBセキュリティグループを識別できる名前 |
+| dbSecurityGroups.dbSecurityGroupStatus | Enum | DBセキュリティグループの現在状態<br/>- CREATED: `作成済み`<br/>- DELETED: `削除済み` |
+| dbSecurityGroups.description | String | DBセキュリティグループの追加情報 |
+| dbSecurityGroups.progressStatus | Enum | DBセキュリティグループの現在の進行状態<br/>- NONE: `進行中の作業なし`<br/>- CREATING_RULE: `ルールポリシー作成中`<br/>- UPDATING_RULE: `ルールポリシー修正中`<br/>- DELETING_RULE: `ルールポリシー削除中`<br/>- APPLYING_DEFAULT_RULE: `基本ルール適用中` |
+| dbSecurityGroups.createdYmdt | DateTime | 作成日時 |
+| dbSecurityGroups.updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### DBセキュリティグループの作成
 
-```http
-POST /v1.0/db-security-groups
-```
-
 #### 必要権限
 
-| 権限名                                    | 説明                    |
-|-----------------------------------------|------------------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:DbSecurityGroup.Create | DBセキュリティグループ作成 |
 
 #### リクエスト
 
-| 名前                 | 種類  | 形式    | 必須 | 説明                                                                                                                                                                                                                                                              |
-|---------------------|------|--------|-----|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupName | Body | String | O   | DBセキュリティグループを識別できる名前                                                                                                                                                                                                                                |
-| description         | Body | String | X   | DBセキュリティグループの追加情報                                                                                                                                                                                                                                     |
-| rules               | Body | Array  | O   | DBセキュリティグループルール情報                                                                                                                                                                                                                                     |
-| rules.direction     | Body | Enum   | O   | 通信方向<br/>- INGRESS: `受信`<br/>- EGRESS: `送信`                                                                                                                                                                                                               |
-| rules.etherType     | Body | Enum   | O   | Etherタイプ<br/>- IPV4: `IPv4形式`<br/>- IPV6: `IPv6形式`                                                                                                                                                                                                        |
-| rules.port          | Body | Object | O   | ポートオブジェクト                                                                                                                                                                                                                                                  |
-| rules.port.portType | Body | Enum   | O   | ポートタイプ<br/>- ALL: `ポート範囲全体(ユーザーコンソールでは使用しない)`<br/>- PORT: `特定ポート`<br/>- DB_PORT: `DB受信ポート`<br/>- PORT_RANGE: `ポート範囲`                                                                                                           |
-| rules.port.minPort  | Body | Number | X   | 最小ポート範囲<br/>- 最小値: `1`                                                                                                                                                                                                                                    |
-| rules.port.maxPort  | Body | Number | X   | 最大ポート範囲<br/>- 最大値: `65535`                                                                                                                                                                                                                               |
-| rules.cidr          | Body | String | O   | CIDR                                                                                                                                                                                                                                                             |
-| rules.description   | Body | String | X   | DBセキュリティグループルールの追加情報                                                                                                                                                                                                                               |
+```http
+POST /v1.0/db-security-groups
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "dbSecurityGroupName": "dbSecurityGroupName-example",
-    "description": "description-example",
-    "rules": [
-        {
-            "direction": "INGRESS",
-            "etherType": "IPV4",
-            "port": {
-                "portType": "ALL",
-                "minPort": 1,
-                "maxPort": 1
-            },
-            "cidr": "192.168.0.0/24",
-            "description": "description-example"
-        }
-    ]
+"dbSecurityGroupName": "dbSecurityGroupName-example",
+"description": "description-example",
+"rules": [
+{
+"direction": "INGRESS",
+"etherType": "IPV4",
+"port": {
+"portType": "ALL",
+"minPort": 1,
+"maxPort": 1
+},
+"cidr": "192.168.0.0/24",
+"description": "description-example"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbSecurityGroupName | String | Y | DBセキュリティグループを識別できる名前 |
+| description | String | N | DBセキュリティグループの追加情報 |
+| rules | Array | Y | DBセキュリティグループルール情報 |
+| rules.direction | Enum | Y | 通信方向<br/>- INGRESS: `受信`<br/>- EGRESS: `送信` |
+| rules.etherType | Enum | Y | Etherタイプ<br/>- IPV4: `IPv4形式`<br/>- IPV6: `IPv6形式` |
+| rules.port | Object | Y | ポートオブジェクト |
+| rules.port.portType | Enum | Y | ポートタイプ<br/>- ALL: `ポート範囲全体(ユーザーコンソールでは使用しない)`<br/>- PORT: `特定ポート`<br/>- DB_PORT: `DB受信ポート`<br/>- PORT_RANGE: `ポート範囲` |
+| rules.port.minPort | Number | N | 最小ポート範囲<br/>- 最小値: `1` |
+| rules.port.maxPort | Number | N | 最大ポート範囲<br/>- 最大値: `65535` |
+| rules.cidr | String | Y | CIDR |
+| rules.description | String | N | DBセキュリティグループルールの追加情報 |
 
 #### レスポンス
 
-| 名前               | 種類  | 形式  | 説明                      |
-|-------------------|------|------|--------------------------|
-| dbSecurityGroupId | Body | UUID | DBセキュリティグループの識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbSecurityGroupId | UUID | DBセキュリティグループの識別子 |
 
 ---
 
 ### DBセキュリティグループの削除
 
-```http
-DELETE /v1.0/db-security-groups/{dbSecurityGroupId}
-```
-
 #### 必要権限
 
-| 権限名                                    | 説明                    |
-|-----------------------------------------|------------------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:DbSecurityGroup.Delete | DBセキュリティグループの削除 |
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+DELETE /v1.0/db-security-groups/{dbSecurityGroupId}
+```
 
-| 名前               | 種類 | 形式  | 必須 | 説明 |
-|-------------------|-----|------|----|-----|
-| dbSecurityGroupId | URL | UUID | O  |     |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
@@ -4127,124 +4385,133 @@ DELETE /v1.0/db-security-groups/{dbSecurityGroupId}
 
 ### DBセキュリティグループ詳細を表示
 
-```http
-GET /v1.0/db-security-groups/{dbSecurityGroupId}
-```
-
 #### 必要権限
 
-| 権限名                                 | 説明                         |
-|--------------------------------------|------------------------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:DbSecurityGroup.Get | DBセキュリティグループ詳細を表示 |
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v1.0/db-security-groups/{dbSecurityGroupId}
+```
 
-| 名前               | 種類 | 形式  | 必須 | 説明                      |
-|-------------------|-----|------|----|--------------------------|
-| dbSecurityGroupId | URL | UUID | O  |                          |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前                                    | 種類  | 形式      | 説明                                                                                                                                                                                                                                                                 |
-|-----------------------------------------|------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroup                         | Body | Object   | DBセキュリティグループ                                                                                                                                                                                                                                                  |
-| dbSecurityGroup.dbSecurityGroupId       | Body | UUID     | DBセキュリティグループの識別子                                                                                                                                                                                                                                           |
-| dbSecurityGroup.dbSecurityGroupName     | Body | String   | DBセキュリティグループを識別できる名前                                                                                                                                                                                                                                   |
-| dbSecurityGroup.dbSecurityGroupStatus   | Body | Enum     | DBセキュリティグループの現在状態<br/>- CREATED: `作成済み`<br/>- DELETED: `削除済み`                                                                                                                                                                                      |
-| dbSecurityGroup.description             | Body | String   | DBセキュリティグループの追加情報                                                                                                                                                                                                                                        |
-| dbSecurityGroup.progressStatus          | Body | Enum     | DBセキュリティグループの現在の進行状態<br/>- NONE: `進行中の作業なし`<br/>- CREATING_RULE: `ルールポリシー作成中`<br/>- UPDATING_RULE: `ルールポリシー修正中`<br/>- DELETING_RULE: `ルールポリシー削除中`<br/>- APPLYING_DEFAULT_RULE: `基本ルール適用中` |
-| dbSecurityGroup.rules                   | Body | Array    | DBセキュリティグループルールリスト                                                                                                                                                                                                                                      |
-| dbSecurityGroup.rules.ruleId            | Body | UUID     | DBセキュリティグループルールの識別子                                                                                                                                                                                                                                    |
-| dbSecurityGroup.rules.description       | Body | String   | DBセキュリティグループルールの追加情報                                                                                                                                                                                                                                  |
-| dbSecurityGroup.rules.direction         | Body | Enum     | 通信方向<br/>- INGRESS: `受信`<br/>- EGRESS: `送信`                                                                                                                                                                                                                  |
-| dbSecurityGroup.rules.etherType         | Body | Enum     | Etherタイプ<br/>- IPV4: `IPv4形式`<br/>- IPV6: `IPv6形式`                                                                                                                                                                                                           |
-| dbSecurityGroup.rules.port              | Body | Object   | ポートオブジェクト                                                                                                                                                                                                                                                      |
-| dbSecurityGroup.rules.port.portType     | Body | Enum     | ポートタイプ<br/>- ALL: `ポート範囲全体(ユーザーコンソールでは使用しない)`<br/>- PORT: `特定ポート`<br/>- DB_PORT: `DB受信ポート`<br/>- PORT_RANGE: `ポート範囲`                                                                                                            |
-| dbSecurityGroup.rules.port.minPort      | Body | Number   | 最小ポート範囲                                                                                                                                                                                                                                                        |
-| dbSecurityGroup.rules.port.maxPort      | Body | Number   | 最大ポート範囲                                                                                                                                                                                                                                                        |
-| dbSecurityGroup.rules.cidr              | Body | String   | CIDR                                                                                                                                                                                                                                                                |
-| dbSecurityGroup.rules.createdYmdt       | Body | DateTime | 作成日時                                                                                                                                                                                                                                                            |
-| dbSecurityGroup.rules.updatedYmdt       | Body | DateTime | 修正日時                                                                                                                                                                                                                                                            |
-| dbSecurityGroup.createdYmdt             | Body | DateTime | 作成日時                                                                                                                                                                                                                                                            |
-| dbSecurityGroup.updatedYmdt             | Body | DateTime | 修正日時                                                                                                                                                                                                                                                            |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbSecurityGroup": {
-        "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
-        "dbSecurityGroupName": "dbSecurityGroupName-example",
-        "dbSecurityGroupStatus": "CREATED",
-        "description": "description-example",
-        "progressStatus": "NONE",
-        "rules": [
-            {
-                "ruleId": "550e8400-e29b-41d4-a716-446655440000",
-                "description": "description-example",
-                "direction": "INGRESS",
-                "etherType": "IPV4",
-                "port": {
-                    "portType": "ALL",
-                    "minPort": 1,
-                    "maxPort": 1
-                },
-                "cidr": "192.168.0.0/24",
-                "createdYmdt": "2023-12-31T15:00:00+09:00",
-                "updatedYmdt": "2023-12-31T15:00:00+09:00"
-            }
-        ],
-        "createdYmdt": "2023-12-31T15:00:00+09:00",
-        "updatedYmdt": "2023-12-31T15:00:00+09:00"
-    }
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbSecurityGroup": {
+"dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupName": "dbSecurityGroupName-example",
+"dbSecurityGroupStatus": "CREATED",
+"description": "description-example",
+"progressStatus": "NONE",
+"rules": [
+{
+"ruleId": "550e8400-e29b-41d4-a716-446655440000",
+"description": "description-example",
+"direction": "INGRESS",
+"etherType": "IPV4",
+"port": {
+"portType": "ALL",
+"minPort": 1,
+"maxPort": 1
+},
+"cidr": "192.168.0.0/24",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbSecurityGroup | Object | DBセキュリティグループ |
+| dbSecurityGroup.dbSecurityGroupId | UUID | DBセキュリティグループの識別子 |
+| dbSecurityGroup.dbSecurityGroupName | String | DBセキュリティグループを識別できる名前 |
+| dbSecurityGroup.dbSecurityGroupStatus | Enum | DBセキュリティグループの現在状態<br/>- CREATED: `作成済み`<br/>- DELETED: `削除済み` |
+| dbSecurityGroup.description | String | DBセキュリティグループの追加情報 |
+| dbSecurityGroup.progressStatus | Enum | DBセキュリティグループの現在の進行状態<br/>- NONE: `進行中の作業なし`<br/>- CREATING_RULE: `ルールポリシー作成中`<br/>- UPDATING_RULE: `ルールポリシー修正中`<br/>- DELETING_RULE: `ルールポリシー削除中`<br/>- APPLYING_DEFAULT_RULE: `基本ルール適用中` |
+| dbSecurityGroup.rules | Array | DBセキュリティグループルールリスト |
+| dbSecurityGroup.rules.ruleId | UUID | DBセキュリティグループルールの識別子 |
+| dbSecurityGroup.rules.description | String | DBセキュリティグループルールの追加情報 |
+| dbSecurityGroup.rules.direction | Enum | 通信方向<br/>- INGRESS: `受信`<br/>- EGRESS: `送信` |
+| dbSecurityGroup.rules.etherType | Enum | Etherタイプ<br/>- IPV4: `IPv4形式`<br/>- IPV6: `IPv6形式` |
+| dbSecurityGroup.rules.port | Object | ポートオブジェクト |
+| dbSecurityGroup.rules.port.portType | Enum | ポートタイプ<br/>- ALL: `ポート範囲全体(ユーザーコンソールでは使用しない)`<br/>- PORT: `特定ポート`<br/>- DB_PORT: `DB受信ポート`<br/>- PORT_RANGE: `ポート範囲` |
+| dbSecurityGroup.rules.port.minPort | Number | 最小ポート範囲 |
+| dbSecurityGroup.rules.port.maxPort | Number | 最大ポート範囲 |
+| dbSecurityGroup.rules.cidr | String | CIDR |
+| dbSecurityGroup.rules.createdYmdt | DateTime | 作成日時 |
+| dbSecurityGroup.rules.updatedYmdt | DateTime | 修正日時 |
+| dbSecurityGroup.createdYmdt | DateTime | 作成日時 |
+| dbSecurityGroup.updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### DBセキュリティグループの修正
 
-```http
-PUT /v1.0/db-security-groups/{dbSecurityGroupId}
-```
-
 #### 必要権限
 
-| 権限名                                    | 説明                    |
-|-----------------------------------------|------------------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:DbSecurityGroup.Modify | DBセキュリティグループの修正 |
 
 #### リクエスト
 
-| 名前                 | 種類  | 形式    | 必須 | 説明                                    |
-|---------------------|------|--------|-----|----------------------------------------|
-| dbSecurityGroupId   | URL  | UUID   | O   |                                        |
-| dbSecurityGroupName | Body | String | O   | DBセキュリティグループを識別できる名前       |
-| description         | Body | String | X   | DBセキュリティグループの追加情報            |
+```http
+PUT /v1.0/db-security-groups/{dbSecurityGroupId}
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "dbSecurityGroupName": "dbSecurityGroupName-example",
-    "description": "description-example"
+"dbSecurityGroupName": "dbSecurityGroupName-example",
+"description": "description-example"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbSecurityGroupName | String | Y | DBセキュリティグループを識別できる名前 |
+| description | String | N | DBセキュリティグループの追加情報 |
 
 #### レスポンス
 
@@ -4254,199 +4521,209 @@ PUT /v1.0/db-security-groups/{dbSecurityGroupId}
 
 ### DBセキュリティグループルールの削除
 
-```http
-DELETE /v1.0/db-security-groups/{dbSecurityGroupId}/rules
-```
-
 #### 必要権限
 
-| 権限名                                        | 説明                         |
-|---------------------------------------------|------------------------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:DbSecurityGroupRule.Delete | DBセキュリティグループルールの削除 |
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+DELETE /v1.0/db-security-groups/{dbSecurityGroupId}/rules
+```
 
-| 名前               | 種類   | 形式    | 必須 | 説明                             |
-|-------------------|-------|--------|-----|----------------------------------|
-| dbSecurityGroupId | URL   | UUID   | O   |                                  |
-| ruleIds           | Query | String | O   | DBセキュリティグループルールIDリスト |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+| ruleIds | Query | String | Y | DBセキュリティグループルールIDリスト |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前   | 種類  | 形式  | 説明                    |
-|-------|------|------|------------------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### DBセキュリティグループルールの作成
 
-```http
-POST /v1.0/db-security-groups/{dbSecurityGroupId}/rules
-```
-
 #### 必要権限
 
-| 権限名                                        | 説明                         |
-|---------------------------------------------|------------------------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:DbSecurityGroupRule.Create | DBセキュリティグループルールの作成 |
 
 #### リクエスト
 
-| 名前               | 種類  | 形式    | 必須 | 説明                                                                                                                                                                                                               |
-|-------------------|------|--------|-----|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId | URL  | UUID   | O   |                                                                                                                                                                                                                    |
-| direction         | Body | Enum   | O   | 通信方向<br/>- INGRESS: `受信`<br/>- EGRESS: `送信`                                                                                                                                                               |
-| etherType         | Body | Enum   | O   | Etherタイプ<br/>- IPV4: `IPv4形式`<br/>- IPV6: `IPv6形式`                                                                                                                                                        |
-| port              | Body | Object | O   | ポート情報                                                                                                                                                                                                         |
-| port.portType     | Body | Enum   | O   | ポートタイプ<br/>- ALL: `ポート範囲全体(ユーザーコンソールでは使用しない)`<br/>- PORT: `特定ポート`<br/>- DB_PORT: `DB受信ポート`<br/>- PORT_RANGE: `ポート範囲`                                                       |
-| port.minPort      | Body | Number | X   | 最小ポート範囲<br/>- 最小値: `1`                                                                                                                                                                                   |
-| port.maxPort      | Body | Number | X   | 最大ポート範囲<br/>- 最大値: `65535`                                                                                                                                                                              |
-| cidr              | Body | String | O   | CIDR                                                                                                                                                                                                              |
-| description       | Body | String | X   | DBセキュリティグループルールの追加情報                                                                                                                                                                               |
+```http
+POST /v1.0/db-security-groups/{dbSecurityGroupId}/rules
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "direction": "INGRESS",
-    "etherType": "IPV4",
-    "port": {
-        "portType": "ALL",
-        "minPort": 1,
-        "maxPort": 1
-    },
-    "cidr": "192.168.0.0/24",
-    "description": "description-example"
+"direction": "INGRESS",
+"etherType": "IPV4",
+"port": {
+"portType": "ALL",
+"minPort": 1,
+"maxPort": 1
+},
+"cidr": "192.168.0.0/24",
+"description": "description-example"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| direction | Enum | Y | 通信方向<br/>- INGRESS: `受信`<br/>- EGRESS: `送信` |
+| etherType | Enum | Y | Etherタイプ<br/>- IPV4: `IPv4形式`<br/>- IPV6: `IPv6形式` |
+| port | Object | Y | ポート情報 |
+| port.portType | Enum | Y | ポートタイプ<br/>- ALL: `ポート範囲全体(ユーザーコンソールでは使用しない)`<br/>- PORT: `特定ポート`<br/>- DB_PORT: `DB受信ポート`<br/>- PORT_RANGE: `ポート範囲` |
+| port.minPort | Number | N | 最小ポート範囲<br/>- 最小値: `1` |
+| port.maxPort | Number | N | 最大ポート範囲<br/>- 最大値: `65535` |
+| cidr | String | Y | CIDR |
+| description | String | N | DBセキュリティグループルールの追加情報 |
 
 #### レスポンス
 
-| 名前   | 種類  | 形式  | 説明                    |
-|-------|------|------|------------------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### DBセキュリティグループルールの修正
 
-```http
-PUT /v1.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
-```
-
 #### 必要権限
 
-| 権限名                                        | 説明                         |
-|---------------------------------------------|------------------------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:DbSecurityGroupRule.Modify | DBセキュリティグループルールの修正 |
 
 #### リクエスト
 
-| 名前               | 種類  | 形式    | 必須 | 説明                                                                                                                                                                                                               |
-|-------------------|------|--------|-----|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId | URL  | UUID   | O   |                                                                                                                                                                                                                    |
-| ruleId            | URL  | UUID   | O   |                                                                                                                                                                                                                    |
-| direction         | Body | Enum   | O   | 通信方向<br/>- INGRESS: `受信`<br/>- EGRESS: `送信`                                                                                                                                                               |
-| etherType         | Body | Enum   | O   | Etherタイプ<br/>- IPV4: `IPv4形式`<br/>- IPV6: `IPv6形式`                                                                                                                                                        |
-| port              | Body | Object | O   | ポート情報                                                                                                                                                                                                         |
-| port.portType     | Body | Enum   | O   | ポートタイプ<br/>- ALL: `ポート範囲全体(ユーザーコンソールでは使用しない)`<br/>- PORT: `特定ポート`<br/>- DB_PORT: `DB受信ポート`<br/>- PORT_RANGE: `ポート範囲`                                                       |
-| port.minPort      | Body | Number | X   | 最小ポート範囲<br/>- 最小値: `1`                                                                                                                                                                                   |
-| port.maxPort      | Body | Number | X   | 最大ポート範囲<br/>- 最大値: `65535`                                                                                                                                                                              |
-| cidr              | Body | String | O   | CIDR                                                                                                                                                                                                              |
-| description       | Body | String | X   | DBセキュリティグループルールの追加情報                                                                                                                                                                               |
+```http
+PUT /v1.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+| ruleId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "direction": "INGRESS",
-    "etherType": "IPV4",
-    "port": {
-        "portType": "ALL",
-        "minPort": 1,
-        "maxPort": 1
-    },
-    "cidr": "192.168.0.0/24",
-    "description": "description-example"
+"direction": "INGRESS",
+"etherType": "IPV4",
+"port": {
+"portType": "ALL",
+"minPort": 1,
+"maxPort": 1
+},
+"cidr": "192.168.0.0/24",
+"description": "description-example"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| direction | Enum | Y | 通信方向<br/>- INGRESS: `受信`<br/>- EGRESS: `送信` |
+| etherType | Enum | Y | Etherタイプ<br/>- IPV4: `IPv4形式`<br/>- IPV6: `IPv6形式` |
+| port | Object | Y | ポート情報 |
+| port.portType | Enum | Y | ポートタイプ<br/>- ALL: `ポート範囲全体(ユーザーコンソールでは使用しない)`<br/>- PORT: `特定ポート`<br/>- DB_PORT: `DB受信ポート`<br/>- PORT_RANGE: `ポート範囲` |
+| port.minPort | Number | N | 最小ポート範囲<br/>- 最小値: `1` |
+| port.maxPort | Number | N | 最大ポート範囲<br/>- 最大値: `65535` |
+| cidr | String | Y | CIDR |
+| description | String | N | DBセキュリティグループルールの追加情報 |
 
 #### レスポンス
 
-| 名前   | 種類  | 形式  | 説明                    |
-|-------|------|------|------------------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
+
 ---
+
 ## パラメータグループ
 
 ### パラメータグループリストを表示
-
-```http
-GET /v1.0/parameter-groups
-```
 
 #### 必要権限
 
@@ -4456,55 +4733,56 @@ GET /v1.0/parameter-groups
 
 #### リクエスト
 
+```http
+GET /v1.0/parameter-groups
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| parameterGroups | Body | Array | パラメータグループリスト |
-| parameterGroups.parameterGroupId | Body | UUID | パラメータグループの識別子 |
-| parameterGroups.parameterGroupName | Body | String | パラメータグループを識別できる名前 |
-| parameterGroups.description | Body | String | パラメータグループの追加情報 |
-| parameterGroups.dbVersion | Body | Enum | DBバージョン情報 |
-| parameterGroups.parameterGroupStatus | Body | Enum | パラメータグループの現在状態<br/>- STABLE: `適用完了`<br/>- NEED_TO_APPLY: `適用必要`<br/>- DELETED: `削除済み` |
-| parameterGroups.createdYmdt | Body | DateTime | 作成日時 |
-| parameterGroups.updatedYmdt | Body | DateTime | 修正日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroups": [
-        {
-            "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-            "parameterGroupName": "parameterGroupName-example",
-            "description": "description-example",
-            "dbVersion": "POSTGRESQL_V14_17",
-            "parameterGroupStatus": "STABLE",
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"parameterGroups": [
+{
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"parameterGroupName": "parameterGroupName-example",
+"description": "description-example",
+"dbVersion": "POSTGRESQL_V14_17",
+"parameterGroupStatus": "STABLE",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| parameterGroups | Array | パラメータグループリスト |
+| parameterGroups.parameterGroupId | UUID | パラメータグループの識別子 |
+| parameterGroups.parameterGroupName | String | パラメータグループを識別できる名前 |
+| parameterGroups.description | String | パラメータグループの追加情報 |
+| parameterGroups.dbVersion | String | DBバージョン情報 |
+| parameterGroups.parameterGroupStatus | Enum | パラメータグループの現在状態<br/>- STABLE: `適用完了`<br/>- NEED_TO_APPLY: `適用必要`<br/>- DELETED: `削除済み` |
+| parameterGroups.createdYmdt | DateTime | 作成日時 |
+| parameterGroups.updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### パラメータグループの作成
-
-```http
-POST /v1.0/parameter-groups
-```
 
 #### 必要権限
 
@@ -4514,56 +4792,56 @@ POST /v1.0/parameter-groups
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| parameterGroupName | Body | String | O | パラメータグループを識別できる名前 |
-| description | Body | String | X | パラメータグループの追加情報 |
-| dbVersion | Body | Enum | O | DBバージョン情報 |
+```http
+POST /v1.0/parameter-groups
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "parameterGroupName": "parameterGroupName-example",
-    "description": "description-example",
-    "dbVersion": "POSTGRESQL_V14_17"
+"parameterGroupName": "parameterGroupName-example",
+"description": "description-example",
+"dbVersion": "POSTGRESQL_V14_17"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| parameterGroupName | String | Y | パラメータグループを識別できる名前 |
+| description | String | N | パラメータグループの追加情報 |
+| dbVersion | String | Y | DBバージョン情報 |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| parameterGroupId | Body | UUID | パラメータグループの識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| parameterGroupId | UUID | パラメータグループの識別子 |
 
 ---
 
 ### パラメータグループの削除
-
-```http
-DELETE /v1.0/parameter-groups/{parameterGroupId}
-```
 
 #### 必要権限
 
@@ -4573,11 +4851,19 @@ DELETE /v1.0/parameter-groups/{parameterGroupId}
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+DELETE /v1.0/parameter-groups/{parameterGroupId}
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O | パラメータグループの識別子 |
+| parameterGroupId | URL | UUID | Y | パラメータグループの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
@@ -4587,10 +4873,6 @@ DELETE /v1.0/parameter-groups/{parameterGroupId}
 
 ### パラメータグループ詳細を表示
 
-```http
-GET /v1.0/parameter-groups/{parameterGroupId}
-```
-
 #### 必要権限
 
 | 権限名 | 説明 |
@@ -4599,79 +4881,87 @@ GET /v1.0/parameter-groups/{parameterGroupId}
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v1.0/parameter-groups/{parameterGroupId}
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O | パラメータグループの識別子 |
+| parameterGroupId | URL | UUID | Y | パラメータグループの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| parameterGroupId | Body | UUID | パラメータグループの識別子 |
-| parameterGroupName | Body | String | パラメータグループを識別できる名前 |
-| description | Body | String | パラメータグループの追加情報 |
-| dbVersion | Body | Enum | DBバージョン情報 |
-| parameterGroupStatus | Body | Enum | パラメータグループの現在状態<br/>- STABLE: `適用完了`<br/>- NEED_TO_APPLY: `適用必要`<br/>- DELETED: `削除済み` |
-| parameters | Body | Array | パラメータリスト |
-| parameters.parameterCategory | Body | String | パラメータカテゴリー |
-| parameters.parameterName | Body | String | パラメータ名 |
-| parameters.value | Body | String | 現在設定されている値 |
-| parameters.valueUnit | Body | String | 値の単位(バイト: B,kB,MB,GB,TB、時間: us,ms,s,min,h,d) |
-| parameters.defaultValue | Body | String | デフォルト値 |
-| parameters.allowedValue | Body | String | 許可された値 |
-| parameters.valueType | Body | Enum | 値タイプ<br/>- BOOLEAN: `ブーリアンタイプ`<br/> `* ex) on, off, true, false, yes, no, 1, 0`<br/>- STRING: `文字列タイプ`<br/>- NUMERIC: `整数および浮動小数点タイプ`<br/>- NUMERIC_WITH_BYTE_UNIT: `バイト単位の数字タイプ`<br/> `* ex) 120kB, 100MB`<br/> `* 許可されたバイト単位: B (bytes), kB (kilobytes), MB (megabytes), GB (gigabytes), and TB (terabytes)`<br/>- NUMERIC_WITH_TIME_UNIT: `時間単位の数字タイプ`<br/> `* ex) 120ms, 100s, 1d`<br/> `* 許可された時間単位: us (microseconds), ms (milliseconds), s (seconds), min (minutes), h (hours), and d (days)`<br/>- ENUMERATED: `許可された値に宣言された値の中から1つを選択(コンマ(,)で区分される)`<br/>- MULTI_ENUMERATED: `許可された値に宣言された値の中から複数個を選択(コンマ(,)で区分される)` |
-| parameters.updateType | Body | Enum | 修正タイプ<br/>- VARIABLE: `常に修正可能`<br/>- CONSTANT: `修正不可能` |
-| parameters.applyType | Body | Enum | 適用タイプ<br/>- BOTH: `セッション、設定ファイルの両方に適用`<br/>- SESSION: `セッションにのみ適用`<br/>- FILE: `設定ファイルにのみ適用` |
-| parameters.expressionAvailable | Body | Boolean | 数式の使用可否 |
-| createdYmdt | Body | DateTime | 作成日時 |
-| updatedYmdt | Body | DateTime | 修正日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "parameterGroupName": "parameterGroupName-example",
-    "description": "description-example",
-    "dbVersion": "POSTGRESQL_V14_17",
-    "parameterGroupStatus": "STABLE",
-    "parameters": [
-        {
-            "parameterCategory": "parameterCategory-example",
-            "parameterName": "parameterName-example",
-            "value": "value-example",
-            "valueUnit": "valueUnit-example",
-            "defaultValue": "defaultValue-example",
-            "allowedValue": "allowedValue-example",
-            "valueType": "BOOLEAN",
-            "updateType": "VARIABLE",
-            "applyType": "BOTH",
-            "expressionAvailable": false
-        }
-    ],
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"parameterGroupName": "parameterGroupName-example",
+"description": "description-example",
+"dbVersion": "POSTGRESQL_V14_17",
+"parameterGroupStatus": "STABLE",
+"valueUnit": "valueUnit-example",
+{
+"allowedValue": "allowedValue-example",
+"valueType": "BOOLEAN",
+"updateType": "VARIABLE",
+"applyType": "BOTH",
+"expressionAvailable": false
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| parameterGroupId | UUID | パラメータグループの識別子 |
+| parameterGroupName | String | パラメータグループを識別できる名前 |
+| description | String | パラメータグループの追加情報 |
+| dbVersion | String | DBバージョン情報 |
+| parameterGroupStatus | Enum | パラメータグループの現在状態<br/>- STABLE: `適用完了`<br/>- NEED_TO_APPLY: `適用必要`<br/>- DELETED: `削除済み` |
+| parameters | Array | パラメータリスト |
+| parameters.parameterCategory | String | パラメータカテゴリー |
+| parameters.parameterName | String | パラメータ名 |
+| parameters.value | String | 現在設定されている値 |
+| parameters.valueUnit | String | 値の単位(バイト: B,kB,MB,GB,TB、時間: us,ms,s,min,h,d) |
+| parameters.defaultValue | String | デフォルト値 |
+| parameters.allowedValue | String | 許可された値 |
+| parameters.valueType | Enum | 値タイプ<br/>- BOOLEAN: `ブーリアンタイプ`<br/> `* ex) on, off, true, false, yes, no, 1, 0`<br/>- STRING: `文字列タイプ`<br/>- NUMERIC: `整数および浮動小数点タイプ`<br/>- NUMERIC_WITH_BYTE_UNIT: `バイト単位の数字タイプ`<br/> `* ex) 120kB, 100MB`<br/> `* 許可されたバイト単位: B (bytes), kB (kilobytes), MB (megabytes), GB (gigabytes), and TB (terabytes)`<br/>- NUMERIC_WITH_TIME_UNIT: `時間単位の数字タイプ`<br/> `* ex) 120ms, 100s, 1d`<br/> `* 許可された時間単位: us (microseconds), ms (milliseconds), s (seconds), min (minutes), h (hours), and d (days)`<br/>- ENUMERATED: `許可された値に宣言された値の中から1つを選択(コンマ(,)で区分される)`<br/>- MULTI_ENUMERATED: `許可された値に宣言された値の中から複数個を選択(コンマ(,)で区分される)` |
+<p>
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+| parameters.updateType | Enum | 修正タイプ<br/>- VARIABLE: `常に修正可能`<br/>- CONSTANT: `修正不可能` |
+| parameters.applyType | Enum | 適用タイプ<br/>- BOTH: `セッション、設定ファイルの両方に適用`<br/>- SESSION: `セッションにのみ適用`<br/>- FILE: `設定ファイルにのみ適用` |
+| parameters.expressionAvailable | Boolean | 数式の使用可否 |
+| createdYmdt | DateTime | 作成日時 |
+| updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### パラメータグループの修正
-
-```http
-PUT /v1.0/parameter-groups/{parameterGroupId}
-```
 
 #### 必要権限
 
@@ -4681,24 +4971,34 @@ PUT /v1.0/parameter-groups/{parameterGroupId}
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O | パラメータグループの識別子 |
-| parameterGroupName | Body | String | X | パラメータグループを識別できる名前 |
-| description | Body | String | X | パラメータグループの追加情報 |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "parameterGroupName": "parameterGroupName-example",
-    "description": "description-example"
+```http
 }
 ```
 
-</p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y | パラメータグループの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"parameterGroupName": "parameterGroupName-example",
+"description": "description-example"
+}
+```
+
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| parameterGroupName | String | N | パラメータグループを識別できる名前 |
+| description | String | N | パラメータグループの追加情報 |
 
 #### レスポンス
 
@@ -4708,10 +5008,6 @@ PUT /v1.0/parameter-groups/{parameterGroupId}
 
 ### パラメータグループのコピー
 
-```http
-POST /v1.0/parameter-groups/{parameterGroupId}/copy
-```
-
 #### 必要権限
 
 | 権限名 | 説明 |
@@ -4720,55 +5016,60 @@ POST /v1.0/parameter-groups/{parameterGroupId}/copy
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O | パラメータグループの識別子 |
-| parameterGroupName | Body | String | O | パラメータグループを識別できる名前 |
-| description | Body | String | X | パラメータグループの追加情報 |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "parameterGroupName": "parameterGroupName-example",
-    "description": "description-example"
+```http
 }
 ```
 
-</p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y | パラメータグループの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"parameterGroupName": "parameterGroupName-example",
+"description": "description-example"
+}
+```
+
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| parameterGroupName | String | Y | パラメータグループを識別できる名前 |
+| description | String | N | パラメータグループの追加情報 |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| parameterGroupId | Body | UUID | パラメータグループの識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| parameterGroupId | UUID | パラメータグループの識別子 |
 
 ---
 
 ### パラメータ修正
-
-```http
-PUT /v1.0/parameter-groups/{parameterGroupId}/parameters
-```
 
 #### 必要権限
 
@@ -4778,29 +5079,39 @@ PUT /v1.0/parameter-groups/{parameterGroupId}/parameters
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O | パラメータグループの識別子 |
-| modifiedParameters | Body | Array | O | 変更するパラメータリスト |
-| modifiedParameters.parameterName | Body | String | O | パラメータ名 |
-| modifiedParameters.value | Body | String | O | 変更するパラメータ値 |
+```http
+"parameterName": "parameterName-example",
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y | パラメータグループの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "modifiedParameters": [
-        {
-            "parameterName": "parameterName-example",
-            "value": "value-example"
-        }
-    ]
+]
+{
+"valueType": "BOOLEAN",
+このAPIはレスポンス本文を返しません。
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| modifiedParameters | Array | Y | 変更するパラメータリスト |
+| modifiedParameters.parameterName | String | Y | パラメータ名 |
+| modifiedParameters.value | String | Y | 変更するパラメータ値 |
 
 #### レスポンス
 
@@ -4810,10 +5121,6 @@ PUT /v1.0/parameter-groups/{parameterGroupId}/parameters
 
 ### パラメータグループの再設定
 
-```http
-PUT /v1.0/parameter-groups/{parameterGroupId}/reset
-```
-
 #### 必要権限
 
 | 権限名 | 説明 |
@@ -4822,24 +5129,29 @@ PUT /v1.0/parameter-groups/{parameterGroupId}/reset
 
 #### リクエスト
 
+```http
 このAPIはリクエスト本文を要求しません。
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O | パラメータグループの識別子 |
+| parameterGroupId | URL | UUID | Y | パラメータグループの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
 
 ---
+
 ## ユーザーグループ
 
 ### ユーザーグループリストを表示
-
-```http
-GET /v1.0/user-groups
-```
 
 #### 必要権限
 
@@ -4849,51 +5161,52 @@ GET /v1.0/user-groups
 
 #### リクエスト
 
+```http
+"resultCode": 0,
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| userGroups | Body | Array | ユーザーグループリスト |
-| userGroups.userGroupId | Body | UUID | ユーザーグループの識別子 |
-| userGroups.userGroupName | Body | String | ユーザーグループを識別できる名前 |
-| userGroupStatus | Body | Enum | ユーザーグループの現在状態<br/>- CREATED<br/>- DELETED |
-| userGroups.createdYmdt | Body | DateTime | 作成日時 |
-| userGroups.updatedYmdt | Body | DateTime | 修正日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "userGroups": [
-        {
-            "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
-            "userGroupName": "userGroupName-example",
-            "userGroupStatus": "CREATED",
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+{
+}
+]
+}
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| userGroups | Array | ユーザーグループリスト |
+| userGroups.userGroupId | UUID | ユーザーグループの識別子 |
+| userGroups.userGroupName | String | ユーザーグループを識別できる名前 |
+| userGroups.userGroupStatus | Enum | ユーザーグループの現在状態<br/>- CREATED<br/>- DELETED |
+| userGroups.createdYmdt | DateTime | 作成日時 |
+| userGroups.updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### ユーザーグループの作成
-
-```http
-POST /v1.0/user-groups
-```
 
 #### 必要権限
 
@@ -4903,56 +5216,56 @@ POST /v1.0/user-groups
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| userGroupName | Body | String | O | ユーザーグループを識別できる名前 |
-| memberIds | Body | Array | O | プロジェクトメンバーの識別子リスト |
-| selectAllYN | Body | Boolean | O | プロジェクトメンバー全体の有無<br/>- デフォルト値: `false` |
+```http
+"selectAllYN": false
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "userGroupName": "userGroupName-example",
-    "memberIds": [],
-    "selectAllYN": false
+]
+{
+"header": {
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| userGroupName | String | Y | ユーザーグループを識別できる名前 |
+| memberIds | Array | Y | プロジェクトメンバーの識別子リスト |
+| selectAllYN | Boolean | Y | プロジェクトメンバー全体の有無<br/>- デフォルト値: `false` |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| userGroupId | Body | UUID | ユーザーグループの識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "userGroupId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+このAPIはリクエスト本文を要求しません。
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| userGroupId | UUID | ユーザーグループの識別子 |
 
 ---
 
 ### ユーザーグループの削除
-
-```http
-DELETE /v1.0/user-groups/{userGroupId}
-```
 
 #### 必要権限
 
@@ -4962,11 +5275,19 @@ DELETE /v1.0/user-groups/{userGroupId}
 
 #### リクエスト
 
+```http
 このAPIはリクエスト本文を要求しません。
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| userGroupId | URL | UUID | O | ユーザーグループの識別子 |
+| userGroupId | URL | UUID | Y | ユーザーグループの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
@@ -4976,10 +5297,6 @@ DELETE /v1.0/user-groups/{userGroupId}
 
 ### ユーザーグループ詳細を表示
 
-```http
-GET /v1.0/user-groups/{userGroupId}
-```
-
 #### 必要権限
 
 | 権限名 | 説明 |
@@ -4988,59 +5305,62 @@ GET /v1.0/user-groups/{userGroupId}
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+"resultCode": 0,
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| userGroupId | URL | UUID | O | ユーザーグループの識別子 |
+| userGroupId | URL | UUID | Y | ユーザーグループの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| userGroupId | Body | UUID | ユーザーグループの識別子 |
-| userGroupName | Body | String | ユーザーグループを識別できる名前 |
-| userGroupTypeCode | Body | Enum | ユーザーグループ種類<br/>- ENTIRE: `プロジェクトメンバー全体`<br/>- INDIVIDUAL_MEMBER: `ユーザー指定` |
-| userGroupStatus | Body | Enum | ユーザーグループの現在状態<br/>- CREATED<br/>- DELETED |
-| members | Body | Array | プロジェクトメンバーリスト |
-| members.memberId | Body | UUID | プロジェクトメンバーの識別子 |
-| createdYmdt | Body | DateTime | 作成日時 |
-| updatedYmdt | Body | DateTime | 修正日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "userGroupName": "userGroupName-example",
-    "userGroupTypeCode": "ENTIRE",
-    "userGroupStatus": "CREATED",
-    "members": [
-        {
-            "memberId": "550e8400-e29b-41d4-a716-446655440000"
-        }
-    ],
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+}
+]
+}
+}
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+{
+}
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| userGroupId | UUID | ユーザーグループの識別子 |
+| userGroupName | String | ユーザーグループを識別できる名前 |
+| userGroupTypeCode | Enum | ユーザーグループ種類<br/>- ENTIRE: `プロジェクトメンバー全体`<br/>- INDIVIDUAL_MEMBER: `ユーザー指定` |
+| userGroupStatus | Enum | ユーザーグループの現在状態<br/>- CREATED<br/>- DELETED |
+| members | Array | プロジェクトメンバーリスト |
+| members.memberId | UUID | プロジェクトメンバーの識別子 |
+| createdYmdt | DateTime | 作成日時 |
+| updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### ユーザーグループの修正
-
-```http
-PUT /v1.0/user-groups/{userGroupId}
-```
 
 #### 必要権限
 
@@ -5050,39 +5370,46 @@ PUT /v1.0/user-groups/{userGroupId}
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| userGroupId | URL | UUID | O | ユーザーグループの識別子 |
-| userGroupName | Body | String | X | ユーザーグループを識別できる名前 |
-| memberIds | Body | Array | X | プロジェクトメンバーの識別子リスト |
-| selectAllYN | Body | Boolean | O | プロジェクトメンバー全体の有無<br/>- デフォルト値: `false` |
+```http
+"selectAllYN": false
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | Y | ユーザーグループの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "userGroupName": "userGroupName-example",
-    "memberIds": [],
-    "selectAllYN": false
+]
+{
+"header": {
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| userGroupName | String | N | ユーザーグループを識別できる名前 |
+| memberIds | Array | N | プロジェクトメンバーの識別子リスト |
+| selectAllYN | Boolean | Y | プロジェクトメンバー全体の有無<br/>- デフォルト値: `false` |
 
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
 
 ---
+
 ## 通知グループ
 
 ### 通知グループリストを表示
-
-```http
-GET /v1.0/notification-groups
-```
 
 #### 必要権限
 
@@ -5092,57 +5419,58 @@ GET /v1.0/notification-groups
 
 #### リクエスト
 
+```http
+"resultCode": 0,
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| notificationGroups | Body | Array |  |
-| notificationGroups.notificationGroupId | Body | UUID | 通知グループの識別子 |
-| notificationGroups.notificationGroupName | Body | String | 通知グループを識別できる名前 |
-| notificationGroups.notificationGroupStatus | Body | Enum | 通知グループの現在状態<br/>- CREATED: `作成済み`<br/>- DELETED: `削除済み` |
-| notificationGroups.notifyEmail | Body | Boolean | メール通知の有無 |
-| notificationGroups.notifySms | Body | Boolean | SMS通知の有無 |
-| notificationGroups.isEnabled | Body | Boolean | 有効かどうか |
-| notificationGroups.createdYmdt | Body | DateTime | 作成日時 |
-| notificationGroups.updatedYmdt | Body | DateTime | 修正日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "notificationGroups": [
-        {
-            "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
-            "notificationGroupName": "notificationGroupName-example",
-            "notificationGroupStatus": "CREATED",
-            "notifyEmail": false,
-            "notifySms": false,
-            "isEnabled": false,
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"notifyEmail": false,
+{
+"isEnabled": false,
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
+}
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| notificationGroups | Array |  |
+| notificationGroups.notificationGroupId | UUID | 通知グループの識別子 |
+| notificationGroups.notificationGroupName | String | 通知グループを識別できる名前 |
+| notificationGroups.notificationGroupStatus | Enum | 通知グループの現在状態<br/>- CREATED: `作成済み`<br/>- DELETED: `削除済み` |
+| notificationGroups.notifyEmail | Boolean | メール通知の有無 |
+| notificationGroups.notifySms | Boolean | SMS通知の有無 |
+| notificationGroups.isEnabled | Boolean | 有効かどうか |
+| notificationGroups.createdYmdt | DateTime | 作成日時 |
+| notificationGroups.updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### 通知グループの作成
-
-```http
-POST /v1.0/notification-groups
-```
 
 #### 必要権限
 
@@ -5152,76 +5480,84 @@ POST /v1.0/notification-groups
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| notificationGroupName | Body | String | O | 通知グループを識別できる名前 |
-| notifyEmail | Body | Boolean | X | メール通知の有無<br/>- デフォルト値: `true` |
-| notifySms | Body | Boolean | X | SMS通知の有無<br/>- デフォルト値: `true` |
-| isEnabled | Body | Boolean | X | 有効かどうか<br/>- デフォルト値: `true` |
-| dbInstanceIds | Body | Array | O | 監視対象のDBインスタンスの識別子リスト |
-| userGroupIds | Body | Array | O | ユーザーグループの識別子リスト |
+```http
+"notifySms": true,
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "notificationGroupName": "notificationGroupName-example",
-    "notifyEmail": true,
-    "notifySms": true,
-    "isEnabled": true,
-    "dbInstanceIds": [],
-    "userGroupIds": []
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+}
+</p>
+<p>
+{
+"header": {
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| notificationGroupName | String | Y | 通知グループを識別できる名前 |
+| notifyEmail | Boolean | N | メール通知の有無<br/>- デフォルト値: `true` |
+| notifySms | Boolean | N | SMS通知の有無<br/>- デフォルト値: `true` |
+| isEnabled | Boolean | N | 有効かどうか<br/>- デフォルト値: `true` |
+| dbInstanceIds | Array | Y | 監視対象のDBインスタンスの識別子リスト |
+| userGroupIds | Array | Y | ユーザーグループの識別子リスト |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| notificationGroupId | Body | UUID | 通知グループの識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+このAPIはリクエスト本文を要求しません。
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| notificationGroupId | UUID | 通知グループの識別子 |
 
 ---
 
-### 通知グループの削除
-
-```http
-DELETE /v1.0/notification-groups/{notificationGroupId}
-```
+### 監視設定の削除
 
 #### 必要権限
 
 | 権限名 | 説明 |
 |-----|-----|
-| RDSforPostgreSQL:NotificationGroup.Delete | 通知グループの削除 |
+| RDSforPostgreSQL:NotificationGroup.Delete | 監視設定の削除 |
 
 #### リクエスト
 
+```http
 このAPIはリクエスト本文を要求しません。
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| notificationGroupId | URL | UUID | O | 通知グループの識別子 |
+| notificationGroupId | URL | UUID | Y | 通知グループの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
@@ -5231,10 +5567,6 @@ DELETE /v1.0/notification-groups/{notificationGroupId}
 
 ### 通知グループ詳細を表示
 
-```http
-GET /v1.0/notification-groups/{notificationGroupId}
-```
-
 #### 必要権限
 
 | 権限名 | 説明 |
@@ -5243,74 +5575,77 @@ GET /v1.0/notification-groups/{notificationGroupId}
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+"resultCode": 0,
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| notificationGroupId | URL | UUID | O | 通知グループの識別子 |
+| notificationGroupId | URL | UUID | Y | 通知グループの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| notificationGroupId | Body | UUID | 通知グループの識別子 |
-| notificationGroupName | Body | String | 通知グループを識別できる名前 |
-| notificationGroupStatus | Body | Enum | 通知グループの現在状態<br/>- CREATED: `作成済み`<br/>- DELETED: `削除済み` |
-| notifyEmail | Body | Boolean | メール通知の有無 |
-| notifySms | Body | Boolean | SMS通知の有無 |
-| isEnabled | Body | Boolean | 有効かどうか |
-| dbInstances | Body | Array | 監視対象のDBインスタンスリスト |
-| dbInstances.dbInstanceId | Body | UUID | DBインスタンスの識別子 |
-| dbInstances.dbInstanceName | Body | String | DBインスタンスを識別できる名前 |
-| userGroups | Body | Array | ユーザーグループリスト |
-| userGroups.userGroupId | Body | UUID | ユーザーグループの識別子 |
-| userGroups.userGroupName | Body | String | ユーザーグループを識別できる名前 |
-| createdYmdt | Body | DateTime | 作成日時 |
-| updatedYmdt | Body | DateTime | 修正日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "notificationGroupName": "notificationGroupName-example",
-    "notificationGroupStatus": "CREATED",
-    "notifyEmail": false,
-    "notifySms": false,
-    "isEnabled": false,
-    "dbInstances": [
-        {
-            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbInstanceName": "dbInstanceName-example"
-        }
-    ],
-    "userGroups": [
-        {
-            "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
-            "userGroupName": "userGroupName-example"
-        }
-    ],
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"isEnabled": false,
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
+}
+"dbInstances": [
+{
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+{
+}
+}
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| notificationGroupId | UUID | 通知グループの識別子 |
+| notificationGroupName | String | 通知グループを識別できる名前 |
+| notificationGroupStatus | Enum | 通知グループの現在状態<br/>- CREATED: `作成済み`<br/>- DELETED: `削除済み` |
+| notifyEmail | Boolean | メール通知の有無 |
+| notifySms | Boolean | SMS通知の有無 |
+| isEnabled | Boolean | 有効かどうか |
+| dbInstances | Array | 監視対象のDBインスタンスリスト |
+| dbInstances.dbInstanceId | UUID | DBインスタンスの識別子 |
+| dbInstances.dbInstanceName | String | DBインスタンスを識別できる名前 |
+| userGroups | Array | ユーザーグループリスト |
+| userGroups.userGroupId | UUID | ユーザーグループの識別子 |
+| userGroups.userGroupName | String | ユーザーグループを識別できる名前 |
+| createdYmdt | DateTime | 作成日時 |
+| updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### 通知グループの修正
-
-```http
-PUT /v1.0/notification-groups/{notificationGroupId}
-```
 
 #### 必要権限
 
@@ -5320,32 +5655,42 @@ PUT /v1.0/notification-groups/{notificationGroupId}
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| notificationGroupId | URL | UUID | O | 通知グループの識別子 |
-| notificationGroupName | Body | String | X | 通知グループを識別できる名前 |
-| notifyEmail | Body | Boolean | X | メール通知の有無<br/>- デフォルト値: `false` |
-| notifySms | Body | Boolean | X | SMS通知の有無<br/>- デフォルト値: `false` |
-| isEnabled | Body | Boolean | X | 有効かどうか<br/>- デフォルト値: `false` |
-| dbInstanceIds | Body | Array | O | 監視対象のDBインスタンスの識別子リスト |
-| userGroupIds | Body | Array | O | ユーザーグループの識別子リスト |
+```http
+"notifySms": false,
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | Y | 通知グループの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "notificationGroupName": "notificationGroupName-example",
-    "notifyEmail": false,
-    "notifySms": false,
-    "isEnabled": false,
-    "dbInstanceIds": [],
-    "userGroupIds": []
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+}
+]
+}
+{
+"header": {
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| notificationGroupName | String | N | 通知グループを識別できる名前 |
+| notifyEmail | Boolean | N | メール通知の有無<br/>- デフォルト値: `false` |
+| notifySms | Boolean | N | SMS通知の有無<br/>- デフォルト値: `false` |
+| isEnabled | Boolean | N | 有効かどうか<br/>- デフォルト値: `false` |
+| dbInstanceIds | Array | Y | 監視対象のDBインスタンスの識別子リスト |
+| userGroupIds | Array | Y | ユーザーグループの識別子リスト |
 
 #### レスポンス
 
@@ -5355,10 +5700,6 @@ PUT /v1.0/notification-groups/{notificationGroupId}
 
 ### 監視設定リストを表示
 
-```http
-GET /v1.0/notification-groups/{notificationGroupId}/watchdogs
-```
-
 #### 必要権限
 
 | 権限名 | 説明 |
@@ -5367,57 +5708,60 @@ GET /v1.0/notification-groups/{notificationGroupId}/watchdogs
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+"resultCode": 0,
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| notificationGroupId | URL | UUID | O | 通知グループの識別子 |
+| notificationGroupId | URL | UUID | Y | 通知グループの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| notificationWatchdogs | Body | Array | 監視設定情報 |
-| notificationWatchdogs.watchdogId | Body | UUID | 監視設定の識別子 |
-| notificationWatchdogs.metricName | Body | String | 監視対象の性能指標 |
-| notificationWatchdogs.comparisonOperator | Body | Enum | 監視対象の比較方法<br/>- LE: `<=`<br/>- LT: `<`<br/>- GE: `>=`<br/>- GT: `>` |
-| notificationWatchdogs.threshold | Body | Number | 監視対象のしきい値 |
-| notificationWatchdogs.duration | Body | Number | 監視対象の持続時間 |
-| notificationWatchdogs.createdYmdt | Body | DateTime | 作成日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "notificationWatchdogs": [
-        {
-            "watchdogId": "550e8400-e29b-41d4-a716-446655440000",
-            "metricName": "metricName-example",
-            "comparisonOperator": "LE",
-            "threshold": 1,
-            "duration": 1,
-            "createdYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"threshold": 1,
+{
+"createdYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
+}
+</p>
+---
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| notificationWatchdogs | Array | 監視設定情報 |
+| notificationWatchdogs.watchdogId | UUID | 監視設定の識別子 |
+| notificationWatchdogs.metricName | String | 監視対象の性能指標 |
+| notificationWatchdogs.comparisonOperator | Enum | 監視対象の比較方法<br/>- LE: `<=`<br/>- LT: `<`<br/>- GE: `>=`<br/>- GT: `>` |
+| notificationWatchdogs.threshold | Number | 監視対象のしきい値 |
+| notificationWatchdogs.duration | Number | 監視対象の持続時間 |
+| notificationWatchdogs.createdYmdt | DateTime | 作成日時 |
 
 ---
 
 ### 監視設定の作成
-
-```http
-POST /v1.0/notification-groups/{notificationGroupId}/watchdogs
-```
 
 #### 必要権限
 
@@ -5427,74 +5771,87 @@ POST /v1.0/notification-groups/{notificationGroupId}/watchdogs
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| notificationGroupId | URL | UUID | O | 通知グループの識別子 |
-| metricName | Body | String | O | 監視対象の性能指標 |
-| comparisonOperator | Body | Enum | O | 監視対象の比較方法<br/>- LE: `<=`<br/>- LT: `<`<br/>- GE: `>=`<br/>- GT: `>` |
-| threshold | Body | Number | O | 監視対象のしきい値<br/>- 最小値: `0` |
-| duration | Body | Number | O | 監視対象の持続時間（分）<br/>- 最小値: `0` |
+```http
+"threshold": 0,
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | Y | 通知グループの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "metricName": "metricName-example",
-    "comparisonOperator": "LE",
-    "threshold": 0,
-    "duration": 0
+}
+]
+{
+"header": {
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| metricName | String | Y | 監視対象の性能指標 |
+| comparisonOperator | Enum | Y | 監視対象の比較方法<br/>- LE: `<=`<br/>- LT: `<`<br/>- GE: `>=`<br/>- GT: `>` |
+| threshold | Number | Y | 監視対象のしきい値<br/>- 最小値: `0` |
+| duration | Number | Y | 監視対象の持続時間（分）<br/>- 最小値: `0` |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| watchdogId | Body | UUID | 監視設定の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "watchdogId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+このAPIはリクエスト本文を要求しません。
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| watchdogId | UUID | 監視設定の識別子 |
 
 ---
 
-### 通知グループの削除
-
-```http
-DELETE /v1.0/notification-groups/{notificationGroupId}/watchdogs/{watchdogId}
-```
+### 監視設定の削除
 
 #### 必要権限
 
 | 権限名 | 説明 |
 |-----|-----|
-| RDSforPostgreSQL:NotificationWatchdog.Delete | 通知グループの削除 |
+| RDSforPostgreSQL:NotificationWatchdog.Delete | 監視設定の削除 |
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+<p>
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| notificationGroupId | URL | UUID | O | 通知グループの識別子 |
-| watchdogId | URL | UUID | O | 監視設定の識別子 |
+| notificationGroupId | URL | UUID | Y | 通知グループの識別子 |
+| watchdogId | URL | UUID | Y | 監視設定の識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
@@ -5504,10 +5861,6 @@ DELETE /v1.0/notification-groups/{notificationGroupId}/watchdogs/{watchdogId}
 
 ### 監視設定の修正
 
-```http
-PUT /v1.0/notification-groups/{notificationGroupId}/watchdogs/{watchdogId}
-```
-
 #### 必要権限
 
 | 権限名 | 説明 |
@@ -5516,42 +5869,49 @@ PUT /v1.0/notification-groups/{notificationGroupId}/watchdogs/{watchdogId}
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| notificationGroupId | URL | UUID | O | 通知グループの識別子 |
-| watchdogId | URL | UUID | O | 監視設定の識別子 |
-| metricName | Body | String | O | 監視対象の性能指標 |
-| comparisonOperator | Body | Enum | O | 監視対象の比較方法<br/>- LE: `<=`<br/>- LT: `<`<br/>- GE: `>=`<br/>- GT: `>` |
-| threshold | Body | Number | O | 監視対象のしきい値<br/>- 最小値: `0` |
-| duration | Body | Number | O | 監視対象の持続時間（分）<br/>- 最小値: `0` |
+```http
+"threshold": 0,
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | Y | 通知グループの識別子 |
+| watchdogId | URL | UUID | Y | 監視設定の識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "metricName": "metricName-example",
-    "comparisonOperator": "LE",
-    "threshold": 0,
-    "duration": 0
+}
+]
+{
+"header": {
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| metricName | String | Y | 監視対象の性能指標 |
+| comparisonOperator | Enum | Y | 監視対象の比較方法<br/>- LE: `<=`<br/>- LT: `<`<br/>- GE: `>=`<br/>- GT: `>` |
+| threshold | Number | Y | 監視対象のしきい値<br/>- 最小値: `0` |
+| duration | Number | Y | 監視対象の持続時間（分）<br/>- 最小値: `0` |
 
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
 
 ---
+
 ## モニタリング
 
 ### 統計情報照会
-
-```http
-GET /v1.0/metric-statistics
-```
 
 #### 必要権限
 
@@ -5560,6 +5920,12 @@ GET /v1.0/metric-statistics
 | RDSforPostgreSQL:Metric.List | 統計情報照会 |
 
 #### リクエスト
+
+```http
+このAPIはリクエスト本文を要求しません。
+```
+
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
@@ -5571,10 +5937,6 @@ GET /v1.0/metric-statistics
 
 ### 性能指標リストを表示
 
-```http
-GET /v1.0/metrics
-```
-
 #### 必要権限
 
 | 権限名 | 説明 |
@@ -5583,37 +5945,42 @@ GET /v1.0/metrics
 
 #### リクエスト
 
+```http
+"resultCode": 0,
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| metrics | Body | Array | 性能指標リスト |
-| metrics.metricName | Body | String | 性能指標タイプ |
-| metrics.unit | Body | String | 測定値単位 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "metrics": [
-        {
-            "metricName": "metricName-example",
-            "unit": "unit-example"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+]
+{
+}
+---
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| metrics | Array | 性能指標リスト |
+| metrics.metricName | String | 性能指標タイプ |
+| metrics.unit | String | 測定値単位 |
 
 ---
 
@@ -5621,22 +5988,18 @@ GET /v1.0/metrics
 
 ### イベントカテゴリー
 
-イベントはカテゴリーで分類でき、以下のとおりです。
+"header": {
 
 | イベントカテゴリー | 説明 |
 |-------------|---------|
-| ALL         | 全体 |
-| BACKUP      | バックアップ |
+| ALL | 全体 |
+| BACKUP | バックアップ |
 | DB_INSTANCE | DBインスタンス |
-| JOB         | 作業 |
-| TENANT      | テナント |
-| MONITORING  | モニタリング |
+| JOB | 作業 |
+| TENANT | テナント |
+| MONITORING | モニタリング |
 
 ### 購読可能なイベントコードリストを表示
-
-```http
-GET /v1.0/event-codes
-```
 
 #### 必要権限
 
@@ -5646,45 +6009,46 @@ GET /v1.0/event-codes
 
 #### リクエスト
 
+```http
+"resultCode": 0,
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| eventCodes | Body | Array | イベントコードリスト |
-| eventCodes.eventCode | Body | Enum | イベントコード |
-| eventCodes.eventCategoryType | Body | Enum | イベントカテゴリータイプ<br/>- ALL: `全体`<br/>- DB_INSTANCE: `DBインスタンスで発生したイベント`<br/>- DB_SECURITY_GROUP: `DBセキュリティグループで発生したイベント`<br/>- MONITORING: `モニタリングで発生したイベント`<br/>- JOB: `JOBで発生したイベント`<br/>- BACKUP: `バックアップで発生したイベント`<br/>- TENANT: `テナントで発生したイベント` |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "eventCodes": [
-        {
-            "eventCode": "ENUM_VALUE",
-            "eventCategoryType": "ALL"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+]
+{
+</p>
+---
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| eventCodes | Array | イベントコードリスト |
+| eventCodes.eventCode | Enum | イベントコード |
+| eventCodes.eventCategoryType | Enum | イベントカテゴリータイプ<br/>- ALL: `全体`<br/>- DB_INSTANCE: `DBインスタンスで発生したイベント`<br/>- DB_SECURITY_GROUP: `DBセキュリティグループで発生したイベント`<br/>- MONITORING: `モニタリングで発生したイベント`<br/>- JOB: `JOBで発生したイベント`<br/>- BACKUP: `バックアップで発生したイベント`<br/>- TENANT: `テナントで発生したイベント` |
 
 ---
 
 ### イベントリストを表示
-
-```http
-GET /v1.0/events
-```
 
 #### 必要権限
 
@@ -5694,53 +6058,58 @@ GET /v1.0/events
 
 #### リクエスト
 
+```http
+"resultCode": 0,
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | 全体のイベントリスト数 |
-| events | Body | Array | イベントリスト |
-| events.eventCategoryType | Body | Enum | イベントカテゴリータイプ<br/>- ALL: `全体`<br/>- DB_INSTANCE: `DBインスタンスで発生したイベント`<br/>- DB_SECURITY_GROUP: `DBセキュリティグループで発生したイベント`<br/>- MONITORING: `モニタリングで発生したイベント`<br/>- JOB: `JOBで発生したイベント`<br/>- BACKUP: `バックアップで発生したイベント`<br/>- TENANT: `テナントで発生したイベント` |
-| events.eventCode | Body | Enum | 発生したイベントのタイプ |
-| events.sourceId | Body | UUID | イベントソースの識別子 |
-| events.sourceName | Body | String | イベントソースを識別できる名前 |
-| events.messages | Body | Array | イベントメッセージリスト |
-| events.messages.langCode | Body | Enum | 言語コード<br/>- KO<br/>- EN<br/>- JA<br/>- ZH |
-| events.messages.message | Body | String | イベントメッセージ |
-| events.eventYmdt | Body | DateTime | イベント発生日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 1,
-    "events": [
-        {
-            "eventCategoryType": "ALL",
-            "eventCode": "ENUM_VALUE",
-            "sourceId": "550e8400-e29b-41d4-a716-446655440000",
-            "sourceName": "sourceName-example",
-            "messages": [
-                {
-                    "langCode": "KO",
-                    "message": "message-example"
-                }
-            ],
-            "eventYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"totalCounts": 1,
+"sourceName": "sourceName-example",
+{
+{
+</p>
+"message": "message-example"
+}
+],
+{
+}
+]
+}
+],
+---
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| totalCounts | Number | 全体のイベントリスト数 |
+| events | Array | イベントリスト |
+| events.eventCategoryType | Enum | イベントカテゴリータイプ<br/>- ALL: `全体`<br/>- DB_INSTANCE: `DBインスタンスで発生したイベント`<br/>- DB_SECURITY_GROUP: `DBセキュリティグループで発生したイベント`<br/>- MONITORING: `モニタリングで発生したイベント`<br/>- JOB: `JOBで発生したイベント`<br/>- BACKUP: `バックアップで発生したイベント`<br/>- TENANT: `テナントで発生したイベント` |
+| events.eventCode | Enum | 発生したイベントのタイプ |
+| events.sourceId | UUID | イベントソースの識別子 |
+| events.sourceName | String | イベントソースを識別できる名前 |
+| events.messages | Array | イベントメッセージリスト |
+| events.messages.langCode | Enum | 言語コード<br/>- KO<br/>- EN<br/>- JA<br/>- ZH |
+| events.messages.message | String | イベントメッセージ |
+| events.eventYmdt | DateTime | イベント発生日時 |
 
 ---

--- a/ja/api-guide-v1.0.md
+++ b/ja/api-guide-v1.0.md
@@ -58,19 +58,6 @@ APIリクエスト時、認証に失敗または権限がない場合、次の�
 
 ## DBバージョン
 
-| DBバージョン            | 作成可否 |
-|-------------------|----------|
-| POSTGRESQL_V14_6  |          |
-| POSTGRESQL_V14_15 |          |
-| POSTGRESQL_V14_17 | O        |
-| POSTGRESQL_V14_19 | O        |
-| POSTGRESQL_V17_2  |          |
-| POSTGRESQL_V17_4  | O        |
-| POSTGRESQL_V17_6  | O        |
-
-* ENUMタイプのdbVersionフィールドに対して該当値を使用できます。
-* バージョンによっては、作成不可能な場合や復元不可能な場合があります。
-
 ### DBバージョンリストを表示
 
 ```http
@@ -79,8 +66,8 @@ GET /v1.0/db-versions
 
 #### 必要権限
 
-| 権限名                            | 説明         |
-|---------------------------------|-------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:DbVersion.List | DBバージョンリストを表示 |
 
 #### リクエスト
@@ -89,14 +76,16 @@ GET /v1.0/db-versions
 
 #### レスポンス
 
-| 名前                          | 種類  | 形式     | 説明                   |
-|------------------------------|------|---------|-----------------------|
-| dbVersions                   | Body | Array   | DBバージョンリスト             |
-| dbVersions.dbVersion         | Body | String  | DBバージョン                |
-| dbVersions.dbVersionName     | Body | String  | DBバージョン名               |
-| dbVersions.restorableFromObs | Body | Boolean | オブジェクトストレージから復元可能かどうか |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| dbVersions | Body | Array | DBバージョン情報 |
+| dbVersions.dbVersionCode | Body | Enum | DBバージョンコード<br/>- MYSQL_V5633<br/>- MYSQL_V5715<br/>- MYSQL_V5719<br/>- MYSQL_V5726<br/>- MYSQL_V5731<br/>- MYSQL_V5733<br/>- MYSQL_V5737<br/>- MYSQL_V8018<br/>- MYSQL_V8023<br/>- MYSQL_V8028<br/>- MYSQL_V8032<br/>- MYSQL_V8033<br/>- MYSQL_V8034<br/>- MYSQL_V8035<br/>- MYSQL_V8036<br/>- MYSQL_V8040<br/>- MYSQL_V8041<br/>- MYSQL_V8042<br/>- MYSQL_V8043<br/>- MYSQL_V8044<br/>- MYSQL_V8045<br/>- MYSQL_V8405<br/>- MYSQL_V8406<br/>- MYSQL_V8407<br/>- MYSQL_V8408<br/>- MYSQL_V8409<br/>- MARIADB_V10330<br/>- MARIADB_V10611<br/>- MARIADB_V10612<br/>- MARIADB_V10616<br/>- MARIADB_V10622<br/>- MARIADB_V10625<br/>- MARIADB_V101107<br/>- MARIADB_V101108<br/>- MARIADB_V101113<br/>- MARIADB_V101116<br/>- MARIADB_V11407<br/>- MARIADB_V11410<br/>- MARIADB_V11806<br/>- POSTGRESQL_V14_6<br/>- POSTGRESQL_V14_15<br/>- POSTGRESQL_V14_17<br/>- POSTGRESQL_V14_19<br/>- POSTGRESQL_V17_2<br/>- POSTGRESQL_V17_4<br/>- POSTGRESQL_V17_6 |
+| dbVersions.dbMajorVersionCode | Body | Enum | DBメジャーバージョンコード<br/>- MYSQL_V56<br/>- MYSQL_V57<br/>- MYSQL_V80<br/>- MYSQL_V84<br/>- MARIADB_V103<br/>- MARIADB_V106<br/>- MARIADB_V1011<br/>- MARIADB_V114<br/>- MARIADB_V118<br/>- POSTGRES_V14<br/>- POSTGRES_V17 |
+| dbVersions.name | Body | String | DBバージョン名 |
+| dbVersions.canCreate | Body | Boolean | 新規作成可能かどうか |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -107,14 +96,19 @@ GET /v1.0/db-versions
     },
     "dbVersions": [
         {
-            "dbVersion": "POSTGRESQL_V17_6",
-            "dbVersionName": "PostgreSQL V17.6",
-            "restorableFromObs": true
+            "dbVersionCode": "MYSQL_V5633",
+            "dbMajorVersionCode": "MYSQL_V56",
+            "name": "PostgreSQL V14.6",
+            "canCreate": false
         }
     ]
 }
 ```
+
+</p>
 </details>
+
+---
 
 ## DBインスタンス仕様
 
@@ -126,9 +120,9 @@ GET /v1.0/db-flavors
 
 #### 必要権限
 
-| 権限名                           | 説明              |
-|--------------------------------|------------------|
-| RDSforPostgreSQL:DbFlavor.List | DBインスタンス仕様リスト表示 |
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbFlavor.List | DBインスタンス仕様リストを表示 |
 
 #### リクエスト
 
@@ -136,15 +130,16 @@ GET /v1.0/db-flavors
 
 #### レスポンス
 
-| 名前                    | 種類  | 形式    | 説明             |
-|------------------------|------|--------|-----------------|
-| dbFlavors              | Body | Array  | DBインスタンス仕様リスト  |
-| dbFlavors.dbFlavorId   | Body | UUID   | DBインスタンス仕様の識別子 |
-| dbFlavors.dbFlavorName | Body | String | DBインスタンス仕様名  |
-| dbFlavors.ram          | Body | Number | メモリ容量(MB)      |
-| dbFlavors.vcpus        | Body | Number | CPUコア数       |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| dbFlavors | Body | Array | DBインスタンス仕様情報 |
+| dbFlavors.dbFlavorId | Body | UUID | DBインスタンス仕様の識別子 |
+| dbFlavors.dbFlavorName | Body | String | DBインスタンス仕様名 |
+| dbFlavors.ram | Body | Number | メモリ容量(MB) |
+| dbFlavors.vcpus | Body | Number | CPUコア数 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -155,17 +150,73 @@ GET /v1.0/db-flavors
     },
     "dbFlavors": [
         {
-            "dbFlavorId": "50be6d9c-02d6-4594-a2d4-12010eb65ec0",
-            "dbFlavorName": "m2.c1m2",
-            "ram": 2048,
-            "vcpus": 1
+            "dbFlavorId": "289e34e9-cd8a-4baf-82e3-a3d013c5186b",
+            "dbFlavorName": "r2.c2m4",
+            "ram": 4096,
+            "vcpus": 2
         }
     ]
 }
 ```
+
+</p>
 </details>
 
+---
+
 ## プロジェクト情報
+
+### プロジェクトメンバーリストを表示
+
+```http
+GET /v1.0/project/members
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:Project.Get | プロジェクトメンバーリストを表示 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| projectMembers | Body | Array | プロジェクトメンバー情報 |
+| projectMembers.memberId | Body | UUID | プロジェクトメンバーの識別子 |
+| projectMembers.memberName | Body | String | プロジェクトメンバーの名前 |
+| projectMembers.emailAddress | Body | String | プロジェクトメンバーのメールアドレス |
+| projectMembers.phoneNumber | Body | String | プロジェクトメンバーの電話番号 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "projectMembers": [
+        {
+            "memberId": "550e8400-e29b-41d4-a716-446655440000",
+            "memberName": "memberName-example",
+            "emailAddress": "user@example.com",
+            "phoneNumber": "010-1234-5678"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
 
 ### リージョンリストを表示
 
@@ -175,9 +226,9 @@ GET /v1.0/project/regions
 
 #### 必要権限
 
-| 権限名                         | 説明        |
-|------------------------------|------------|
-| RDSforPostgreSQL:Project.Get | プロジェクト情報を照会 |
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:Project.Get | リージョンリストを表示 |
 
 #### リクエスト
 
@@ -185,13 +236,14 @@ GET /v1.0/project/regions
 
 #### レスポンス
 
-| 名前                | 種類  | 形式     | 説明                          |
-|--------------------|------|---------|------------------------------|
-| regions            | Body | Array   | リージョンリスト                       |
-| regions.regionCode | Body | Enum    | リージョンコード<br/>- `KR1`:韓国(パンギョ)リージョン |
-| regions.isEnabled  | Body | Boolean | リージョンが有効かどうか                   |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| regions | Body | Array | リージョン情報 |
+| regions.regionCode | Body | Enum | リージョンコード<br/>- KR1: `韓国(パンギョ)`<br/>- KR2: `韓国(ピョンチョン)` |
+| regions.isEnabled | Body | Boolean | リージョンが有効かどうか |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -203,59 +255,16 @@ GET /v1.0/project/regions
     "regions": [
         {
             "regionCode": "KR1",
-            "isEnabled": true
+            "isEnabled": false
         }
     ]
 }
 ```
+
+</p>
 </details>
 
-### プロジェクトメンバーリストを表示
-
-```http
-GET /v1.0/project/members
-```
-
-#### 必要権限
-
-| 権限名                         | 説明        |
-|------------------------------|------------|
-| RDSforPostgreSQL:Project.Get | プロジェクト情報照会 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-#### レスポンス
-
-| 名前                  | 種類  | 形式    | 説明             |
-|----------------------|------|--------|-----------------|
-| members              | Body | Array  | プロジェクトメンバーリスト     |
-| members.memberId     | Body | UUID   | プロジェクトメンバーの識別子   |
-| members.memberName   | Body | String | プロジェクトメンバーの名前    |
-| members.emailAddress | Body | String | プロジェクトメンバーのメールアドレス |
-| members.phoneNumber  | Body | String | プロジェクトメンバーの電話番号  |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "members": [
-        {
-            "memberId": "1b1d3627-507a-49ea-8cb7-c86dfa9caa58",
-            "memberName": "ホン・ギルドン",
-            "emailAddress": "gildong.hong@nhn.com",
-            "phoneNumber": "+821012345678"
-        }
-    ]
-}
-```
-</details>
+---
 
 ## ネットワーク
 
@@ -267,8 +276,8 @@ GET /v1.0/network/subnets
 
 #### 必要権限
 
-| 権限名                          | 説明       |
-|-------------------------------|-----------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:Network.List | サブネットリストを表示 |
 
 #### リクエスト
@@ -277,17 +286,17 @@ GET /v1.0/network/subnets
 
 #### レスポンス
 
-| 名前                      | 種類  | 形式     | 説明              |
-|--------------------------|------|---------|------------------|
-| subnets                  | Body | Array   | サブネットリスト          |
-| subnets.subnetId         | Body | UUID    | サブネットの識別子        |
-| subnets.subnetName       | Body | String  | サブネットを識別できる名前 |
-| subnets.subnetCidr       | Body | String  | サブネットのCIDR        |
-| subnets.usingGateway     | Body | Boolean | ゲートウェイ使用有無      |
-| subnets.availableIpCount | Body | Number  | 使用可能なIP数      |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| subnets | Body | Array | サブネット情報 |
+| subnets.subnetId | Body | UUID | サブネットの識別子 |
+| subnets.subnetName | Body | String | サブネットを識別できる名前 |
+| subnets.subnetCidr | Body | String | サブネットのCIDR |
+| subnets.usingGateway | Body | Boolean | ゲートウェイ使用有無 |
+| subnets.availableIpCount | Body | Number | 使用可能なIP数 |
 
-<details>
-<summary>例</summary>
+<details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -298,16 +307,20 @@ GET /v1.0/network/subnets
     },
     "subnets": [
         {
-            "subnetId": "1b2a9b23-0725-4b92-8c78-35db66b8ad9f",
-            "subnetName": "Default Network",
+            "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+            "subnetName": "subnetName-example",
             "subnetCidr": "192.168.0.0/24",
-            "usingGateway": true,
-            "availableIpCount": 240
+            "usingGateway": false,
+            "availableIpCount": 1
         }
     ]
 }
 ```
+
+</p>
 </details>
+
+---
 
 ## ストレージ
 
@@ -319,8 +332,8 @@ GET /v1.0/storage-types
 
 #### 必要権限
 
-| 権限名                          | 説明           |
-|-------------------------------|---------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:Storage.List | ストレージタイプリストを表示 |
 
 #### リクエスト
@@ -329,11 +342,12 @@ GET /v1.0/storage-types
 
 #### レスポンス
 
-| 名前          | 種類  | 形式   | 説明        |
-|--------------|------|-------|------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | storageTypes | Body | Array | ストレージタイプリスト |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -348,9 +362,30 @@ GET /v1.0/storage-types
     ]
 }
 ```
+
+</p>
 </details>
 
+---
+
 ## 作業情報
+
+### 作業状態
+
+| 状態名 | 説明 |
+|--------------------|----------------------|
+| `PREPARING` | 作業が準備中の場合 |
+| `READY` | 作業が準備完了した場合 |
+| `RUNNING` | 作業が進行中の場合 |
+| `COMPLETED` | 作業が完了した場合 |
+| `REGISTERED` | 作業が登録された場合 |
+| `WAIT_TO_REGISTER` | 作業が登録待機中の場合 |
+| `INTERRUPTED` | 作業進行中に割り込みが発生した場合 |
+| `CANCELED` | 作業がキャンセルされた場合 |
+| `FAILED` | 作業が失敗した場合 |
+| `ERROR` | 作業進行中にエラーが発生した場合 |
+| `DELETED` | 作業が削除された場合 |
+| `FAIL_TO_READY` | 作業準備に失敗した場合 |
 
 ### 作業情報の詳細を表示
 
@@ -360,31 +395,32 @@ GET /v1.0/jobs/{jobId}
 
 #### 必要権限
 
-| 権限名                     | 説明         |
-|--------------------------|-------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:Job.Get | 作業情報の詳細を表示 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前   | 種類 | 形式  | 必須 | 説明     |
-|-------|-----|------|----|---------|
-| jobId | URL | UUID | O  | 作業の識別子 |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| jobId | URL | UUID | O |  |
 
 #### レスポンス
 
-| 名前                            | 種類  | 形式      | 説明                                                                                                                                                                                                                                                                                                                                                                                                             |
-|--------------------------------|------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| jobId                          | Body | UUID     | 作業の識別子                                                                                                                                                                                                                                                                                                                                                                                                        |
-| jobStatus                      | Body | Enum     | 作業の現在状態<br/>- `PREPARING`:作業が準備中の場合<br/>- `READY`:作業が準備完了した場合<br/>- `RUNNING`:作業が進行中の場合<br/>- `COMPLETED`:作業が完了した場合<br/>- `REGISTERED`:作業が登録された場合<br/>- `WAIT_TO_REGISTER`:作業が登録待機中の場合<br/>- `INTERRUPTED`:作業進行中に割り込みが発生した場合<br/>- `CANCELED`:作業がキャンセルされた場合<br/>- `FAILED`:作業が失敗した場合<br/>- `ERROR`:作業進行中にエラーが発生した場合<br/>- `DELETED`:作業が削除された場合<br/>- `FAIL_TO_READY`:作業準備に失敗した場合 |
-| resourceRelations              | Body | Array    | 関連リソースリスト                                                                                                                                                                                                                                                                                                                                                                                                      |
-| resourceRelations.resourceType | Body | Enum     | 関連リソースタイプ<br/>- `DB_INSTANCE`: DBインスタンス<br/>- `DB_INSTANCE_GROUP`: DBインスタンスグループ<br/>- `DB_SECURITY_GROUP`: DBセキュリティグループ<br/>- `PARAMETER_GROUP`:パラメータグループ<br/>- `BACKUP`:バックアップ<br/>- `TENANT`:テナント                                                                                                                                                                                                                       |
-| resourceRelations.resourceId   | Body | UUID     | 関連リソースの識別子                                                                                                                                                                                                                                                                                                                                                                                                    |
-| createdYmdt                    | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                                                                                                                                                                                                                                               |
-| updatedYmdt                    | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                                                                                                                                                                                                                                               |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 作業の識別子 |
+| jobStatus | Body | Enum | 作業の現在状態<br/>- DELETED<br/>- CANNOT_PROGRESS<br/>- FAILED<br/>- ERROR<br/>- CANCELED<br/>- INTERRUPTED<br/>- COMPLETED<br/>- COMPLETED_WITH_ERROR<br/>- RUNNING<br/>- PREPARING<br/>- READY<br/>- CREATED<br/>- FAIL_TO_READY<br/>- REGISTERED<br/>- FAIL_TO_REGISTER<br/>- WAIT_TO_REGISTER |
+| resourceRelations | Body | Array | 関連リソースリスト |
+| resourceRelations.resourceType | Body | String | 関連リソースタイプ |
+| resourceRelations.resourceId | Body | String | 関連リソースの識別子 |
+| createdYmdt | Body | DateTime | 作成日時 |
+| updatedYmdt | Body | DateTime | 修正日時 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -393,20 +429,23 @@ GET /v1.0/jobs/{jobId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c",
-    "jobStatus": "RUNNING",
+    "jobId": "550e8400-e29b-41d4-a716-446655440000",
+    "jobStatus": "DELETED",
     "resourceRelations": [
         {
-            "resourceType": "DB_INSTANCE",
-            "resourceId": "56b39dcf-65eb-47ec-9d4f-09f160ba2266"
+            "resourceType": "resourceType-example",
+            "resourceId": "resourceId-example"
         }
     ],
-    "createdYmdt": "2023-02-22T20:47:12+09:00",
-    "updatedYmdt": "2023-02-22T20:49:46+09:00"
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
+
+</p>
 </details>
 
+---
 ## DBインスタンスグループ
 
 ### DBインスタンスグループリストを表示
@@ -417,8 +456,8 @@ GET /v1.0/db-instance-groups
 
 #### 必要権限
 
-| 権限名                                  | 説明              |
-|---------------------------------------|------------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:DbInstanceGroup.List | DBインスタンスグループリストを表示 |
 
 #### リクエスト
@@ -427,16 +466,17 @@ GET /v1.0/db-instance-groups
 
 #### レスポンス
 
-| 名前                                    | 種類  | 形式      | 説明                                                         |
-|----------------------------------------|------|----------|-------------------------------------------------------------|
-| dbInstanceGroups                       | Body | Array    | DBインスタンスグループリスト                                              |
-| dbInstanceGroups.dbInstanceGroupId     | Body | UUID     | DBインスタンスグループの識別子                                            |
-| dbInstanceGroups.dbInstanceGroupStatus | Body | Enum     | DBインスタンスグループの現在状態<br/>- `CREATED`:作成済み<br/>- `DELETED`:削除済み |
-| dbInstanceGroups.replicationType       | Body | Enum     | DBインスタンスグループのレプリケーションタイプ<br/>- `STANDALONE`:単一                    |
-| dbInstanceGroups.createdYmdt           | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                           |
-| dbInstanceGroups.updatedYmdt           | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                           |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceGroups | Body | Array | DBインスタンスグループ情報 |
+| dbInstanceGroups.dbInstanceGroupId | Body | UUID | DBインスタンスグループの識別子 |
+| dbInstanceGroups.dbInstanceGroupStatus | Body | Enum | DBインスタンスグループの現在状態<br/>- CREATED: `作成済み`<br/>- DELETED: `削除済み` |
+| dbInstanceGroups.replicationType | Body | Enum | DBインスタンスグループのレプリケーションタイプ<br/>- STANDALONE: `高可用性を使用しない`<br/>- HIGH_AVAILABILITY: `高可用性を使用する` |
+| dbInstanceGroups.createdYmdt | Body | DateTime | 作成日時 |
+| dbInstanceGroups.updatedYmdt | Body | DateTime | 修正日時 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -447,17 +487,20 @@ GET /v1.0/db-instance-groups
     },
     "dbInstanceGroups": [
         {
-            "dbInstanceGroupId": "05de0746-89fd-49c8-94f9-9c5b1df97009",
+            "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
             "dbInstanceGroupStatus": "CREATED",
             "replicationType": "STANDALONE",
-            "createdYmdt": "2023-02-13T17:35:20+09:00",
-            "updatedYmdt": "2023-02-13T17:35:20+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
+
+</p>
 </details>
 
+---
 
 ### DBインスタンスグループ詳細を表示
 
@@ -467,33 +510,34 @@ GET /v1.0/db-instance-groups/{dbInstanceGroupId}
 
 #### 必要権限
 
-| 権限名                                 | 説明              |
-|--------------------------------------|------------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:DbInstanceGroup.Get | DBインスタンスグループ詳細を表示 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前               | 種類 | 形式  | 必須 | 説明             |
-|-------------------|-----|------|----|-----------------|
-| dbInstanceGroupId | URL | UUID | O  | DBインスタンスグループの識別子 |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | O |  |
 
 #### レスポンス
 
-| 名前                          | 種類  | 形式      | 説明                                                                                                                                   |
-|------------------------------|------|----------|---------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceGroupId            | Body | UUID     | DBインスタンスグループの識別子                                                                                                                      |
-| dbInstanceGroupStatus        | Body | Enum     | DBインスタンスグループの現在状態<br/>- `CREATED`:作成済み<br/>- `DELETED`:削除済み                                                                          |
-| replicationType              | Body | Enum     | DBインスタンスグループのレプリケーションタイプ<br/>- `STANDALONE`:単一<br/>- `HIGH_AVAILABILITY`:高可用性                                                             |
-| dbInstances                  | Body | Array    | DBインスタンスグループに属するDBインスタンスリスト                                                                                                            |
-| dbInstances.dbInstanceId     | Body | UUID     | DBインスタンスの識別子                                                                                                                         |
-| dbInstances.dbInstanceType   | Body | Enum     | DBインスタンスのロールタイプ<br/>- `MASTER`:マスター<br/>- `FAILED_MASTER`:フェイルオーバーされたマスター<br/>- `CANDIDATE_MASTER`:予備マスター<br/>- `READ_ONLY_SLAVE`:リードレプリカ |
-| dbInstances.dbInstanceStatus | Body | Enum     | DBインスタンスの現在状態                                                                                                                       |
-| createdYmdt                  | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-| updatedYmdt                  | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceGroupId | Body | UUID | DBインスタンスグループの識別子 |
+| dbInstanceGroupStatus | Body | Enum | DBインスタンスグループの現在状態<br/>- CREATED: `作成済み`<br/>- DELETED: `削除済み` |
+| replicationType | Body | Enum | DBインスタンスグループのレプリケーションタイプ<br/>- STANDALONE: `高可用性を使用しない`<br/>- HIGH_AVAILABILITY: `高可用性を使用する` |
+| dbInstances | Body | Array | DBインスタンスグループに属するDBインスタンスリスト |
+| dbInstances.dbInstanceId | Body | UUID | DBインスタンスの識別子 |
+| dbInstances.dbInstanceType | Body | Enum | DBインスタンスのロールタイプ<br/>- MASTER: `マスター`<br/>- FAILED_MASTER: `フェイルオーバーされたマスター`<br/>- CANDIDATE_MASTER: `予備マスター`<br/>- READ_ONLY_SLAVE: `リードレプリカ` |
+| dbInstances.dbInstanceStatus | Body | Enum | DBインスタンスの現在状態<br/>- BEFORE_CREATE: `作成前(グレー)`<br/>- AVAILABLE: `使用可能(緑)`<br/>- STORAGE_FULL: `容量不足(赤)`<br/>- FAIL_TO_CREATE: `作成失敗(赤)`<br/>- FAIL_TO_CONNECT: `接続失敗(赤)`<br/>- REPLICATION_STOP: `複製中断(赤)`<br/>- REPLICATION_DELAY: `複製遅延(黄)`<br/>- FAILOVER: `フェイルオーバー完了(赤)`<br/>- SHUTDOWN: `停止済み(グレー)`<br/>- DELETED: `削除済み(グレー)` |
+| createdYmdt | Body | DateTime | 作成日時 |
+| updatedYmdt | Body | DateTime | 修正日時 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -502,25 +546,27 @@ GET /v1.0/db-instance-groups/{dbInstanceGroupId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "dbInstanceGroupId": "36617a8e-0df8-4b16-b6ea-6306019e95da",
+    "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
     "dbInstanceGroupStatus": "CREATED",
     "replicationType": "STANDALONE",
     "dbInstances": [
         {
-            "dbInstanceId": "6d2db0ef-fe9b-4ed4-97b1-d97fcb4cf1b8",
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
             "dbInstanceType": "MASTER",
-            "dbInstanceStatus": "AVAILABLE"
+            "dbInstanceStatus": "BEFORE_CREATE"
         }
     ],
-    "createdYmdt": "2023-03-03T17:38:14+09:00",
-    "updatedYmdt": "2023-03-03T17:38:14+09:00"
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
+
+</p>
 </details>
 
-## DBインスタンスグループ > 拡張機能管理
+---
 
-### 拡張機能リスト表示
+### 拡張機能リスト照会
 
 ```http
 GET /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions
@@ -528,36 +574,37 @@ GET /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions
 
 #### 必要権限
 
-| 権限名                                          | 説明     |
-|------------------------------------------------|----------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:DbInstanceGroupExtension.List | 拡張機能リスト照会 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前              | 種類 | 形式 | 必須 | 説明            |
-|-------------------|-----|------|----|-----------------|
-| dbInstanceGroupId | URL | UUID | O  | DBインスタンスグループの識別子 |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | O | DBインスタンスグループID |
 
 #### レスポンス
 
-| 名前                                                | 種類 | 形式    | 説明                                                                                                                                                                                            |
-|-----------------------------------------------------|------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| extensions                                          | Body | Array   | 拡張機能リスト                                                                                                                                                                                         |
-| extensions.extensionId                              | Body | UUID    | 拡張機能の識別子                                                                                                                                                                                       |
-| extensions.extensionName                            | Body | String  | 拡張機能名                                                                                                                                                                                         |
-| extensions.extensionStatus                          | Body | ENUM    | 拡張機能の状態<br/>- `AVAILABLE`:使用可能<br/>- `NEED_TO_APPLY`:適用必要<br/>- `APPLYING`:適用中                                                                                                             |
-| extensions.databases                                | Body | Array   | 拡張機能がインストールされたデータベース情報                                                                                                                                                                             |
-| extensions.databases.dbInstanceGroupExtensionId     | Body | UUID    | DBインスタンスグループ内の拡張機能の識別子                                                                                                                                                                          |
-| extensions.databases.dbInstanceGroupExtensionStatus | Body | ENUM    | DBインスタンスグループ内の拡張機能の状態<br/>- `CREATED`:作成済み<br/>- `INSTALLED`:インストール済み<br/>- `INSTALLING`:インストール中<br/>- `INSTALL_ERROR`:インストールエラー<br/>- `DELETED`:削除済み<br/>- `DELETING`:削除中<br/>- `DELETE_ERROR`:削除エラー |
-| extensions.databases.databaseId                     | Body | UUID    | データベースの識別子                                                                                                                                                                                   |
-| extensions.databases.databaseName                   | Body | String  | データベース名                                                                                                                                                                                     |
-| extensions.databases.reservedAction                 | Body | ENUM    | 予約タスク<br/>- `NONE`:なし<br/>- `INSTALL`:インストール予約(適用必要)<br/>- `INSTALL_WITH_CASCADE`:強制インストール予約(適用必要)<br/>- `DELETE`:削除予約(適用必要)<br/>- `DELETE_WITH_CASCADE`:強制削除予約(適用必要)                |
-| extensions.databases.errorReason                    | Body | String  | エラー原因                                                                                                                                                                                         |
-| isNeedToApply                                       | Body | Boolean | 変更事項の適用が必要かどうか                                                                                                                                                                                |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| extensions | Body | Array | 拡張機能情報 |
+| extensions.extensionId | Body | UUID | 拡張機能の識別子 |
+| extensions.extensionName | Body | String | 拡張機能名 |
+| extensions.extensionStatus | Body | Enum | 拡張機能の状態<br/>- AVAILABLE: `使用可能`<br/>- NEED_TO_APPLY: `適用必要`<br/>- APPLYING: `適用中` |
+| extensions.databases | Body | Array | データベース情報 |
+| extensions.databases.dbInstanceGroupExtensionId | Body | UUID | DBインスタンスグループ内の拡張機能の識別子 |
+| extensions.databases.databaseId | Body | UUID | データベースの識別子 |
+| extensions.databases.databaseName | Body | String | データベース名 |
+| extensions.databases.dbInstanceGroupExtensionStatus | Body | Enum | データベースへの拡張機能インストール状態<br/>- CREATED: `作成済み`<br/>- INSTALLED: `インストール済み`<br/>- INSTALLING: `インストール中`<br/>- INSTALL_ERROR: `インストールエラー`<br/>- DELETED: `削除済み`<br/>- DELETING: `削除中`<br/>- DELETE_ERROR: `削除エラー` |
+| extensions.databases.reservedAction | Body | Enum | 予約タスク<br/>- NONE: `なし`<br/>- INSTALL: `インストール予約(適用必要)`<br/>- INSTALL_WITH_CASCADE: `強制インストール予約(適用必要)`<br/>- DELETE: `削除予約(適用必要)`<br/>- DELETE_WITH_CASCADE: `強制削除予約(適用必要)` |
+| extensions.databases.errorReason | Body | String | エラー原因 |
+| isNeedToApply | Body | Boolean | 変更事項の適用が必要かどうか |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -568,108 +615,29 @@ GET /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions
     },
     "extensions": [
         {
-            "extensionId": "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4",
-            "extensionName": "address_standardizer",
+            "extensionId": "550e8400-e29b-41d4-a716-446655440000",
+            "extensionName": "extensionName-example",
             "extensionStatus": "AVAILABLE",
             "databases": [
                 {
-                    "dbInstanceGroupExtensionId": "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4",
-                    "databaseId": "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4",
-                    "databaseName": "database-1",
-                    "dbInstanceGroupExtensionStatus": "INSTALLED",
+                    "dbInstanceGroupExtensionId": "550e8400-e29b-41d4-a716-446655440000",
+                    "databaseId": "550e8400-e29b-41d4-a716-446655440000",
+                    "databaseName": "databaseName-example",
+                    "dbInstanceGroupExtensionStatus": "CREATED",
                     "reservedAction": "NONE",
-                    "errorReason": null
+                    "errorReason": "errorReason-example"
                 }
             ]
         }
     ],
-    "isNeedToApply": true
+    "isNeedToApply": false
 }
 ```
+
+</p>
 </details>
 
-
-### 拡張機能のインストール
-
-```http
-POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{extensionId}
-```
-
-#### 必要権限
-
-| 権限名                                             | 説明  |
-|---------------------------------------------------|-------|
-| RDSforPostgreSQL:DbInstanceGroupExtension.Install | 拡張機能のインストール |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前              | 種類 | 形式    | 必須 | 説明              |
-|-------------------|------|---------|----|-------------------|
-| dbInstanceGroupId | URL  | UUID    | O  | DBインスタンスグループの識別子 |
-| extensionId       | URL  | UUID    | O  | 拡張機能の識別子         |
-| databaseId        | Body | UUID    | O  | インストール対象データベースの識別子 |
-| schemaName        | Body | String  | O  | インストール対象スキーマ名    |
-| withCascade       | Body | Boolean | X  | 依存情報を強制的にインストールするかどうか   |
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
-
-<details><summary>例</summary>
-
-```json
-{
-  "header": {
-    "resultCode": 0,
-    "resultMessage": "SUCCESS",
-    "isSuccessful": true
-  }
-}
-```
-</details>
-
-
-### 拡張機能の削除(キャンセル)
-
-```http
-DELETE /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{dbInstanceGroupExtensionId}
-```
-
-#### 必要権限
-
-| 権限名                                            | 説明      |
-|--------------------------------------------------|-----------|
-| RDSforPostgreSQL:DbInstanceGroupExtension.Delete | 拡張機能の削除(キャンセル) |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前                       | 種類  | 形式    | 必須 | 説明                 |
-|----------------------------|-------|---------|----|----------------------|
-| dbInstanceGroupId          | URL   | UUID    | O  | DBインスタンスグループの識別子    |
-| dbInstanceGroupExtensionId | URL   | UUID    | O  | DBインスタンスグループ内の拡張機能の識別子 |
-| withCascade                | Query | Boolean | O  | 依存情報を強制的に削除するかどうか      |
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
-
-<details><summary>例</summary>
-
-```json
-{
-  "header": {
-    "resultCode": 0,
-    "resultMessage": "SUCCESS",
-    "isSuccessful": true
-  }
-}
-```
-</details>
-
+---
 
 ### 拡張機能変更事項適用
 
@@ -679,38 +647,42 @@ POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/apply
 
 #### 必要権限
 
-| 権限名                                           | 説明       |
-|-------------------------------------------------|------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:DbInstanceGroupExtension.Apply | 拡張機能変更事項適用 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前                       | 種類  | 形式    | 必須 | 説明                 |
-|----------------------------|-------|---------|----|----------------------|
-| dbInstanceGroupId          | URL   | UUID    | O  | DBインスタンスグループの識別子    |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | O | DBインスタンスグループID |
 
 #### レスポンス
 
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | リクエストした作業の識別子 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
-  "header": {
-    "resultCode": 0,
-    "resultMessage": "SUCCESS",
-    "isSuccessful": true
-  },
-  "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
+---
 
 ### 拡張機能の同期
 
@@ -720,93 +692,158 @@ POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/sync
 
 #### 必要権限
 
-| 権限名                                          | 説明   |
-|------------------------------------------------|--------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:DbInstanceGroupExtension.Sync | 拡張機能の同期 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前                       | 種類  | 形式    | 必須 | 説明                 |
-|----------------------------|-------|---------|----|----------------------|
-| dbInstanceGroupId          | URL   | UUID    | O  | DBインスタンスグループの識別子    |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | O | DBインスタンスグループID |
 
 #### レスポンス
 
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | リクエストした作業の識別子 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
-  "header": {
-    "resultCode": 0,
-    "resultMessage": "SUCCESS",
-    "isSuccessful": true
-  },
-  "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
+---
 
+### 拡張機能の削除(キャンセル)
+
+```http
+DELETE /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{dbInstanceGroupExtensionId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceGroupExtension.Delete | 拡張機能の削除(キャンセル) |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | O | DBインスタンスグループID |
+| dbInstanceGroupExtensionId | URL | UUID | O | DBインスタンスグループ内の拡張機能の識別子 |
+| withCascade | Query | Boolean | O | 強制削除するかどうか |
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
+
+### 拡張機能のインストール
+
+```http
+POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{extensionId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceGroupExtension.Install | 拡張機能のインストール |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | O | DBインスタンスグループID |
+| extensionId | URL | UUID | O | 拡張機能の識別子 |
+| databaseId | Body | UUID | O | データベースの識別子 |
+| schemaName | Body | String | O | スキーマ名 |
+| withCascade | Body | Boolean | X | 関連情報を自動的にインストールするかどうか<br/>- デフォルト値: `false` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "databaseId": "550e8400-e29b-41d4-a716-446655440000",
+    "schemaName": "schemaName-example",
+    "withCascade": false
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
 ## DBインスタンス
 
 ### DBインスタンスの状態
 
-| 状態                 | 説明                         |
-|---------------------|-----------------------------|
-| `AVAILABLE`         | DBインスタンスが使用可能な場合         |
-| `BEFORE_CREATE`     | DBインスタンス作成前の場合           |
-| `STORAGE_FULL`      | DBインスタンスの容量が不足している場合        |
-| `FAIL_TO_CREATE`    | DBインスタンス作成に失敗した場合         |
-| `FAIL_TO_CONNECT`   | DBインスタンス接続に失敗した場合         |
-| `REPLICATION_STOP`  | DBインスタンスの複製が中断された場合        |
-| `REPLICATION_DELAY` | DBインスタンスの複製が遅延している場合      |
-| `FAILOVER`          | 高可用性DBインスタンスのフェイルオーバーが完了した場合 |
-| `SHUTDOWN`          | DBインスタンスが中止された場合            |
-| `DELETED`           | DBインスタンスが削除された場合            |
+| 状態                  | 説明                           |
+|---------------------|------------------------------|
+| `AVAILABLE`         | DBインスタンスが使用可能な場合           |
+| `BEFORE_CREATE`     | DBインスタンス作成前の場合            |
+| `STORAGE_FULL`      | DBインスタンスの容量が不足している場合          |
+| `FAIL_TO_CREATE`    | DBインスタンス作成に失敗した場合           |
+| `FAIL_TO_CONNECT`   | DBインスタンス接続に失敗した場合           |
+| `REPLICATION_STOP`  | DBインスタンスの複製が中断された場合          |
+| `FAILOVER`          | 高可用性DBインスタンスのフェイルオーバーが完了した場合      |
+| `SHUTDOWN`          | DBインスタンスが中止された場合              |
+| `DELETED`           | DBインスタンスが削除された場合              |
 
 ### DBインスタンスの進行状態
 
-| 状態                             | 説明            |
-|---------------------------------|----------------|
-| `APPLYING_DB_INSTANCE_HBA_RULE` | アクセス制御ルール適用中 |
-| `APPLYING_PARAMETER_GROUP`      | パラメータグループ適用中  |
-| `APPLYING_EXTENSION`            | 拡張機能の適用中      |
-| `BACKING_UP`                    | バックアップ中          |
-| `CANCELING`                     | キャンセル中          |
-| `CREATING`                      | 作成中          |
-| `CREATING_DATABASE`             | データベース作成中	   |
-| `CREATING_USER`                 | ユーザー作成中	      |
-| `DELETING`                      | 削除中          |
-| `DELETING_DATABASE`             | データベース削除中   |
-| `DELETING_USER`                 | ユーザー削除中      |
-| `EXPORTING_BACKUP`              | バックアップをエクスポート中    |
-| `FAILING_OVER`                  | フェイルオーバー中       |
-| `MIGRATING`                     | マイグレーション中      |
-| `MODIFYING`                     | 修正中          |
-| `OCCUPIED`                      | 占有中           |
-| `PREPARING`                     | 準備中          |
-| `PROMOTING`                     | 昇格中          |
-| `PROMOTING_FORCIBLY`            | 強制昇格中       |
-| `REBUILDING`                    | 再構築中         |
-| `REPAIRING`                     | 復旧中          |
-| `REPLICATING`                   | 複製中          |
-| `RESTARTING`                    | 再起動中         |
-| `RESTARTING_FORCIBLY`           | 強制再起動中      |
-| `RESTORING`                     | 復元中          |
-| `STARTING`                      | 起動中          |
-| `STOPPING`                      | 停止中          |
-| `SYNCING_DATABASE`              | データベース同期中  |
-| `SYNCING_USER`                  | ユーザー同期中	     |
-| `SYNCING_EXTENSION`             | 拡張機能の同期中	      |
-| `UPDATING_USER`                 | ユーザー修正中	      |
-| `UPDATING_DATABASE`             | データベース修正中	   |
-| `WAIT_MANUAL_CONTROL`           | 手動フェイルオーバー待機中	 |
+| 状態                         | 説明           |
+|----------------------------|--------------|
+| `APPLYING_PARAMETER_GROUP` | パラメータグループ適用中 |
+| `BACKING_UP`               | バックアップ中         |
+| `CANCELING`                | キャンセル中         |
+| `CREATING`                 | 作成中         |
+| `CREATING_SCHEMA`          | スキーマ作成中  |
+| `CREATING_USER`            | ユーザー作成中     |
+| `DELETING`                 | 削除中         |
+| `DELETING_SCHEMA`          | スキーマ削除中  |
+| `DELETING_USER`            | ユーザー削除中     |
+| `EXPORTING_BACKUP`         | バックアップをエクスポート中   |
+| `FAILING_OVER`             | フェイルオーバー中      |
+| `MIGRATING`                | マイグレーション中         |
+| `MODIFYING`                | 修正中         |
+| `PREPARING`                | 準備中         |
+| `PROMOTING`                | 昇格中         |
+| `REBUILDING`               | 再構築中        |
+| `REPAIRING`                | 復旧中         |
+| `REPLICATING`              | 複製中         |
+| `RESTARTING`               | 再起動中         |
+| `RESTARTING_FORCIBLY`      | 強制再起動中     |
+| `RESTORING`                | 復元中         |
+| `STARTING`                 | 起動中         |
+| `STOPPING`                 | 停止中         |
+| `SYNCING_SCHEMA`           | スキーマ同期中 |
+| `SYNCING_USER`             | ユーザー同期中    |
+| `UPDATING_USER`            | ユーザー修正中     |
 
 ### DBインスタンスリストを表示
 
@@ -816,8 +853,8 @@ GET /v1.0/db-instances
 
 #### 必要権限
 
-| 権限名                             | 説明           |
-|----------------------------------|---------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:DbInstance.List | DBインスタンスリストを表示 |
 
 #### リクエスト
@@ -826,22 +863,23 @@ GET /v1.0/db-instances
 
 #### レスポンス
 
-| 名前                           | 種類  | 形式      | 説明                                                                                                                                   |
-|-------------------------------|------|----------|---------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstances                   | Body | Array    | DBインスタンスリスト                                                                                                                           |
-| dbInstances.dbInstanceId      | Body | UUID     | DBインスタンスの識別子                                                                                                                         |
-| dbInstances.dbInstanceGroupId | Body | UUID     | DBインスタンスグループの識別子                                                                                                                      |
-| dbInstances.dbInstanceName    | Body | String   | DBインスタンスを識別できる名前                                                                                                                 |
-| dbInstances.description       | Body | String   | DBインスタンスの追加情報                                                                                                                    |
-| dbInstances.dbVersion         | Body | Enum     | DBバージョン情報                                                                                                                             |
-| dbInstances.dbPort            | Body | Number   | DBポート                                                                                                                                |
-| dbInstances.dbInstanceType    | Body | Enum     | DBインスタンスのロールタイプ<br/>- `MASTER`:マスター<br/>- `FAILED_MASTER`:フェイルオーバーされたマスター<br/>- `CANDIDATE_MASTER`:予備マスター<br/>- `READ_ONLY_SLAVE`:リードレプリカ |
-| dbInstances.dbInstanceStatus  | Body | Enum     | DBインスタンスの現在状態                                                                                                                       |
-| dbInstances.progressStatus    | Body | Enum     | DBインスタンスの現在進行状態                                                                                                                    |
-| dbInstances.createdYmdt       | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-| dbInstances.updatedYmdt       | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| dbInstances | Body | Array | DBインスタンスリスト |
+| dbInstances.dbInstanceId | Body | UUID | DBインスタンスの識別子 |
+| dbInstances.dbInstanceGroupId | Body | UUID | DBインスタンスグループの識別子 |
+| dbInstances.dbInstanceName | Body | String | DBインスタンスを識別できる名前 |
+| dbInstances.description | Body | String | DBインスタンスの追加情報 |
+| dbInstances.dbVersion | Body | Enum | DBバージョン情報 |
+| dbInstances.dbPort | Body | Number | DBポート |
+| dbInstances.dbInstanceType | Body | Enum | DBインスタンスのロールタイプ<br/>- MASTER: `マスター`<br/>- FAILED_MASTER: `フェイルオーバーされたマスター`<br/>- CANDIDATE_MASTER: `予備マスター`<br/>- READ_ONLY_SLAVE: `リードレプリカ` |
+| dbInstances.dbInstanceStatus | Body | Enum | DBインスタンスの現在状態<br/>- BEFORE_CREATE: `作成前(グレー)`<br/>- AVAILABLE: `使用可能(グリーン)`<br/>- STORAGE_FULL: `容量不足(レッド)`<br/>- FAIL_TO_CREATE: `作成失敗(レッド)`<br/>- FAIL_TO_CONNECT: `接続失敗(レッド)`<br/>- REPLICATION_STOP: `複製中断(レッド)`<br/>- REPLICATION_DELAY: `複製遅延(イエロー)`<br/>- FAILOVER: `フェイルオーバー完了(レッド)`<br/>- SHUTDOWN: `停止済み(グレー)`<br/>- DELETED: `削除済み(グレー)` |
+| dbInstances.progressStatus | Body | String | DBインスタンスの現在進行状態 |
+| dbInstances.createdYmdt | Body | DateTime | 作成日時 |
+| dbInstances.updatedYmdt | Body | DateTime | 修正日時 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -852,98 +890,26 @@ GET /v1.0/db-instances
     },
     "dbInstances": [
         {
-            "dbInstanceId": "d067593b-1acc-4ccc-9e8a-cc72d6d79ec3",
-            "dbInstanceGroupId": "51c7d080-ff36-4025-84b1-9d9d0b4fe9e0",
-            "dbInstanceName": "db-instance",
-            "description": null,
-            "dbVersion": "POSTGRESQL_V17_6",
-            "dbPort": 15432,
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbInstanceName": "dbInstanceName-example",
+            "description": "description-example",
+            "dbVersion": "POSTGRESQL_V14_17",
+            "dbPort": 1,
             "dbInstanceType": "MASTER",
-            "dbInstanceStatus": "AVAILABLE",
-            "progressStatus": "NONE",
-            "createdYmdt": "2023-01-23T12:03:13+09:00",
-            "updatedYmdt": "2023-02-02T17:20:17+09:00"
+            "dbInstanceStatus": "BEFORE_CREATE",
+            "progressStatus": "progressStatus-example",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
+
+</p>
 </details>
 
-
-### DBインスタンス詳細を表示
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}
-```
-
-#### 必要権限
-
-| 権限名                            | 説明           |
-|---------------------------------|---------------|
-| RDSforPostgreSQL:DbInstance.Get | DBインスタンス詳細を表示 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前          | 種類 | 形式  | 必須 | 説明          |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前                       | 種類  | 形式      | 説明                                                                                                                                   |
-|---------------------------|------|----------|---------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId              | Body | UUID     | DBインスタンスの識別子                                                                                                                         |
-| dbInstanceGroupId         | Body | UUID     | DBインスタンスグループの識別子                                                                                                                      |
-| dbInstanceName            | Body | String   | DBインスタンスを識別できる名前                                                                                                                 |
-| description               | Body | String   | DBインスタンスの追加情報                                                                                                                    |
-| dbVersion                 | Body | Enum     | DBバージョン情報                                                                                                                             |
-| dbPort                    | Body | Number   | DBポート                                                                                                                                |
-| dbInstanceType            | Body | Enum     | DBインスタンスのロールタイプ<br/>- `MASTER`:マスター<br/>- `FAILED_MASTER`:フェイルオーバーされたマスター<br/>- `CANDIDATE_MASTER`:予備マスター<br/>- `READ_ONLY_SLAVE`:リードレプリカ |
-| dbInstanceStatus          | Body | Enum     | DBインスタンスの現在状態                                                                                                                       |
-| progressStatus            | Body | Enum     | DBインスタンスの現在の作業進行状態                                                                                                                 |
-| dbFlavorId                | Body | UUID     | DBインスタンス仕様の識別子                                                                                                                      |
-| parameterGroupId          | Body | UUID     | DBインスタンスに適用されたパラメータグループの識別子                                                                                                            |
-| dbSecurityGroupIds        | Body | Array    | DBインスタンスに適用されたDBセキュリティグループの識別子リスト                                                                                                        |
-| notificationGroupIds      | Body | Array    | DBインスタンスに適用された通知グループの識別子リスト                                                                                                           |
-| useDeletionProtection     | Body | Boolean  | DBインスタンス削除保護の有無                                                                                                                      |
-| needToApplyParameterGroup | Body | Boolean  | 最新パラメータグループの適用可否                                                                                                                   |
-| needMigration             | Body | Boolean  | マイグレーションの要否                                                                                                                          |
-| osVersion                 | Body | String   | OSバージョン                                                                                                                              |
-| createdYmdt               | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-| updatedYmdt               | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceId": "d067593b-1acc-4ccc-9e8a-cc72d6d79ec3",
-    "dbInstanceGroupId": "51c7d080-ff36-4025-84b1-9d9d0b4fe9e0",
-    "dbInstanceName": "db-instance",
-    "description": null,
-    "dbVersion": "POSTGRESQL_V17_6",
-    "dbPort": 15432,
-    "dbInstanceType": "MASTER",
-    "dbInstanceStatus": "AVAILABLE",
-    "progressStatus": "NONE",
-    "dbFlavorId": "e9ed4ef6-78d7-46fa-ace9-32481e97f3b7",
-    "parameterGroupId": "b03e8b13-de27-4d04-a488-ff5689589372",
-    "dbSecurityGroupIds": ["01908c35-d2c9-4852-baf0-17f06ec42c03"],
-    "notificationGroupIds": ["83a62a33-ddbf-4a04-8653-e54463d5b1ac"],
-    "useDeletionProtection": false,
-    "needToApplyParameterGroup": false,
-    "needMigration": false,
-    "createdYmdt": "2022-11-23T12:03:13+09:00",
-    "updatedYmdt": "2022-12-02T17:20:17+09:00"
-}
-```
-</details>
+---
 
 ### DBインスタンスを作成する
 
@@ -953,62 +919,70 @@ POST /v1.0/db-instances
 
 #### 必要権限
 
-| 権限名                               | 説明          |
-|------------------------------------|--------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:DbInstance.Create | DBインスタンスを作成する |
 
 #### リクエスト
 
-| 名前                                      | 種類  | 形式     | 必須 | 説明                                                                                                                                                                                                                  |
-|------------------------------------------|------|---------|----|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceName                           | Body | String  | O  | DBインスタンスを識別できる名前                                                                                                                                                                                                |
-| description                              | Body | String  | X  | DBインスタンスの追加情報                                                                                                                                                                                                   |
-| dbFlavorId                               | Body | UUID    | O  | DBインスタンス仕様の識別子                                                                                                                                                                                                     |
-| dbVersion                                | Body | Enum    | O  | DBバージョン情報                                                                                                                                                                                                            |
-| dbPort                                   | Body | Number  | O  | DBポート<br/>- 最小値:`5432`<br/>- 最大値:`45432`                                                                                                                                                                           |
-| databaseName                             | Body | String  | O  | DBエンジン内で新規作成するデータベース名                                                                                                                                                                                              |
-| dbUserName                               | Body | String  | O  | DBエンジン内で新規作成するユーザーアカウント名                                                                                                                                                                                              |
-| dbPassword                               | Body | String  | O  | DBエンジン内で新規作成するユーザーアカウントのパスワード<br/>- 最小文字数:`4`<br/>- 最大文字数:`16`                                                                                                                                                          |
-| parameterGroupId                         | Body | UUID    | O  | パラメータグループの識別子                                                                                                                                                                                                        |
-| dbSecurityGroupIds                       | Body | Array   | X  | DBセキュリティグループの識別子リスト                                                                                                                                                                                                    |
-| useDeletionProtection                    | Body | Boolean | X  | 削除保護の有無<br/>- デフォルト値:`false`                                                                                                                                                                                          |
-| useDefaultNotification                   | Body | Boolean | X  | 基本通知の使用有無<br/>- デフォルト値:`false`                                                                                                                                                                                       |
-| useHighAvailability                      | Body | Boolean | X  | 高可用性の使用有無                                                                                                                                                                                                           |
-| pingInterval                             | Body | Number  | X  | 高可用性使用時のPing間隔(秒)<br/>- 最小値:`1`<br/>- 最大値:`600`                                                                                                                                                                 |
-| failoverReplWaitingTime                  | Body | Number  | X  | 高可用性使用時のフェイルオーバー待機時間<br/>- 最小値:`-1`<br/>- -1に設定時、複製遅延が解消されるまで待機し続けます。                                                                                                                                         |                                                                                                                                                                                                                      | userGroupIds                             | Body | Array   | X  | 基本通知受信用のユーザーグループの識別子リスト                                                                                                                                                                                            |
-| network                                  | Body | Object  | O  | ネットワーク情報オブジェクト                                                                                                                                                                                                          |
-| network.subnetId                         | Body | UUID    | O  | サブネットの識別子                                                                                                                                                                                                            |
-| network.usePublicAccess                  | Body | Boolean | X  | 外部接続可否<br/>- デフォルト値:`false`                                                                                                                                                                                      |
-| network.availabilityZone                 | Body | Enum    | X  | DBインスタンスを作成するアベイラビリティゾーン<br/>- 例:`kr-pub-a`<br/>- デフォルト値:`任意のアベイラビリティゾーン`                                                                                                                                                     |
-| storage                                  | Body | Object  | O  | ストレージ情報オブジェクト                                                                                                                                                                                                          |    
-| storage.storageType                      | Body | Enum    | O  | データストレージタイプ<br/>- 例:`General SSD`                                                                                                                                                                                  |
-| storage.storageSize                      | Body | Number  | O  | データストレージサイズ(GB)<br/>- 最小値:`20`<br/>- 最大値:`2048`                                                                                                                                                                    |
-| backup                                   | Body | Object  | O  | バックアップ情報オブジェクト                                                                                                                                                                                                            |
-| backup.backupPeriod                      | Body | Number  | O  | バックアップ保管期間(日)<br/>- 最小値:`0`<br/>- 最大値:`730`                                                                                                                                                                          |
-| backup.backupRetryCount                  | Body | Number  | X  | バックアップ再試行回数<br/>- デフォルト値:`0`<br/>- 最小値:`0`<br/>- 最大値:`10`                                                                                                                                                              |
-| backup.backupSchedules                   | Body | Array   | X  | バックアップスケジュールリスト                                                                                                                                                                                                           |
-| backup.backupSchedules.backupWndBgnTime  | Body | String  | O  | バックアップ開始時間<br/>- 例:`00:00:00`                                                                                                                                                                                        |
-| backup.backupSchedules.backupWndDuration | Body | Enum    | O  | バックアップWindows<br/>バックアップ開始時間から設定された期間内に自動バックアップが実行されます。<br/>- `HALF_AN_HOUR`:30分<br/>- `ONE_HOUR`:1時間<br/>- `ONE_HOUR_AND_HALF`:1時間30分<br/>- `TWO_HOURS`:2時間<br/>- `TWO_HOURS_AND_HALF`:2時間30分<br/>- `THREE_HOURS`:3時間 |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceName | Body | String | O | DBインスタンスを識別できる名前 |
+| dbInstanceCandidateName | Body | String | X | DBインスタンスを識別できる予備マスター名 |
+| description | Body | String | X | DBインスタンスの追加情報 |
+| dbFlavorId | Body | UUID | O | DBインスタンス仕様の識別子 |
+| dbVersion | Body | Enum | O | DBバージョン情報 |
+| dbPort | Body | Number | O | DBポート<br/>- 最小値: 5432、最大値: 45432 |
+| databaseName | Body | String | O | データベース名 |
+| dbUserName | Body | String | O | DBユーザーアカウント名 |
+| dbPassword | Body | String | O | DBユーザーアカウントのパスワード |
+| parameterGroupId | Body | UUID | O | パラメータグループの識別子 |
+| dbSecurityGroupIds | Body | Array | X | DBセキュリティグループの識別子リスト |
+| userGroupIds | Body | Array | X | ユーザーグループの識別子リスト |
+| useHighAvailability | Body | Boolean | X | 高可用性の使用有無<br/>- デフォルト値: `false` |
+| useDefaultNotification | Body | Boolean | X | 基本通知の使用有無<br/>- デフォルト値: `false` |
+| useDeletionProtection | Body | Boolean | X | 削除保護の有無<br/>- デフォルト値: `false` |
+| pingInterval | Body | Number | X | Ping間隔(秒)<br/>- 最小値: `1`<br/>- 最大値: `600` |
+| failoverReplWaitingTime | Body | Number | X | フェイルオーバー複製遅延待機時間(秒)<br/>- 最小値: `-1` |
+| network | Body | Object | O | ネットワーク情報オブジェクト |
+| network.subnetId | Body | UUID | O | サブネットの識別子 |
+| network.usePublicAccess | Body | Boolean | X | 外部接続可否<br/>- デフォルト値: `false` |
+| network.availabilityZone | Body | Enum | X | DBインスタンスを作成するアベイラビリティゾーン |
+| storage | Body | Object | O | ストレージ情報オブジェクト |
+| storage.storageType | Body | Enum | O | データストレージタイプ |
+| storage.storageSize | Body | Number | O | データストレージサイズ(GB)<br/>- 最小値: `20` |
+| backup | Body | Object | O | バックアップ情報オブジェクト |
+| backup.backupPeriod | Body | Number | O | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| backup.backupRetryCount | Body | Number | X | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| backup.backupSchedules | Body | Array | O | バックアップスケジュール情報 |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | O | バックアップ開始時間 |
+| backup.backupSchedules.backupWndDuration | Body | Enum | O | バックアップWindow<br/>バックアップ開始時間から設定された期間内に自動バックアップが実行されます。<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbVersion": "POSTGRESQL_V17_6",
-    "dbPort": 15432,
-    "databaseName": "database",
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
+    "dbInstanceName": "dbInstanceName-example",
+    "dbInstanceCandidateName": "dbInstanceCandidateName-example",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbVersion": "POSTGRESQL_V14_17",
+    "dbPort": 1,
+    "databaseName": "databaseName-example",
+    "dbUserName": "dbUserName-example",
+    "dbPassword": "dbPassword-example",
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
     "userGroupIds": [],
+    "useHighAvailability": false,
+    "useDefaultNotification": false,
+    "useDeletionProtection": false,
+    "pingInterval": 1,
+    "failoverReplWaitingTime": 1,
     "network": {
-        "subnetId": "e721a9dd-dad0-4cf0-a53b-dd654ebfc683",
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
         "availabilityZone": "kr-pub-a"
     },
     "storage": {
@@ -1016,26 +990,29 @@ POST /v1.0/db-instances
         "storageSize": 20
     },
     "backup": {
-        "backupPeriod": 1,
+        "backupPeriod": 0,
+        "backupRetryCount": 0,
         "backupSchedules": [
             {
                 "backupWndBgnTime": "00:00:00",
-                "backupWndDuration": "ONE_HOUR_AND_HALF",
-                "backupRetryExpireTime": "01:30:00"
+                "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
     }
 }
 ```
+
+</p>
 </details>
 
 #### レスポンス
 
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | リクエストした作業の識別子 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -1044,142 +1021,127 @@ POST /v1.0/db-instances
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-### DBインスタンスを修正する
+---
+### オブジェクトストレージにあるバックアップからDBインスタンスを復元する
 
 ```http
-PUT /v1.0/db-instances/{dbInstanceId}
+POST /v1.0/db-instances/restore-from-obs
 ```
 
 #### 必要権限
 
-| 権限名                               | 説明          |
-|------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Modify | DBインスタンスを修正する |
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.RestoreFromObs | オブジェクトストレージにあるバックアップからDBインスタンスを復元 |
 
 #### リクエスト
 
-| 名前                | 種類  | 形式     | 必須 | 説明                                                                       |
-|--------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId       | URL  | UUID    | O  | DBインスタンスの識別子                                                             |
-| dbInstanceName     | Body | String  | X  | DBインスタンスを識別できる名前                                                     |
-| description        | Body | String  | X  | DBインスタンスの追加情報                                                        |
-| dbPort             | Body | Number  | X  | DBポート<br/>- 最小値:`5432`<br/>- 最大値:`45432`                                |
-| dbFlavorId         | Body | UUID    | X  | DBインスタンス仕様の識別子                                                          |
-| parameterGroupId   | Body | UUID    | X  | パラメータグループの識別子                                                             |
-| dbSecurityGroupIds | Body | Array   | X  | DBセキュリティグループの識別子リスト                                                         |
-| executeBackup      | Body | Boolean | X  | 現時点バックアップを実行するかどうか<br/>- デフォルト値:`false`                                         |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceName | Body | String | X | DBインスタンスを識別できる名前<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| dbInstanceCandidateName | Body | String | X | DBインスタンスを識別できる予備マスターの名前 |
+| description | Body | String | X | DBインスタンスの追加情報<br/>- 最大長さ: `100` |
+| dbFlavorId | Body | UUID | O | DBインスタンス仕様の識別子 |
+| dbPort | Body | Number | X | DBポート<br/>- 最小値: 5432、最大値: 45432 |
+| dbVersion | Body | Enum | O | DBエンジンタイプ |
+| useHighAvailability | Body | Boolean | X | 高可用性の使用有無<br/>- デフォルト値: `false` |
+| imageId | Body | UUID | X | イメージの識別子 |
+| pingInterval | Body | Number | X | 高可用性使用時のPing間隔(秒)<br/>- 最小値: `1`<br/>- 最大値: `600` |
+| failoverReplWaitingTime | Body | Number | X | フェイルオーバー複製遅延待機時間(秒)<br/>- 最小値: `-1` |
+| storage | Body | Object | O | ストレージ情報オブジェクト |
+| storage.storageType | Body | Enum | O | ストレージタイプ |
+| storage.storageSize | Body | Number | O | データストレージサイズ(GB)<br/>- 最小値: `20` |
+| network | Body | Object | O | ネットワーク情報オブジェクト |
+| network.subnetId | Body | UUID | O | サブネットの識別子 |
+| network.usePublicAccess | Body | Boolean | X | 外部接続の可否<br/>- デフォルト値: `false` |
+| network.availabilityZone | Body | Enum | X | DBインスタンスを作成するアベイラビリティゾーン |
+| backup | Body | Object | O | バックアップ情報オブジェクト |
+| backup.backupPeriod | Body | Number | O | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| backup.backupRetryCount | Body | Number | X | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| backup.replicationRegion | Body | Enum | X | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)`<br/>- KR2: `韓国(ピョンチョン)` |
+| backup.backupSchedules | Body | Array | O | バックアップスケジュールリスト |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | O | バックアップ開始時刻 |
+| backup.backupSchedules.backupWndDuration | Body | Enum | O | バックアップ期間<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+| restore | Body | Object | O | 復元情報オブジェクト |
+| restore.tenantId | Body | String | O | バックアップが保存されているオブジェクトストレージのテナントID |
+| restore.username | Body | String | O | NHN CloudアカウントまたはIAMメンバーID |
+| restore.password | Body | String | O | バックアップが保存されているオブジェクトストレージのAPIパスワード |
+| restore.targetContainer | Body | String | O | バックアップが保存されているオブジェクトストレージのコンテナ |
+| restore.objectPath | Body | String | O | コンテナに保存されているバックアップのパス |
+| useDefaultNotification | Body | Boolean | X | デフォルト通知の使用有無<br/>- デフォルト値: `false` |
+| parameterGroupId | Body | UUID | O | パラメータグループの識別子 |
+| dbSecurityGroupIds | Body | Array | X | DBセキュリティグループの識別子リスト |
+| userGroupIds | Body | Array | X | ユーザーグループの識別子リスト |
+| useDeletionProtection | Body | Boolean | X | 削除保護の有無<br/>- デフォルト値: `false` |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
-    "dbInstanceName": "db-instance2",
-    "description": "description2",
-    "dbPort": 25432,
-    "dbSecurityGroupIds": [],
-    "executeBackup": true
-}
-```
-</details>
-
-#### レスポンス
-
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-
-### 高可用性情報の照会
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}/high-availability
-```
-
-#### 必要権限
-
-| 権限名                                  | 説明        |
-|---------------------------------------|------------|
-| RDSforPostgreSQL:HighAvailability.Get | 高可用性情報照会 |
-
-#### リクエスト
-
-| 名前                 | 種類  | 形式     | 必須 | 説明                                                  |
-|---------------------|------|---------|----|------------------------------------------------------|
-| dbInstanceId        | URL  | UUID    | O  | DBインスタンスの識別子                                        |
-
-#### レスポンス
-
-| 名前                     | 種類  | 形式     | 説明                                                                                                                                                                                                                                                                                                                            |
-|-------------------------|------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| haStatus                | Body | Boolean | 高可用性状態<br/>- `CREATED`:作成済み<br/>- `STABLE`:正常<br/>- `DISABLE_REPLICATION_DELAY`:複製遅延によるフェイルオーバー停止<br/>- `PAUSING`:一時停止中<br/>- `PAUSED`:一時停止<br/>- `PAUSED_DUE_TO_TASK`:作業による一時停止<br/>- `FAILOVER_STARTED`:フェイルオーバー開始<br/>- `FAILOVER_FAILED`:フェイルオーバー失敗<br/>- `FAILOVER_COMPLETED`:フェイルオーバー完了<br/>- `DELETED`:削除済み |
-| pingInterval            | Body | Number  | 高可用性使用時のPing間隔(秒)<br/>- 最小値:`1`<br/>- 最大値:`600`                                                                                                                                                                                                                                                                           |
-| failoverReplWaitingTime | Body | Number  | 高可用性使用時のフェイルオーバー待機時間<br/>- 最小値:`-1`<br/>- -1に設定時、複製遅延が解消されるまで待機し続けます。                                                                                                                                                                                                                                                   |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "useHighAvailability": true,
-    "haStatus": "STABLE",
+    "dbInstanceName": "dbInstanceName",
+    "dbInstanceCandidateName": "dbInstanceCandidateName-example",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "dbVersion": "POSTGRESQL_V14_17",
+    "useHighAvailability": false,
+    "imageId": "550e8400-e29b-41d4-a716-446655440000",
     "pingInterval": 3,
-    "failoverReplWaitingTime": 60
+    "failoverReplWaitingTime": 60,
+    "storage": {
+        "storageType": "General SSD",
+        "storageSize": 20
+    },
+    "network": {
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
+        "availabilityZone": "kr-pub-a"
+    },
+    "backup": {
+        "backupPeriod": 0,
+        "backupRetryCount": 0,
+        "replicationRegion": "KR1",
+        "backupSchedules": [
+            {
+                "backupWndBgnTime": "00:00:00",
+                "backupWndDuration": "HALF_AN_HOUR"
+            }
+        ]
+    },
+    "restore": {
+        "tenantId": "0123456789abcdef0123456789abcdef",
+        "username": "username-example",
+        "password": "password-example",
+        "targetContainer": "targetContainer-example",
+        "objectPath": "objectPath-example"
+    },
+    "useDefaultNotification": false,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useDeletionProtection": false
 }
 ```
+
+</p>
 </details>
-
-
-### 高可用性を修正する
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/high-availability
-```
-
-#### 必要権限
-
-| 権限名                                     | 説明       |
-|------------------------------------------|-----------|
-| RDSforPostgreSQL:HighAvailability.Modify | 高可用性を修正する |
-
-#### リクエスト
-
-| 名前                     | 種類  | 形式     | 必須 | 説明                                                                          |
-|-------------------------|------|---------|----|------------------------------------------------------------------------------|
-| dbInstanceId            | URL  | UUID    | O  | DBインスタンスの識別子                                                                |
-| useHighAvailability     | Body | Boolean | O  | 高可用性の使用有無                                                                   |
-| pingInterval            | Body | Number  | X  | 高可用性使用時のPing間隔(秒)<br/>- 最小値:`1`<br/>- 最大値:`600`                         |
-| failoverReplWaitingTime | Body | Number  | X  | 高可用性使用時フェイルオーバー待機時間<br/>- 最小値:`-1`<br/>- -1に設定時、複製遅延が解消されるまで待機し続けます。 |
 
 #### レスポンス
 
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | リクエストした作業の識別子 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -1188,840 +1150,14 @@ PUT /v1.0/db-instances/{dbInstanceId}/high-availability
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-### 高可用性の再起動
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/high-availability/resume
-```
-
-#### 必要権限
-
-| 権限名                                     | 説明          |
-|------------------------------------------|--------------|
-| RDSforPostgreSQL:HighAvailability.Resume | 高可用性の再起動 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前          | 種類 | 形式  | 必須 | 説明          |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-
-### 高可用性の一時停止
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/high-availability/pause
-```
-
-#### 必要権限
-
-| 権限名                                    | 説明          |
-|-----------------------------------------|--------------|
-| RDSforPostgreSQL:HighAvailability.Pause | 高可用性の一時停止 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前          | 種類 | 形式  | 必須 | 説明          |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-
-### 高可用性の復旧
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/high-availability/repair
-```
-
-#### 必要権限
-
-| 権限名                                     | 説明       |
-|------------------------------------------|-----------|
-| RDSforPostgreSQL:HighAvailability.Repair | 高可用性の復旧 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前          | 種類 | 形式  | 必須 | 説明          |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-
-### 高可用性の分離
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/high-availability/split
-```
-
-#### 必要権限
-
-| 権限名                                    | 説明       |
-|-----------------------------------------|-----------|
-| RDSforPostgreSQL:HighAvailability.Split | 高可用性の分離 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前          | 種類 | 形式  | 必須 | 説明          |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-
-### DBインスタンスストレージ情報の照会
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}/storage-info
-```
-
-#### 必要権限
-
-| 権限名                            | 説明           |
-|---------------------------------|---------------|
-| RDSforPostgreSQL:DbInstance.Get | DBインスタンス詳細を表示 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前          | 種類 | 形式  | 必須 | 説明          |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前              | 種類  | 形式     | 説明                                                                                  |
-|------------------|------|---------|--------------------------------------------------------------------------------------|
-| storageType      | Body | Enum    | データストレージタイプ                                                                         |
-| storageSize      | Body | Number  | データストレージサイズ(GB)                                                                      |
-| storageStatus    | Body | Enum    | データストレージの現在状態<br/>- `DETACHED`:デタッチ<br/>- `ATTACHED`:アタッチ<br/>- `DELETED`:削除済み |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "storageType": "General SSD",
-    "storageSize": 20,
-    "storageStatus": "ATTACHED"
-}
-```
-</details>
-
-
-### DBインスタンスストレージ情報の修正
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/storage-info
-```
-
-#### 必要権限
-
-| 権限名                               | 説明          |
-|------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Modify | DBインスタンスの修正 |
-
-#### リクエスト
-
-| 名前               | 種類  | 形式     | 必須 | 説明                                                                       |
-|-------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID    | O  | DBインスタンスの識別子                                                             |
-| storageSize       | Body | Number  | O  | データストレージサイズ(GB)<br/>- 最小値:現在値<br/>- 最大値:`2048`                          |
-
-#### レスポンス
-
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### DBインスタンスネットワーク情報の照会
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}/network-info
-```
-
-#### 必要権限
-
-| 権限名                            | 説明           |
-|---------------------------------|---------------|
-| RDSforPostgreSQL:DbInstance.Get | DBインスタンス詳細を表示 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前          | 種類 | 形式  | 必須 | 説明          |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前                     | 種類  | 形式     | 説明                                                                                                                                     |
-|-------------------------|------|---------|-----------------------------------------------------------------------------------------------------------------------------------------|
-| availabilityZone        | Body | Enum    | DBインスタンスを作成するアベイラビリティゾーン                                                                                                                    |
-| subnet                  | Body | Object  | サブネットオブジェクト                                                                                                                                 |
-| subnet.subnetId         | Body | UUID    | サブネットの識別子                                                                                                                               |
-| subnet.subnetName       | Body | UUID    | サブネットを識別できる名前                                                                                                                       |
-| subnet.subnetCidr       | Body | UUID    | サブネットのCIDR                                                                                                                               |
-| subnet.publicAccessible | Body | Boolean | 外部接続可否                                                                                                                            |
-| endPoints               | Body | Array   | 接続情報リスト                                                                                                                               |
-| endPoints.domain        | Body | String  | ドメイン                                                                                                                                    |
-| endPoints.ipAddress     | Body | String  | IPアドレス                                                                                                                                  |
-| endPoints.endPointType  | Body | Enum    | 接続情報タイプ<br>-`EXTERNAL`:外部接続ドメイン<br>-`INTERNAL`:内部接続ドメイン<br>-`PUBLIC`:(Deprecated)外部接続ドメイン<br>-`PRIVATE`:(Deprecated)内部接続ドメイン |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "availabilityZone": "kr-pub-a",
-    "subnet": {
-        "subnetId": "bd453789-34ae-416c-9f78-05b9e43a46be",
-        "subnetName": "Default Network",
-        "subnetCidr": "192.168.0.0/16",
-        "publicAccessible": true
-    },
-    "endPoints": [
-        {
-            "domain": "ea548a78-d85f-43b4-8ddf-c88d999b9905.internal.kr1.postgres.rds.nhncloudservice.com",
-            "ipAddress": "192.168.0.2",
-            "endPointType": "INTERNAL"
-        }
-    ]
-}
-```
-</details>
-
-### DBインスタンスネットワーク情報の修正
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/network-info
-```
-
-#### 必要権限
-
-| 権限名                               | 説明          |
-|------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Modify | DBインスタンスの修正 |
-
-#### リクエスト
-
-| 名前             | 種類  | 形式     | 必須 | 説明          |
-|-----------------|------|---------|----|--------------|
-| dbInstanceId    | URL  | UUID    | O  | DBインスタンスの識別子 |
-| usePublicAccess | Body | Boolean | O  | 外部接続可否 |
-
-#### レスポンス
-
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### DBインスタンスバックアップ情報の照会
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}/backup-info
-```
-
-#### 必要権限
-
-| 権限名                            | 説明           |
-|---------------------------------|---------------|
-| RDSforPostgreSQL:DbInstance.Get | DBインスタンス詳細を表示 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前          | 種類 | 形式  | 必須 | 説明          |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前                                   | 種類  | 形式    | 説明                                                                                                                                                                                                                  |
-|---------------------------------------|------|--------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| backupPeriod                          | Body | Number | バックアップの保管期間(日)                                                                                                                                                                                                          |
-| backupRetryCount                      | Body | Number | バックアップの再試行回数                                                                                                                                                                                                           |
-| backupSchedules                       | Body | Array  | バックアップスケジュールリスト                                                                                                                                                                                                           |
-| backupSchedules.backupWndBgnTime      | Body | String | バックアップ開始時間                                                                                                                                                                                                            |
-| backupSchedules.backupWndDuration     | Body | Enum   | バックアップWindows<br/>バックアップ開始時間から設定された期間内に自動バックアップが実行されます。<br/>- `HALF_AN_HOUR`:30分<br/>- `ONE_HOUR`:1時間<br/>- `ONE_HOUR_AND_HALF`:1時間30分<br/>- `TWO_HOURS`:2時間<br/>- `TWO_HOURS_AND_HALF`:2時間30分<br/>- `THREE_HOURS`:3時間 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "backupPeriod": 1,
-    "backupRetryCount": 0,
-    "backupSchedules": [
-        {
-            "backupWndBgnTime": "00:00:00",
-            "backupWndDuration": "ONE_HOUR_AND_HALF",
-            "backupRetryExpireTime": "01:30:00"
-        }
-    ]
-}
-```
-</details>
-
-### DBインスタンスバックアップ情報の修正
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/backup-info
-```
-
-#### 必要権限
-
-| 権限名                               | 説明          |
-|------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Modify | DBインスタンスの修正 |
-
-#### リクエスト
-
-| 名前                                   | 種類  | 形式    | 必須 | 説明                                                                                                                                                                                                                  |
-|---------------------------------------|------|--------|----|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                          | URL  | UUID   | O  | DBインスタンスの識別子                                                                                                                                                                                                        |
-| backupPeriod                          | Body | Number | X  | バックアップの保管期間(日)<br/>- 最小値:`0`<br/>- 最大値:`730`                                                                                                                                                                          |
-| backupRetryCount                      | Body | Number | X  | バックアップの再試行回数<br/>- 最小値:`0`<br/>- 最大値:`10`                                                                                                                                                                             |
-| backupSchedules                       | Body | Array  | X  | バックアップスケジュールリスト                                                                                                                                                                                                           |
-| backupSchedules.backupWndBgnTime      | Body | String | O  | バックアップ開始時間<br/>- 例:`00:00:00`                                                                                                                                                                                        |
-| backupSchedules.backupWndDuration     | Body | Enum   | O  | バックアップWindows<br/>バックアップ開始時間から設定された期間内に自動バックアップが実行されます。<br/>- `HALF_AN_HOUR`:30分<br/>- `ONE_HOUR`:1時間<br/>- `ONE_HOUR_AND_HALF`:1時間30分<br/>- `TWO_HOURS`:2時間<br/>- `TWO_HOURS_AND_HALF`:2時間30分<br/>- `THREE_HOURS`:3時間 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "backupPeriod": 5,
-    "backupSchedules": [
-        {
-            "backupWndBgnTime": "01:00:00",
-            "backupWndDuration": "TWO_HOURS",
-            "backupRetryExpireTime": "03:00:00"
-        }
-    ]
-}
-```
-</details>
-
-#### レスポンス
-
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### DBインスタンス復元情報の照会
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}/restoration-info
-```
-
-#### 必要権限
-
-| 権限名                            | 説明           |
-|---------------------------------|---------------|
-| RDSforPostgreSQL:DbInstance.Get | DBインスタンス詳細を表示 |
-
-#### リクエスト
-
-| 名前          | 種類 | 形式  | 必須 | 説明          |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前                                     | 種類  | 形式      | 説明                                                                                                                                                   |
-|-----------------------------------------|------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
-| oldestRestorableYmdt                    | Body | DateTime | 最も古い復元可能時間                                                                                                                                     |
-| latestRestorableYmdt                    | Body | DateTime | 最も最新の復元可能時間                                                                                                                                     |
-| restorableBackups                       | Body | Array    | 復元可能なバックアップリスト                                                                                                                                         |
-| restorableBackups.backup                | Body | Object   | バックアップの情報オブジェクト                                                                                                                                             |
-| restorableBackups.backup.backupId       | Body | UUID     | バックアップの識別子                                                                                                                                              |
-| restorableBackups.backup.backupName     | Body | String   | バックアップ名                                                                                                                                                |
-| restorableBackups.backup.backupSize     | Body | Number   | バックアップサイズ                                                                                                                                                |
-| restorableBackups.backup.backupType     | Body | Enum     | バックアップタイプ<br/>- `AUTO`:自動<br/>- `MANUAL`:手動                                                                                                            |
-| restorableBackups.backup.backupStatus   | Body | Enum     | バックアップ状態<br/>- `BACKING_UP`:バックアップ中の場合<br/>- `COMPLETED`:バックアップが完了した場合<br/>- `DELETING`:バックアップが削除中の場合<br/>- `DELETED`:バックアップが削除された場合<br/>- `ERROR`:エラーが発生した場合 |
-| restorableBackups.backup.dbInstanceId   | Body | UUID     | 原本DBインスタンスの識別子                                                                                                                                      |
-| restorableBackups.backup.dbInstanceName | Body | String   | 原本DBインスタンス名                                                                                                                                       |
-| restorableBackups.backup.dbVersion      | Body | String   | DBバージョン情報                                                                                                                                             |
-| restorableBackups.backup.failoverCount  | Body | Number   | フェイルオーバー回数                                                                                                                                             |
-| restorableBackups.backup.walFileName    | Body | String   | WALログファイル名                                                                                                                                         |
-| restorableBackups.backup.createdYmdt    | Body | DateTime | バックアップ作成日時                                                                                                                                             |
-| restorableBackups.backup.updatedYmdt    | Body | DateTime | バックアップ更新日時                                                                                                                                             |
-| restorableBackups.backup.startYmdt      | Body | DateTime | バックアップ開始日時                                                                                                                                             |
-| restorableBackups.backup.completedYmdt  | Body | DateTime | バックアップ完了日時                                                                                                                                             |
-
-<details><summary>例</summary>
-
-```json
-{
-	"header": {
-		"resultCode": 0,
-		"resultMessage": "SUCCESS",
-		"isSuccessful": true
-	},
-    "oldestRestorableYmdt": "2023-07-09T16:33:33+09:00",
-	"latestRestorableYmdt": "2023-07-10T15:44:44+09:00",
-	"restorableBackups": [
-		{
-			"backup": {
-				"backupId": "145d889a-fe08-474f-8f58-bde576ff96a9",
-				"backupName": "example-backup-name",
-				"backupStatus": "COMPLETED",
-				"dbInstanceId": "dba1be25-9429-4589-9716-7fb6daad7cb9",
-				"dbInstanceName": "original-db-instance-name",
-				"dbVersion": "POSTGRESQL_V17_6",
-				"backupType": "MANUAL",
-				"backupSize": 8299904,
-				"walFileName": "000000010000000000000005",
-				"createdYmdt": "2023-07-10T15:44:44+09:00",
-				"updatedYmdt": "2023-07-10T15:46:07+09:00"
-			}
-		}
-	]
-}
-```
-</details>
-
-### DBインスタンスの復元
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/restore
-```
-
-#### 必要権限
-
-| 権限名                                | 説明          |
-|-------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Restore | DBインスタンスの復元 |
-
-#### 共通リクエスト
-
-| 名前                                      | 種類  | 形式     | 必須 | 説明                                                                                                                                                                                                                                                 |
-|------------------------------------------|------|---------|----|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                             | URL  | UUID    | O  | DBインスタンスの識別子                                                                                                                                                                                                                                       |
-| restore                                  | Body | Object  | O  | 復元情報オブジェクト                                                                                                                                                                                                                                           |
-| restore.restoreType                      | Body | Enum    | O  | 復元タイプ種類<br/>- `TIMESTAMP`:復元可能時間内の時間を利用した時点復元タイプ<br/>- `BACKUP`:既存のバックアップを利用した復元タイプ                                                                                                                                                   |
-| dbInstanceName                           | Body | String  | O  | DBインスタンスを識別できる名前                                                                                                                                                                                                                               |
-| description                              | Body | String  | X  | DBインスタンスの追加情報                                                                                                                                                                                                                                  |
-| dbFlavorId                               | Body | UUID    | O  | DBインスタンス仕様の識別子                                                                                                                                                                                                                                    |
-| dbPort                                   | Body | Number  | O  | DBポート<br/>- 最小値:`3306`<br/>- 最大値:`43306`                                                                                                                                                                                                          |
-| parameterGroupId                         | Body | UUID    | O  | パラメータグループの識別子                                                                                                                                                                                                                                       |
-| dbSecurityGroupIds                       | Body | Array   | X  | DBセキュリティグループの識別子リスト                                                                                                                                                                                                                                   |
-| userGroupIds                             | Body | Array   | X  | ユーザーグループの識別子リスト                                                                                                                                                                                                                                     |
-| useDefaultNotification                   | Body | Boolean | X  | 基本通知の使用有無<br/>- デフォルト値:`false`                                                                                                                                                                                                                      |
-| useDeletionProtection                    | Body | Boolean | X  | 削除保護の有無<br>デフォルト値:`false`                                                                                                                                                                                                                            |                                                                                                                                                                                                                                                                                                                                                                                                                                        |
-| useHighAvailability                      | Body | Boolean | X  | 高可用性の使用有無<br/>- デフォルト値:`false`                                                                                                                                                                                                                       |
-| pingInterval                             | Body | Number  | X  | 高可用性使用時Ping間隔(秒)<br/>- デフォルト値: `3`最小値: `1`<br/>- 最大値: `600`                                                                                                                                                                                        |
-| failoverReplWaitingTime                  | Body | Number  | X  | 高可用性使用時のフェイルオーバー待機時間<br/>- 最小値:`-1`<br/>- -1に設定時、複製遅延が解消されるまで待機し続けます。                                                                                                                                                                        |                                                                                                                                                                                                                      | userGroupIds                             | Body | Array   | X  | 基本通知受信用のユーザーグループの識別子リスト                                                                                                                                                                                            |
-| network                                  | Body | Object  | O  | ネットワーク情報オブジェクト                                                                                                                                                                                                                                         |
-| network.subnetId                         | Body | UUID    | O  | サブネットの識別子                                                                                                                                                                                                                                           |
-| network.usePublicAccess                  | Body | Boolean | X  | 外部接続可否<br/>- デフォルト値:`false`</li></ul>                                                                                                                                                                                                            |
-| network.availabilityZone                 | Body | Enum    | X  | DBインスタンスを作成するアベイラビリティゾーン<br/>- 例:`kr-pub-a`<br/>- デフォルト値:`任意のアベイラビリティゾーン`                                                                                                                                                                                    |
-| storage                                  | Body | Object  | O  | ストレージ情報オブジェクト                                                                                                                                                                                                                                         |
-| storage.storageType                      | Body | Enum    | O  | データストレージタイプ<br/>- 例:`General SSD`                                                                                                                                                                                                                 |
-| storage.storageSize                      | Body | Number  | O  | データストレージサイズ(GB)<br/>- 最小値:`20`<br/>- 最大値:`2048`                                                                                                                                                                                                   |
-| backup                                   | Body | Object  | O  | バックアップの情報オブジェクト                                                                                                                                                                                                                                           |
-| backup.backupPeriod                      | Body | Number  | O  | バックアップの保管期間(日)<br/>- 最小値:`0`<br/>- 最大値:`730`                                                                                                                                                                                                         |
-| backup.backupRetryCount                  | Body | Number  | X  | バックアップの再試行回数<br/>- デフォルト値:`0`<br/>- 最小値:`0`<br/>- 最大値:`10`                                                                                                                                                                                             |
-| backup.backupSchedules                   | Body | Array   | O  | バックアップスケジュールリスト                                                                                                                                                                                                                                          |
-| backup.backupSchedules.backupWndBgnTime  | Body | String  | X  | バックアップ開始時刻<br/>- 例:`00:00:00`<br/>- デフォルト値:原本DBインスタンス値                                                                                                                                                                                              |
-| backup.backupSchedules.backupWndDuration | Body | Enum    | X  | バックアップDuration<br/>バックアップ開始時刻からDuration内に自動バックアップが実行されます。<br/>- `HALF_AN_HOUR`:30分<br/>- `ONE_HOUR`:1時間<br/>- `ONE_HOUR_AND_HALF`:1時間30分<br/>- `TWO_HOURS`:2時間<br/>- `TWO_HOURS_AND_HALF`:2時間30分<br/>- `THREE_HOURS`:3時間<br/>- デフォルト値:原本DBインスタンス値 |
-
-#### Timestampを利用した時点復元時のリクエスト(restoreTypeが`TIMESTAMP`の場合)
-
-| 名前                 | 種類  | 形式      | 必須 | 説明                                                                                             |
-|---------------------|------|----------|----|-------------------------------------------------------------------------------------------------|
-| restore.restoreYmdt | Body | DateTime | O  | DBインスタンス復元時間。(YYYY-MM-DDThh:mm:ss.SSSTZD)<br>復元情報照会で照会した最も最新の復元可能な時間以前のデータのみ復元が可能 |
-
-<details><summary>例</summary>
-
-```json
-{
-  "dbInstanceName": "db-instance",
-  "description": "description",
-  "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-  "dbPort": 10000,
-  "dbUserName": "db-user",
-  "dbPassword": "password",
-  "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-  "dbSecurityGroupIds": [
-    "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-  ],
-  "userGroupIds": [],
-  "network": {
-    "subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36"
-  },
-  "storage": {
-    "storageType": "General SSD",
-    "storageSize": 20
-  },
-  "restore": {
-    "restoreType": "TIMESTAMP",
-    "restoreYmdt": "2023-07-10T15:44:44+09:00"
-  },
-  "backup": {
-    "backupPeriod": 1,
-    "backupSchedules": [
-      {
-        "backupWndBgnTime": "00:00:00",
-        "backupWndDuration": "ONE_HOUR_AND_HALF"
-      }
-    ]
-  }
-}
-```
-</details>
-
-#### レスポンス
-
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-
-### DBインスタンス削除保護設定の変更
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/deletion-protection
-```
-
-#### 必要権限
-
-| 権限名                               | 説明          |
-|------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Modify | DBインスタンスの修正 |
-
-#### リクエスト
-
-| 名前                   | 種類  | 形式     | 必須 | 説明          |
-|-----------------------|------|---------|----|--------------|
-| dbInstanceId          | URL  | UUID    | O  | DBインスタンスの識別子 |
-| useDeletionProtection | Body | Boolean | O  | 削除保護の有無     |
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
-
-### DBインスタンス保守情報照会
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}/maintenance-info
-```
-
-#### 必要権限
-
-| 権限名                           | 説明          |
-|---------------------------------|---------------|
-| RDSforPostgreSQL:DbInstance.Get | DBインスタンス詳細表示 |
-
-#### リクエスト
-
-| 名前                  | 種類 | 形式    | 必須 | 説明         |
-|-----------------------|------|---------|----|--------------|
-| dbInstanceId          | URL  | UUID    | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前                  | 種類 | 形式    | 説明                                                                                                                 |
-|-----------------------|------|---------|----------------------------------------------------------------------------------------------------------------------|
-| allowAutoMaintenance  | Body | Boolean | 自動保守を許可するかどうか                                                                                                       |
-| useAutoStorageCleanup | Body | Boolean | 自動ストレージクリーンアップを使用するかどうか                                                                                                    |
-| maintWndBgnTime       | Body | String  | 自動保守開始時間 <br/>- 例: `00:00:00`                                                                                  |
-| maintWndDuration      | Body | ENUM    | 保守Windows <br/> 例: `HALF_AN_HOUR`, `ONE_HOUR`, `ONE_HOUR_AND_HALF`, `TWO_HOURS`, `TWO_HOURS_AND_HALF`, `THREE_HOURS` |
-| logRetentionPeriod    | Body | Number  | ログ保管期間(日)                                                                                                         |
-
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "allowAutoMaintenance": true,
-    "useAutoStorageCleanup": true,
-    "maintWndBgnTime": "00:00:00",
-    "maintWndDuration": "HALF_AN_HOUR",
-    "logRetentionPeriod": 7
-}
-```
-</details>
-
-
-### DBインスタンス保守情報修正
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/maintenance-info
-```
-
-#### 必要権限
-
-| 権限名                              | 説明         |
-|------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Modify | DBインスタンスを修正する |
-
-#### リクエスト
-
-| 名前                  | 種類 | 形式    | 必須 | 説明                                                                                                                 |
-|-----------------------|------|---------|----|----------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId          | URL  | UUID    | O  | DBインスタンスの識別子                                                                                                       |
-| allowAutoMaintenance  | Body | Boolean | X  | 自動保守を許可するかどうか                                                                                                       |
-| useAutoStorageCleanup | Body | Boolean | X  | 自動ストレージクリーンアップを使用するかどうか                                                                                                    |
-| maintWndBgnTime       | Body | String  | X  | 自動保守開始時間 <br/>- 例: `00:00:00`                                                                                  |
-| maintWndDuration      | Body | ENUM    | X  | 保守Windows <br/> 例: `HALF_AN_HOUR`, `ONE_HOUR`, `ONE_HOUR_AND_HALF`, `TWO_HOURS`, `TWO_HOURS_AND_HALF`, `THREE_HOURS` |
-| logRetentionPeriod    | Body | Number  | X  | ログ保管期間(日)                                                                                                         |
-
-<details><summary>例</summary>
-
-```json
-{
-  "allowAutoMaintenance": true,
-  "useAutoStorageCleanup": true,
-  "logRetentionPeriod": 7
-}
-```
-</details>
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-
-```json
-{
-  "header": {
-    "resultCode": 0,
-    "resultMessage": "SUCCESS",
-    "isSuccessful": true
-  },
-  "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-
-### 現在のDBインスタンスで選択可能なDBバージョンの照会
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}/available-db-versions
-```
-
-#### 必要権限
-
-| 権限名                              | 説明         |
-|------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Get | DBインスタンス詳細表示 |
-
-#### リクエスト
-
-| 名前                  | 種類 | 形式    | 必須 | 説明         |
-|-----------------------|------|---------|----|--------------|
-| dbInstanceId          | URL  | UUID    | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前                         | 種類 | 形式    | 説明                  |
-|------------------------------|------|---------|-----------------------|
-| dbVersions                   | Body | Array   | DBバージョンリスト            |
-| dbVersions.dbVersion         | Body | String  | DBバージョン               |
-| dbVersions.dbVersionName     | Body | String  | DBバージョン名              |
-| dbVersions.restorableFromObs | Body | Boolean | オブジェクトストレージから復元の可否 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbVersions": [
-        {
-            "dbVersion": "POSTGRESQL_V17_6",
-            "dbVersionName": "PostgreSQL V17.6",
-            "restorableFromObs": true
-        }
-    ]
-}
-```
-</details>
+---
 
 ### DBインスタンスの削除
 
@@ -2031,25 +1167,26 @@ DELETE /v1.0/db-instances/{dbInstanceId}
 
 #### 必要権限
 
-| 権限名                               | 説明          |
-|------------------------------------|--------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:DbInstance.Delete | DBインスタンスの削除 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前          | 種類 | 形式  | 必須 | 説明          |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
 
 #### レスポンス
 
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | リクエストした作業の識別子 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -2058,123 +1195,61 @@ DELETE /v1.0/db-instances/{dbInstanceId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-### DBインスタンスの再起動
+---
+
+### DBインスタンス詳細を表示
 
 ```http
-POST /v1.0/db-instances/{dbInstanceId}/restart
+GET /v1.0/db-instances/{dbInstanceId}
 ```
 
 #### 必要権限
 
-| 権限名                                | 説明           |
-|-------------------------------------|---------------|
-| RDSforPostgreSQL:DbInstance.Restart | DBインスタンスの再起動 |
-
-#### リクエスト
-
-| 名前               | 種類  | 形式     | 必須 | 説明                                                                       |
-|-------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID    | O  | DBインスタンスの識別子                                                             |
-| useOnlineFailover | Body | Boolean | X  | フェイルオーバーを利用した再起動の有無<br/>高可用性を使用中のDBインスタンスでのみ使用可能です。<br/>- デフォルト値:`false` |
-| executeBackup     | Body | Boolean | X  | 現時点バックアップを実行するかどうか<br/>- デフォルト値: `false`                                         |
-
-<details><summary>例</summary>
-
-```json
-{
-    "executeBackup": true
-}
-```
-</details>
-
-#### レスポンス
-
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### DBインスタンスの強制再起動
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/force-restart
-```
-
-#### 必要権限
-
-| 権限名                                     | 説明              |
-|------------------------------------------|------------------|
-| RDSforPostgreSQL:DbInstance.ForceRestart | DBインスタンスの強制再起動 |
-
-#### リクエスト
-
-| 名前          | 種類 | 形式  | 必須 | 説明          |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
-
-
-### DBインスタンス開始
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/start
-```
-
-#### 必要権限
-
-| 権限名                              | 説明          |
-|-----------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Start | DBインスタンス開始 |
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Get | DBインスタンス詳細を表示 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前          | 種類 | 形式  | 必須 | 説明          |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
 
 #### レスポンス
 
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceId | Body | UUID | DBインスタンスの識別子 |
+| dbInstanceGroupId | Body | UUID | DBインスタンスグループの識別子 |
+| dbInstanceName | Body | String | DBインスタンスを識別できる名前 |
+| description | Body | String | DBインスタンスの追加情報 |
+| dbVersion | Body | Enum | DBエンジンタイプ |
+| dbPort | Body | Number | DBポート |
+| dbInstanceType | Body | Enum | DBインスタンスのロールタイプ<br/>- MASTER: `マスター`<br/>- FAILED_MASTER: `フェイルオーバーされたマスター`<br/>- CANDIDATE_MASTER: `予備マスター`<br/>- READ_ONLY_SLAVE: `リードレプリカ` |
+| dbInstanceStatus | Body | Enum | DBインスタンスの現在状態<br/>- BEFORE_CREATE: `作成以前(グレー)`<br/>- AVAILABLE: `使用可能(緑)`<br/>- STORAGE_FULL: `容量不足(赤)`<br/>- FAIL_TO_CREATE: `作成失敗(赤)`<br/>- FAIL_TO_CONNECT: `接続失敗(赤)`<br/>- REPLICATION_STOP: `複製中断(赤)`<br/>- REPLICATION_DELAY: `複製遅延(黄色)`<br/>- FAILOVER: `フェイルオーバー完了(赤)`<br/>- SHUTDOWN: `停止済み(グレー)`<br/>- DELETED: `削除済み(グレー)` |
+| progressStatus | Body | String | DBインスタンスの現在の作業進行状態 |
+| dbFlavorId | Body | UUID | DBインスタンス仕様の識別子 |
+| parameterGroupId | Body | UUID | DBインスタンスに適用されたパラメータグループの識別子 |
+| dbSecurityGroupIds | Body | Array | DBインスタンスに適用されたDBセキュリティグループの識別子リスト |
+| notificationGroupIds | Body | Array | DBインスタンスに適用された通知グループの識別子リスト |
+| useDeletionProtection | Body | Boolean | DBインスタンスの削除保護の有無 |
+| needToApplyParameterGroup | Body | Boolean | 最新パラメータグループの適用可否 |
+| needMigration | Body | Boolean | マイグレーションの要否 |
+| osVersion | Body | String | OSバージョン |
+| createdYmdt | Body | DateTime | 作成日時 |
+| updatedYmdt | Body | DateTime | 修正日時 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -2183,38 +1258,98 @@ POST /v1.0/db-instances/{dbInstanceId}/start
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbInstanceName": "dbInstanceName-example",
+    "description": "description-example",
+    "dbVersion": "POSTGRESQL_V14_17",
+    "dbPort": 1,
+    "dbInstanceType": "MASTER",
+    "dbInstanceStatus": "BEFORE_CREATE",
+    "progressStatus": "progressStatus-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [
+        "550e8400-e29b-41d4-a716-446655440000"
+    ],
+    "notificationGroupIds": [
+        "550e8400-e29b-41d4-a716-446655440000"
+    ],
+    "useDeletionProtection": false,
+    "needToApplyParameterGroup": false,
+    "needMigration": false,
+    "osVersion": "osVersion-example",
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
+
+</p>
 </details>
 
-### DBインスタンス停止
+---
+
+### DBインスタンスを修正する
 
 ```http
-POST /v1.0/db-instances/{dbInstanceId}/stop
+PUT /v1.0/db-instances/{dbInstanceId}
 ```
 
 #### 必要権限
 
-| 権限名                            | 説明         |
-|----------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Stop | DBインスタンスを停止する |
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Modify | DBインスタンスを修正する |
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceName | Body | String | X | DBインスタンスを識別できる名前 |
+| dbInstanceCandidateName | Body | String | X | DBインスタンスを識別できる予備マスターの名前 |
+| description | Body | String | X | DBインスタンスの追加情報<br/>- 最大長さ: `100` |
+| dbPort | Body | Number | X | DBポート<br/>- 最小値: 5432、最大値: 45432 |
+| dbFlavorId | Body | UUID | X | DBインスタンス仕様の識別子 |
+| parameterGroupId | Body | UUID | X | パラメータグループの識別子 |
+| dbVersion | Body | Enum | X | DBエンジンバージョンコード |
+| dbSecurityGroupIds | Body | Array | X | DBセキュリティグループの識別子リスト |
+| executeBackup | Body | Boolean | X | 現時点バックアップを実行するかどうか<br/>- デフォルト値: `false` |
+| useOnlineFailover | Body | Boolean | X | フェイルオーバーを利用した再起動の有無<br/>- デフォルト値: `false` |
+| waitReplicationDelay | Body | Boolean | X | 複製遅延の解消を待機するかどうか<br/>- デフォルト値: `false` |
+| useReadOnly | Body | Boolean | X | 書き込み負荷のブロック<br/>- デフォルト値: `false` |
 
-| 名前          | 種類 | 形式  | 必須 | 説明          |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName-example",
+    "dbInstanceCandidateName": "dbInstanceCandidateName-example",
+    "description": "description-example",
+    "dbPort": 1,
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbVersion": "POSTGRESQL_V14_17",
+    "dbSecurityGroupIds": [],
+    "executeBackup": false,
+    "useOnlineFailover": false,
+    "waitReplicationDelay": false,
+    "useReadOnly": false
+}
+```
+
+</p>
+</details>
 
 #### レスポンス
 
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | リクエストした作業の識別子 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -2223,114 +1358,14 @@ POST /v1.0/db-instances/{dbInstanceId}/stop
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-### DBインスタンスのバックアップ
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/backup
-```
-
-#### 必要権限
-
-| 権限名                               | 説明          |
-|------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Backup | DBインスタンスのバックアップ |
-
-#### リクエスト
-
-| 名前          | 種類  | 形式    | 必須 | 説明             |
-|--------------|------|--------|----|-----------------|
-| dbInstanceId | URL  | UUID   | O  | DBインスタンスの識別子   |
-| backupName   | Body | String | O  | バックアップを識別できる名前 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "backupName": "backup"
-}
-```
-</details>
-
-#### レスポンス
-
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### DBインスタンスバックアップ後にエクスポート
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/backup-to-object-storage
-```
-
-#### 必要権限
-
-| 権限名                                              | 説明                        |
-|---------------------------------------------------|----------------------------|
-| RDSforPostgreSQL:DbInstance.BackupToObjectStorage | バックアップ後にバックアップファイルをオブジェクトストレージにエクスポート |
-
-#### リクエスト
-
-| 名前             | 種類  | 形式    | 必須 | 説明                         |
-|-----------------|------|--------|----|-----------------------------|
-| dbInstanceId    | URL  | UUID   | O  | DBインスタンスの識別子               |
-| tenantId        | Body | String | O  | バックアップが保存されるオブジェクトストレージのテナントID   |
-| username        | Body | String | O  | NHN CloudアカウントまたはIAMアカウントID   |
-| password        | Body | String | O  | バックアップが保存されるオブジェクトストレージのAPIパスワード |
-| targetContainer | Body | String | O  | バックアップが保存されるオブジェクトストレージのコンテナ    |
-| objectPath      | Body | String | O  | コンテナに保存されるバックアップのパス           |
-
-<details><summary>例</summary>
-
-```json
-{
-    "tenantId": "399631c404744dbbb18ce4fa2dc71a5a",
-    "username": "gildong.hong@nhn.com",
-    "password": "password",
-    "targetContainer": "/container",
-    "objectPath": "/backups/backup_file"
-}
-```
-</details>
-
-#### レスポンス
-
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
+---
 
 ### DBインスタンスの最新パラメータグループを適用する
 
@@ -2340,143 +1375,26 @@ POST /v1.0/db-instances/{dbInstanceId}/apply-recent-parameter-group
 
 #### 必要権限
 
-| 権限名                               | 説明          |
-|------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Modify | DBインスタンスの修正 |
-
-#### リクエスト
-
-| 名前               | 種類  | 形式     | 必須 | 説明                                                                       |
-|-------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID    | O  | DBインスタンスの識別子                                                             |
-| executeBackup     | Body | Boolean | X  | 現時点バックアップを実行するかどうか<br/>- デフォルト値:`false`                                         |
-
-<details><summary>例</summary>
-
-```json
-{
-  "executeBackup": true
-}
-```
-</details>
-
-#### レスポンス
-
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### DBインスタンスの複製
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/replicate
-```
-
-#### 必要権限
-
-| 権限名                                  | 説明          |
-|---------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Replicate | DBインスタンスの複製 |
-
-#### リクエスト
-
-| 名前                                          | 種類  | 形式     | 必須 | 説明                                                                                                                                                                                                                                                 |
-|----------------------------------------------|------|---------|----|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                                 | URL  | UUID    | O  | DBインスタンスの識別子                                                                                                                                                                                                                                       |
-| dbInstanceName                               | Body | String  | O  | DBインスタンスを識別できる名前                                                                                                                                                                                                                               |
-| description                                  | Body | String  | X  | DBインスタンスの追加情報                                                                                                                                                                                                                                  |
-| dbFlavorId                                   | Body | UUID    | X  | DBインスタンス仕様の識別子<br/>- デフォルト値:原本DBインスタンス値                                                                                                                                                                                                            |
-| dbPort                                       | Body | Number  | X  | DBポート<br/>- デフォルト値:原本DBインスタンス値<br/>- 最小値:`5432`<br/>- 最大値:`45432`                                                                                                                                                                                  |
-| parameterGroupId                             | Body | UUID    | X  | パラメータグループの識別子<br/>- デフォルト値:原本DBインスタンス値                                                                                                                                                                                                               |
-| dbSecurityGroupIds                           | Body | Array   | X  | DBセキュリティグループの識別子リスト<br/>- デフォルト値:原本DBインスタンス値                                                                                                                                                                                                           |
-| userGroupIds                                 | Body | Array   | X  | ユーザーグループの識別子リスト                                                                                                                                                                                                                                     |
-| useDefaultNotification                       | Body | Boolean | X  | 基本通知の使用有無<br/>- デフォルト値:`false`                                                                                                                                                                                                                      |
-| useDeletionProtection                        | Body | Boolean | X  | 削除保護の有無<br/>- デフォルト値: `false`                                                                                                                                                                                                                         |
-| network                                      | Body | Object  | X  | ネットワーク情報オブジェクト                                                                                                                                                                                                                                         |
-| network.usePublicAccess                      | Body | Boolean | X  | 外部接続可否<br/>- デフォルト値:`false`                                                                                                                                                                                                                      |
-| network.availabilityZone                     | Body | Enum    | X  | DBインスタンスを作成するアベイラビリティゾーン<br/>- 例:`kr-pub-a`<br/>- デフォルト値:`任意のアベイラビリティゾーン`                                                                                                                                                                                    |  
-| storage                                      | Body | Object  | X  | ストレージ情報オブジェクト                                                                                                                                                                                                                                         |    
-| storage.storageType                          | Body | Enum    | X  | データストレージタイプ<br>- 例:`General SSD`                                                                                                                                                                                                                  |
-| storage.storageSize                          | Body | Number  | X  | データストレージサイズ(GB)<br/>- デフォルト値:原本DBインスタンス値<br/>- 最小値:`20`<br/>- 最大値:`2048`                                                                                                                                                                           |
-| backup                                       | Body | Object  | X  | バックアップ情報オブジェクト                                                                                                                                                                                                                                           |
-| backup.backupPeriod                          | Body | Number  | X  | バックアップの保管期間(日)<br/>- デフォルト値:原本DBインスタンス値<br/>- 最小値:`0`<br/>- 最大値:`730`                                                                                                                                                                                 |
-| backup.backupRetryCount                      | Body | Number  | X  | バックアップの再試行回数<br/>- デフォルト値:原本DBインスタンス値<br/>- 最小値:`0`<br/>- 最大値:`10`                                                                                                                                                                                    |
-
-<details><summary>例</summary>
-
-```json
-{
-    "dbInstanceName": "db-instance-replicate",
-    "description": "description",
-    "dbPort": 15432,
-    "storage": {
-        "storageSize": 100
-    }
-}
-```
-</details>
-
-#### レスポンス
-
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### DBインスタンスの昇格
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/promote
-```
-
-#### 必要権限
-
-| 権限名                                | 説明          |
-|-------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Promote | DBインスタンスの昇格 |
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Modify | DBインスタンスの最新パラメータグループを適用する |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前          | 種類 | 形式  | 必須 | 説明          |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
 
 #### レスポンス
 
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | リクエストした作業の識別子 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -2485,14 +1403,320 @@ POST /v1.0/db-instances/{dbInstanceId}/promote
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
+---
+### 現在のDBインスタンスで選択可能なDBバージョンの照会
 
-## DBインスタンス > データベース
+```http
+GET /v1.0/db-instances/{dbInstanceId}/available-db-versions
+```
 
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Get | 現在のDBインスタンスで選択可能なDBバージョンの照会 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| availableDbVersions | Body | Array | DBバージョン情報 |
+| availableDbVersions.dbVersionCode | Body | Enum | DBバージョンコード<br/>- MYSQL_V5633<br/>- MYSQL_V5715<br/>- MYSQL_V5719<br/>- MYSQL_V5726<br/>- MYSQL_V5731<br/>- MYSQL_V5733<br/>- MYSQL_V5737<br/>- MYSQL_V8018<br/>- MYSQL_V8023<br/>- MYSQL_V8028<br/>- MYSQL_V8032<br/>- MYSQL_V8033<br/>- MYSQL_V8034<br/>- MYSQL_V8035<br/>- MYSQL_V8036<br/>- MYSQL_V8040<br/>- MYSQL_V8041<br/>- MYSQL_V8042<br/>- MYSQL_V8043<br/>- MYSQL_V8044<br/>- MYSQL_V8045<br/>- MYSQL_V8405<br/>- MYSQL_V8406<br/>- MYSQL_V8407<br/>- MYSQL_V8408<br/>- MYSQL_V8409<br/>- MARIADB_V10330<br/>- MARIADB_V10611<br/>- MARIADB_V10612<br/>- MARIADB_V10616<br/>- MARIADB_V10622<br/>- MARIADB_V10625<br/>- MARIADB_V101107<br/>- MARIADB_V101108<br/>- MARIADB_V101113<br/>- MARIADB_V101116<br/>- MARIADB_V11407<br/>- MARIADB_V11410<br/>- MARIADB_V11806<br/>- POSTGRESQL_V14_6<br/>- POSTGRESQL_V14_15<br/>- POSTGRESQL_V14_17<br/>- POSTGRESQL_V14_19<br/>- POSTGRESQL_V17_2<br/>- POSTGRESQL_V17_4<br/>- POSTGRESQL_V17_6 |
+| availableDbVersions.dbMajorVersionCode | Body | Enum | DBメジャーバージョンコード<br/>- MYSQL_V56<br/>- MYSQL_V57<br/>- MYSQL_V80<br/>- MYSQL_V84<br/>- MARIADB_V103<br/>- MARIADB_V106<br/>- MARIADB_V1011<br/>- MARIADB_V114<br/>- MARIADB_V118<br/>- POSTGRES_V14<br/>- POSTGRES_V17 |
+| availableDbVersions.name | Body | String | DBバージョン名 |
+| availableDbVersions.canCreate | Body | Boolean | 新規作成可能かどうか |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "availableDbVersions": [
+        {
+            "dbVersionCode": "MYSQL_V5633",
+            "dbMajorVersionCode": "MYSQL_V56",
+            "name": "PostgreSQL V14.6",
+            "canCreate": false
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBインスタンスのバックアップ
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/backup
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Backup | DBインスタンスのバックアップ |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| backupName | Body | String | O | バックアップを識別できる名前 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "backupName": "backupName-example"
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBインスタンスバックアップ情報の照会
+
+```http
+GET /v1.0/db-instances/{dbInstanceId}/backup-info
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Get | DBインスタンスバックアップ情報の照会 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| allowAutoBackup | Body | Boolean | 自動バックアップを許可するかどうか |
+| usePeriodicAutoBackup | Body | Boolean | 予定された自動バックアップを使用するかどうか |
+| backupPeriod | Body | Number | バックアップの保管期間(日) |
+| backupRetryCount | Body | Number | バックアップの再試行回数 |
+| backupSchedules | Body | Array | バックアップスケジュールリスト |
+| backupSchedules.backupWndBgnTime | Body | Time | バックアップ開始時間 |
+| backupSchedules.backupWndDuration | Body | Enum | バックアップWindows<br/>バックアップ開始時間から設定された期間内に自動バックアップが実行されます。<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "allowAutoBackup": false,
+    "usePeriodicAutoBackup": false,
+    "backupPeriod": 1,
+    "backupRetryCount": 1,
+    "backupSchedules": [
+        {
+            "backupWndBgnTime": "00:00:00",
+            "backupWndDuration": "HALF_AN_HOUR"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBインスタンスバックアップ情報の修正
+
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/backup-info
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Modify | DBインスタンスバックアップ情報の修正 |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| allowAutoBackup | Body | Boolean | X | 自動バックアップを許可するかどうか |
+| usePeriodicAutoBackup | Body | Boolean | X | 予定された自動バックアップを使用するかどうか |
+| backupPeriod | Body | Number | X | バックアップの保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| backupRetryCount | Body | Number | X | バックアップの再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| backupSchedules | Body | Array | X | バックアップスケジュールリスト |
+| backupSchedules.backupWndBgnTime | Body | Time | O | バックアップ開始時間 |
+| backupSchedules.backupWndDuration | Body | Enum | O | バックアップWindows<br/>バックアップ開始時間から設定された期間内に自動バックアップが実行されます。<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "allowAutoBackup": false,
+    "usePeriodicAutoBackup": false,
+    "backupPeriod": 0,
+    "backupRetryCount": 0,
+    "backupSchedules": [
+        {
+            "backupWndBgnTime": "00:00:00",
+            "backupWndDuration": "HALF_AN_HOUR"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBインスタンスバックアップ後にオブジェクトストレージへエクスポート
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/backup-to-object-storage
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.BackupToObjectStorage | DBインスタンスバックアップ後にオブジェクトストレージへエクスポート |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| tenantId | Body | String | O | バックアップが保存されるオブジェクトストレージのテナントID<br/>- 最小長さ: `32`<br/>- 最大長さ: `32` |
+| username | Body | String | O | NHN CloudアカウントまたはIAMメンバーID |
+| password | Body | String | O | バックアップが保存されるオブジェクトストレージのAPIパスワード |
+| targetContainer | Body | String | O | バックアップが保存されるオブジェクトストレージのコンテナ |
+| objectPath | Body | String | O | コンテナに保存されるバックアップのパス |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "tenantId": "0123456789abcdef0123456789abcdef",
+    "username": "username-example",
+    "password": "password-example",
+    "targetContainer": "targetContainer-example",
+    "objectPath": "objectPath-example"
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
 ### データベースリスト表示
 
 ```http
@@ -2501,32 +1725,34 @@ GET /v1.0/db-instances/{dbInstanceId}/databases
 
 #### 必要権限
 
-| 権限名                                     | 説明                    |
-|------------------------------------------|------------------------|
-| RDSforPostgreSQL:DbInstanceDatabase.List | DBインスタンス内のデータベースリスト表示 |
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceDatabase.List | データベースリスト表示 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前          | 種類 | 形式  | 必須 | 説明          |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
 
 #### レスポンス
 
-| 名前                          | 種類  | 形式      | 説明                                                                                                                                                 |
-|------------------------------|------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| databases                    | Body | Array    | データベースリスト                                                                                                                                          |
-| databases.databaseId         | Body | UUID     | データベースの識別子                                                                                                                                        |
-| databases.databaseName       | Body | String   | データベース名                                                                                                                                          |
-| databases.databaseStatus     | Body | Enum     | データベースの現在状態<br/>- `STABLE`:作成済み<br/>- `CREATING`:作成中<br/>- `MODIFYING`:修正中<br/>- `SYNCING`:同期中<br/>- `DELETING`:削除中<br/>- `DELETED`:削除済み |
-| databases.createdYmdt        | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                   |
-| databases.updatedYmdt        | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                   |
-| databases.schemas            | Body | Array    | データベース内のスキーマリスト                                                                                                                                    |
-| databases.schemas.schemaName | Body | String   | スキーマ名                                                                                                                                             |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| databases | Body | Array | データベース情報 |
+| databases.databaseId | Body | UUID | データベースの識別子 |
+| databases.databaseName | Body | String | データベース名 |
+| databases.databaseStatus | Body | Enum | データベースの現在状態<br/>- STABLE: `使用可能`<br/>- CREATING: `作成中`<br/>- MODIFYING: `修正中`<br/>- DELETING: `削除中`<br/>- DELETED: `削除済み`<br/>- SYNCING: `同期中`<br/>- DELETE_ERROR: `削除失敗` |
+| databases.createdYmdt | Body | DateTime | 作成日時 |
+| databases.updatedYmdt | Body | DateTime | 修正日時 |
+| databases.schemas | Body | Array | スキーマ情報 |
+| databases.schemas.schemaName | Body | String | スキーマ名 |
+| databases.errorReason | Body | String | 削除失敗の原因 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -2537,21 +1763,26 @@ GET /v1.0/db-instances/{dbInstanceId}/databases
     },
     "databases": [
         {
-            "databaseId": "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4",
-            "databaseName": "database",
+            "databaseId": "550e8400-e29b-41d4-a716-446655440000",
+            "databaseName": "databaseName-example",
             "databaseStatus": "STABLE",
-            "createdYmdt": "2023-03-20T13:37:45+09:00",
-            "updatedYmdt": "2023-03-20T13:37:45+09:00",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00",
             "schemas": [
                 {
-                    "schemaName": "rds"
+                    "schemaName": "schemaName-example"
                 }
-            ]
+            ],
+            "errorReason": "errorReason-example"
         }
     ]
 }
 ```
+
+</p>
 </details>
+
+---
 
 ### データベース作成
 
@@ -2561,33 +1792,37 @@ POST /v1.0/db-instances/{dbInstanceId}/databases
 
 #### 必要権限
 
-| 権限名                                       | 説明                   |
-|--------------------------------------------|-----------------------|
-| RDSforPostgreSQL:DbInstanceDatabase.Create | DBインスタンス内のデータベース作成 |
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceDatabase.Create | データベース作成 |
 
 #### リクエスト
 
-| 名前          | 種類  | 形式    | 必須 | 説明          |
-|--------------|------|--------|----|--------------|
-| dbInstanceId | URL  | UUID   | O  | DBインスタンスの識別子 |
-| databaseName | Body | String | O  | データベース名   |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| databaseName | Body | String | O | データベース名 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
-    "databaseName": "database"
+    "databaseName": "databaseName-example"
 }
 ```
+
+</p>
 </details>
 
 #### レスポンス
 
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | リクエストした作業の識別子 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -2596,60 +1831,14 @@ POST /v1.0/db-instances/{dbInstanceId}/databases
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-### データベースの修正
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/databases/{databaseId}
-```
-
-#### 必要権限
-
-| 権限名                                       | 説明                   |
-|--------------------------------------------|-----------------------|
-| RDSforPostgreSQL:DbInstanceDatabase.Modify | DBインスタンス内のデータベース修正 |
-
-#### リクエスト
-
-| 名前                      | 種類  | 形式     | 必須 | 説明                                                                                         |
-|--------------------------|------|---------|----|---------------------------------------------------------------------------------------------|
-| dbInstanceId             | URL  | UUID    | O  | DBインスタンスの識別子                                                                               |
-| databaseId               | URL  | UUID    | O  | データベースの識別子                                                                                |
-| databaseName             | Body | String  | O  | データベース名                                                                                  |
-| applyHbaRulesImmediately | Body | Boolean | X  | 関連するアクセス制御ルールを即時適用するかどうか<br/>- データベース名変更時、以前のデータベース名で設定されたアクセス制御ルールが存在する場合、変更された名前で反映します。 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "databaseName": "database-1"
-}
-```
-</details>
-
-#### レスポンス
-
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
+---
 
 ### データベース削除
 
@@ -2659,26 +1848,27 @@ DELETE /v1.0/db-instances/{dbInstanceId}/databases/{databaseId}
 
 #### 必要権限
 
-| 権限名                                       | 説明                   |
-|--------------------------------------------|-----------------------|
-| RDSforPostgreSQL:DbInstanceDatabase.Delete | DBインスタンス内のデータベースを削除 |
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceDatabase.Delete | データベース削除 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前          | 種類 | 形式  | 必須 | 説明          |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-| databaseId   | URL | UUID | O  | データベースの識別子 |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| databaseId | URL | UUID | O | データベースの識別子 |
 
 #### レスポンス
 
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | リクエストした作業の識別子 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -2687,13 +1877,73 @@ DELETE /v1.0/db-instances/{dbInstanceId}/databases/{databaseId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-## DBインスタンス > ユーザー
+---
 
+### データベースの修正
+
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/databases/{databaseId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceDatabase.Modify | データベースの修正 |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| databaseId | URL | UUID | O | データベースの識別子 |
+| applyHbaRulesImmediately | Body | Boolean | X | 関連するアクセス制御ルールを即時適用するかどうか<br/>- デフォルト値: `false` |
+| databaseName | Body | String | O | データベース名 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "applyHbaRulesImmediately": false,
+    "databaseName": "databaseName-example"
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
 ### ユーザーリスト表示
 
 ```http
@@ -2702,31 +1952,32 @@ GET /v1.0/db-instances/{dbInstanceId}/db-users
 
 #### 必要権限
 
-| 権限名                                 | 説明                 |
-|--------------------------------------|---------------------|
-| RDSforPostgreSQL:DbInstanceUser.List | DBインスタンス内のユーザーリストを表示 |
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceUser.List | ユーザーリスト表示 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前          | 種類 | 形式  | 必須 | 説明          |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
 
 #### レスポンス
 
-| 名前                   | 種類  | 形式      | 説明                                                                                                                                                 |
-|-----------------------|------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbUsers               | Body | Array    | DBユーザーリスト                                                                                                                                          |
-| dbUsers.dbUserId      | Body | UUID     | DBユーザーの識別子                                                                                                                                        |
-| dbUsers.dbUserName    | Body | String   | DBユーザーアカウント名                                                                                                                                       |
-| dbUsers.authorityType | Body | Enum     | DBユーザー権限タイプ<br/>- `CRUD`:DMLクエリ実行可能な権限<br/>- `DDL`:DDLクエリ実行可能な権限                                                                          |
-| dbUsers.dbUserStatus  | Body | Enum     | DBユーザーの現在状態<br/>- `STABLE`:作成済み<br/>- `CREATING`:作成中<br/>- `MODIFYING`:修正中<br/>- `SYNCING`:同期中<br/>- `DELETING`:削除中<br/>- `DELETED`:削除済み |
-| dbUsers.createdYmdt   | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                   |
-| dbUsers.updatedYmdt   | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                   |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| dbUsers | Body | Array | DBユーザーリスト |
+| dbUsers.dbUserId | Body | UUID | DBユーザーの識別子 |
+| dbUsers.dbUserName | Body | String | DBユーザーアカウント名 |
+| dbUsers.authorityType | Body | Enum | DBユーザー権限タイプ<br/>- CUSTOM: `カスタム権限`<br/>- READ: `READ権限(読み取り専用権限)`<br/>- CRUD: `CRUD権限(読み取り権限を含む)`<br/>- DDL: `DDL権限(CRUD権限を含む)` |
+| dbUsers.dbUserStatus | Body | Enum | DBユーザーの現在状態<br/>- STABLE: `使用可能`<br/>- CREATING: `作成中`<br/>- MODIFYING: `修正中`<br/>- DELETING: `削除中`<br/>- DELETED: `削除済み`<br/>- SYNCING: `同期中`<br/>- DELETE_ERROR: `削除失敗` |
+| dbUsers.createdYmdt | Body | DateTime | 作成日時 |
+| dbUsers.updatedYmdt | Body | DateTime | 修正日時 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -2735,17 +1986,23 @@ GET /v1.0/db-instances/{dbInstanceId}/db-users
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "databases": [
+    "dbUsers": [
         {
-            "databaseId": "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4",
-            "databaseName": "database",
-            "databaseStatus": "STABLE",
-            "createdYmdt": "2023-03-20T13:37:45+09:00"
+            "dbUserId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbUserName": "dbUserName-example",
+            "authorityType": "CUSTOM",
+            "dbUserStatus": "STABLE",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
+
+</p>
 </details>
+
+---
 
 ### ユーザー作成
 
@@ -2755,39 +2012,45 @@ POST /v1.0/db-instances/{dbInstanceId}/db-users
 
 #### 必要権限
 
-| 権限名                                   | 説明                |
-|----------------------------------------|--------------------|
-| RDSforPostgreSQL:DbInstanceUser.Create | DBインスタンス内のユーザー作成 |
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceUser.Create | ユーザー作成 |
 
 #### リクエスト
 
-| 名前                   | 種類  | 形式     | 必須 | 説明                                                                       |
-|-----------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId          | URL  | UUID    | O  | DBインスタンスの識別子                                                             |
-| dbUserName            | Body | String  | O  | DBユーザーアカウント名<br/>- 最小文字数:`1`<br/>- 最大文字数:`20`                           |
-| dbPassword            | Body | String  | O  | DBユーザーアカウントパスワード<br/>- 最小文字数:`1`<br/>- 最大文字数:`100`                          |
-| authorityType         | Body | Enum    | O  | DBユーザー権限タイプ<br/>- `CRUD`:DMLクエリ実行可能な権限<br/>- `DDL`:DDLクエリ実行可能な権限 |
-| createDefaultHbaRules | Body | Boolean | X  | 基本アクセス制御ルールの作成可否                                                          |
-| address               | Body | String  | X  | 基本アクセス制御ルール作成時に使用する接続アドレス                                               |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbUserName | Body | String | O | DBユーザーアカウント名 |
+| dbPassword | Body | String | O | DBユーザーアカウントパスワード |
+| authorityType | Body | Enum | O | DBユーザー権限タイプ<br/>- CUSTOM: `カスタム権限`<br/>- READ: `読み取り権限`<br/>- CRUD: `CRUD権限`<br/>- DDL: `DDL権限` |
+| createDefaultHbaRules | Body | Boolean | X | 基本アクセス制御ルールの作成可否<br/>- デフォルト値: `false` |
+| address | Body | String | X | 接続アドレス |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "authorityType": "CRUD"
+    "dbUserName": "dbUserName-example",
+    "dbPassword": "dbPassword-example",
+    "authorityType": "CUSTOM",
+    "createDefaultHbaRules": false,
+    "address": "address-example"
 }
 ```
+
+</p>
 </details>
 
 #### レスポンス
 
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | リクエストした作業の識別子 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -2796,63 +2059,14 @@ POST /v1.0/db-instances/{dbInstanceId}/db-users
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-### ユーザー修正
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
-```
-
-#### 必要権限
-
-| 権限名                                   | 説明                |
-|----------------------------------------|--------------------|
-| RDSforPostgreSQL:DbInstanceUser.Modify | DBインスタンス内のユーザー修正 |
-
-#### リクエスト
-
-| 名前                      | 種類  | 形式     | 必須 | 説明                                                                                         |
-|--------------------------|------|---------|----|---------------------------------------------------------------------------------------------|
-| dbInstanceId             | URL  | UUID    | O  | DBインスタンスの識別子                                                                               |
-| dbUserId                 | URL  | UUID    | O  | DBユーザーの識別子                                                                                |
-| dbUserName               | Body | String  | X  | DBユーザーアカウント名<br/>- 最小文字数:`1`<br/>- 最大文字数:`20`                                             |
-| dbPassword               | Body | String  | X  | DBユーザーアカウントパスワード<br/>- 最小文字数:`1`<br/>- 最大文字数:`100`                                            |
-| authorityType            | Body | Enum    | X  | DBユーザー権限タイプ<br/>- `CRUD`:DMLクエリ実行可能な権限<br/>- `DDL`:DDLクエリ実行可能な権限                  |
-| applyHbaRulesImmediately | Body | Boolean | X  | 関連するアクセス制御ルールを即時適用するかどうか<br/>- ユーザーアカウント名変更時に以前のユーザーアカウント名で設定されたアクセス制御ルールが存在する場合、変更された名前で反映します。 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "dbUserName": "db-user-1",
-    "dbPassword": "new-password"
-}
-```
-</details>
-
-#### レスポンス
-
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
+---
 
 ### ユーザー削除
 
@@ -2862,26 +2076,27 @@ DELETE /v1.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
 
 #### 必要権限
 
-| 権限名                                   | 説明                |
-|----------------------------------------|--------------------|
-| RDSforPostgreSQL:DbInstanceUser.Delete | DBインスタンス内のユーザー削除 |
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceUser.Delete | ユーザー削除 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前          | 種類 | 形式  | 必須 | 説明          |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-| dbUserId     | URL | UUID | O  | DBユーザーの識別子 |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbUserId | URL | UUID | O | ユーザーの識別子 |
 
 #### レスポンス
 
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | リクエストした作業の識別子 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -2890,13 +2105,140 @@ DELETE /v1.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-## DBインスタンス > アクセス制御
+---
 
+### ユーザー修正
+
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceUser.Modify | ユーザー修正 |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbUserId | URL | UUID | O | ユーザーの識別子 |
+| dbUserName | Body | String | X | DBユーザーアカウント名 |
+| dbPassword | Body | String | X | DBユーザーアカウントパスワード |
+| authorityType | Body | Enum | X | DBユーザー権限<br/>- CUSTOM: `カスタム権限`<br/>- READ: `読み取り権限`<br/>- CRUD: `CRUD権限`<br/>- DDL: `DDL権限` |
+| applyHbaRulesImmediately | Body | Boolean | X | アクセス制御変更事項の即時適用可否<br/>- デフォルト値: `false` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "dbUserName": "dbUserName-example",
+    "dbPassword": "dbPassword-example",
+    "authorityType": "CUSTOM",
+    "applyHbaRulesImmediately": false
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBインスタンス削除保護設定の変更
+
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/deletion-protection
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Modify | DBインスタンス削除保護設定の変更 |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| useDeletionProtection | Body | Boolean | O | 削除保護の有無 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "useDeletionProtection": false
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
+
+### DBインスタンスの強制再起動
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/force-restart
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.ForceRestart | DBインスタンスの強制再起動 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
 ### アクセス制御ルールリストを表示
 
 ```http
@@ -2905,41 +2247,42 @@ GET /v1.0/db-instances/{dbInstanceId}/hba-rules
 
 #### 必要権限
 
-| 権限名                                | 説明                      |
-|-------------------------------------|--------------------------|
-| RDSforPostgreSQL:DbInstanceHba.List | DBインスタンス内のアクセス制御ルールリストを表示 |
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceHba.List | アクセス制御ルールリストを表示 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前          | 種類 | 形式  | 必須 | 説明          |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
 
 #### レスポンス
 
-| 名前                             | 種類  | 形式     | 説明                                                                                                                                                  |
-|---------------------------------|------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------|
-| hbaRules                        | Body | Array   | アクセス制御ルールリスト                                                                                                                                         |
-| hbaRules.hbaRuleId              | Body | UUID    | アクセス制御ルールの識別子                                                                                                                                       |
-| hbaRules.hbaRuleStatus          | Body | Enum    | アクセス制御ルールの現在状態<br/>- `CREATED`:作成済み<br/>- `APPLIED`:適用済み<br/>- `CREATING`:作成中<br/>- `MODIFYING`:修正中<br/>- `DELETING`:削除中<br/>- `DELETED`:削除済み |
-| hbaRules.databaseApplyType      | Body | String  | データベースルールの適用方式<br/>- `ENTIRE`:全体<br/>- `USER_CUSTOM`:ユーザー指定                                                                                      |
-| hbaRules.dbUserApplyType        | Body | Enum    | DBユーザールールの適用方式<br/>- `ENTIRE`:全体<br/>- `USER_CUSTOM`:ユーザー指定                                                                                      |
-| hbaRules.databases              | Body | Array   | ユーザー指定のデータベースリスト                                                                                                                                    |
-| hbaRules.databases.databaseId   | Body | UUID    | ユーザー指定のデータベースの識別子                                                                                                                                  |
-| hbaRules.databases.databaseName | Body | String  | ユーザー指定のデータベース名                                                                                                                                    |
-| hbaRules.dbUsers                | Body | Array   | ユーザー指定のDBユーザーリスト                                                                                                                                    |
-| hbaRules.dbUsers.dbUserId       | Body | UUID    | ユーザー指定のDBユーザーの識別子                                                                                                                                  |
-| hbaRules.dbUsers.dbUserName     | Body | String  | ユーザー指定のDBユーザーアカウント名                                                                                                                                 |
-| hbaRules.address                | Body | String  | 接続アドレス                                                                                                                                               |
-| hbaRules.authMethod             | Body | Enum    | 認証方式<br/>- `TRUST`:トラスト(パスワード不要)<br/>- `REJECT`:接続ブロック<br/>- `SCRAM_SHA_256`:パスワード(SCRAM-SHA-256)                                                 |
-| hbaRules.reservedAction         | Body | Enum    | 予約作業<br/>- `NONE`:なし<br/>- `CREATE`:作成予約(適用必要)<br/>- `MODIFY`:修正予約(適用必要)<br/>- `DELETE`:削除予約(適用必要)                                        |
-| hbaRules.order                  | Body | Number  | 適用順序                                                                                                                                               |
-| hbaRules.applicable             | Body | Boolean | 適用可否<br/>- 適用不可状態のルールは無視される                                                                                                                     |
-| needToApply                     | Body | Boolean | 変更内容の適用が必要かどうか                                                                                                                                       |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| hbaRules | Body | Array | アクセス制御ルールリスト |
+| hbaRules.hbaRuleId | Body | UUID | アクセス制御ルールの識別子 |
+| hbaRules.hbaRuleStatus | Body | Enum | アクセス制御ルールの現在状態<br/>- CREATED: `作成済み`<br/>- APPLIED: `適用済み`<br/>- CREATING: `作成中`<br/>- MODIFYING: `修正中`<br/>- DELETING: `削除中`<br/>- DELETED: `削除済み` |
+| hbaRules.databaseApplyType | Body | Enum | データベース適用タイプ<br/>- ENTIRE: `全体`<br/>- USER_CUSTOM: `ユーザー指定` |
+| hbaRules.dbUserApplyTypeCode | Body | Enum | DBユーザー適用タイプ<br/>- ENTIRE: `全体`<br/>- USER_CUSTOM: `ユーザー指定` |
+| hbaRules.databases | Body | Array | ユーザー指定のデータベースリスト |
+| hbaRules.databases.databaseId | Body | UUID | データベースID |
+| hbaRules.databases.databaseName | Body | String | データベース名 |
+| hbaRules.dbUsers | Body | Array | ユーザー指定のDBユーザーリスト |
+| hbaRules.dbUsers.dbUserId | Body | UUID | DBユーザーID |
+| hbaRules.dbUsers.dbUserName | Body | String | DBユーザー名 |
+| hbaRules.address | Body | String | 接続アドレス |
+| hbaRules.authMethod | Body | Enum | 認証方式<br/>- TRUST: `トラスト(パスワード不要)`<br/>- REJECT: `接続ブロック`<br/>- SCRAM_SHA_256: `パスワード(SCRAM-SHA-256)` |
+| hbaRules.reservedAction | Body | Enum | 予約作業<br/>- NONE: `なし`<br/>- CREATE: `作成予約(適用必要)`<br/>- MODIFY: `修正予約(適用必要)`<br/>- DELETE: `削除予約(適用必要)` |
+| hbaRules.order | Body | Number | 適用順序 |
+| hbaRules.applicable | Body | Boolean | 適用可否 |
+| needToApply | Body | Boolean | 変更の適用要否 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -2950,27 +2293,37 @@ GET /v1.0/db-instances/{dbInstanceId}/hba-rules
     },
     "hbaRules": [
         {
-            "hbaRuleId": "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4",
-            "hbaRuleStatus": "APPLIED",
-            "databaseApplyType": "USER_CUSTOM",
-            "dbUserApplyType": "ENTIRE",
+            "hbaRuleId": "550e8400-e29b-41d4-a716-446655440000",
+            "hbaRuleStatus": "CREATED",
+            "databaseApplyType": "ENTIRE",
+            "dbUserApplyTypeCode": "ENTIRE",
             "databases": [
                 {
-                    "databaseId": "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4",
-                    "databaseName": "database"
+                    "databaseId": "550e8400-e29b-41d4-a716-446655440000",
+                    "databaseName": "databaseName-example"
                 }
             ],
-            "dbUsers": [],
-            "address": "0.0.0.0/0",
+            "dbUsers": [
+                {
+                    "dbUserId": "550e8400-e29b-41d4-a716-446655440000",
+                    "dbUserName": "dbUserName-example"
+                }
+            ],
+            "address": "address-example",
             "authMethod": "TRUST",
             "reservedAction": "NONE",
-            "order": 0,
-            "applicable": true
+            "order": 1,
+            "applicable": false
         }
-    ]
+    ],
+    "needToApply": false
 }
 ```
+
+</p>
 </details>
+
+---
 
 ### アクセス制御ルールの追加
 
@@ -2980,45 +2333,49 @@ POST /v1.0/db-instances/{dbInstanceId}/hba-rules
 
 #### 必要権限
 
-| 権限名                                  | 説明                     |
-|---------------------------------------|-------------------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:DbInstanceHba.Create | DBインスタンス内のアクセス制御ルール追加 |
 
 #### リクエスト
 
-| 名前               | 種類  | 形式    | 必須 | 説明                                                                                                  |
-|-------------------|------|--------|----|------------------------------------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID   | O  | DBインスタンスの識別子                                                                                        |
-| databaseApplyType | Body | String | O  | データベースルール適用方式<br/>- `ENTIRE`:全体<br/>- `USER_CUSTOM`:ユーザー指定                                      |
-| dbUserApplyType   | Body | Enum   | O  | DBユーザールール適用方式<br/>- `ENTIRE`:全体<br/>- `USER_CUSTOM`:ユーザー指定                                      |
-| databaseIds       | Body | Array  | X  | ユーザー指定のデータベースの識別子リスト                                                                               |
-| dbUserIds         | Body | Array  | X  | ユーザー指定のDBユーザーの識別子リスト                                                                               |
-| address           | Body | String | O  | 接続アドレス<br/>- CIDR形式、ホスト名またはドメイン形式で入力                                                            |
-| authMethod        | Body | Enum   | O  | 認証方式<br/>- `TRUST`:トラスト(パスワード不要)<br/>- `REJECT`:接続ブロック<br/>- `SCRAM_SHA_256`:パスワード(SCRAM-SHA-256) |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| connectionTypeCode | Body | Enum | X | アクセス制御レコードタイプ<br/>- HOST: `TCP/IP接続時に有効`<br/>- HOST_NO_SSL: `SSL暗号化を使用しない接続時のみ有効` |
+| databaseApplyType | Body | Enum | O | データベース適用タイプ<br/>- ENTIRE: `全体`<br/>- USER_CUSTOM: `ユーザー指定` |
+| dbUserApplyType | Body | Enum | O | DBユーザー適用タイプ<br/>- ENTIRE: `全体`<br/>- USER_CUSTOM: `ユーザー指定` |
+| databaseIds | Body | Array | X | データベースの識別子リスト |
+| dbUserIds | Body | Array | X | DBユーザーの識別子リスト |
+| address | Body | String | O | 接続アドレス |
+| authMethod | Body | Enum | O | 認証方式<br/>- TRUST: `トラスト(パスワード不要)`<br/>- REJECT: `接続ブロック`<br/>- SCRAM_SHA_256: `パスワード(SCRAM-SHA-256)` |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
+    "connectionTypeCode": "HOST",
     "databaseApplyType": "ENTIRE",
-    "dbUserApplyType": "USER_CUSTOM",
-    "databaseIds": [], 
-    "dbUserIds": [
-        "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4"
-    ],
-    "address": "0.0.0.0/0",
+    "dbUserApplyType": "ENTIRE",
+    "databaseIds": [],
+    "dbUserIds": [],
+    "address": "address-example",
     "authMethod": "TRUST"
 }
 ```
+
+</p>
 </details>
 
 #### レスポンス
 
-| 名前       | 種類  | 形式  | 説明           |
-|-----------|------|------|---------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | hbaRuleId | Body | UUID | アクセス制御ルールの識別子 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -3027,151 +2384,14 @@ POST /v1.0/db-instances/{dbInstanceId}/hba-rules
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "hbaRuleId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "hbaRuleId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-### アクセス制御ルールの修正
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/hba-rules/{hbaRuleId}
-```
-
-#### 必要権限
-
-| 権限名                                  | 説明                     |
-|---------------------------------------|-------------------------|
-| RDSforPostgreSQL:DbInstanceHba.Modify | DBインスタンス内のアクセス制御ルール修正 |
-
-#### リクエスト
-
-| 名前               | 種類  | 形式    | 必須 | 説明                                                                                                  |
-|-------------------|------|--------|----|------------------------------------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID   | O  | DBインスタンスの識別子                                                                                        |
-| hbaRuleId         | URL  | UUID   | O  | アクセス制御ルールの識別子                                                                                       |
-| databaseApplyType | Body | String | O  | データベースルールの適用方式<br/>- `ENTIRE`:全体<br/>- `USER_CUSTOM`:ユーザー指定                                      |
-| dbUserApplyType   | Body | Enum   | O  | DBユーザールールの適用方式<br/>- `ENTIRE`:全体<br/>- `USER_CUSTOM`:ユーザー指定                                      |
-| databaseIds       | Body | Array  | X  | ユーザー指定のデータベースの識別子リスト                                                                               |
-| dbUserIds         | Body | Array  | X  | ユーザー指定のDBユーザーの識別子リスト                                                                               |
-| address           | Body | String | O  | 接続アドレス<br/>- CIDR形式、ホスト名またはドメイン形式で入力                                                            |
-| authMethod        | Body | Enum   | O  | 認証方式<br/>- `TRUST`:トラスト(パスワード不要)<br/>- `REJECT`:接続ブロック<br/>- `SCRAM_SHA_256`:パスワード(SCRAM-SHA-256) |
-
-<details><summary>例</summary>
-
-```json
-{
-    "databaseApplyType": "ENTIRE",
-    "dbUserApplyType": "ENTIRE",
-    "databaseIds": [], 
-    "dbUserIds": [],
-    "address": "0.0.0.0/0",
-    "authMethod": "REJECT"
-}
-```
-</details>
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
-
-### アクセス制御ルールの削除
-
-```http
-DELETE /v1.0/db-instances/{dbInstanceId}/hba-rules/{hbaRuleId}
-```
-
-#### 必要権限
-
-| 権限名                                  | 説明                     |
-|---------------------------------------|-------------------------|
-| RDSforPostgreSQL:DbInstanceHba.Delete | DBインスタンス内のアクセス制御ルール削除 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前          | 種類 | 形式  | 必須 | 説明           |
-|--------------|-----|------|----|---------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-| hbaRuleId    | URL | UUID | O  | アクセス制御ルールの識別子 |
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
-
-### アクセス制御ルールの順序調整
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/hba-rules/orders
-```
-
-#### 必要権限
-
-| 権限名                                  | 説明                     |
-|---------------------------------------|-------------------------|
-| RDSforPostgreSQL:DbInstanceHba.Modify | DBインスタンス内のアクセス制御ルール修正 |
-
-#### リクエスト
-
-| 名前          | 種類 | 形式  | 必須 | 説明                                 |
-|--------------|-----|------|----|-------------------------------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子                       |
-| hbaRuleIds   | URL | Body | O  | アクセス制御ルールの識別子リスト<br/>- リクエストした順序どおりに調整 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "hbaRuleIds": [
-        "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4"
-    ]
-}
-```
-</details>
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
+---
 
 ### アクセス制御ルールを適用
 
@@ -3181,25 +2401,26 @@ POST /v1.0/db-instances/{dbInstanceId}/hba-rules/apply
 
 #### 必要権限
 
-| 権限名                                  | 説明          |
-|---------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Modify    | DBインスタンスの修正 |
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Modify | DBインスタンスの修正 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前          | 種類 | 形式  | 必須 | 説明          |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
 
 #### レスポンス
 
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | リクエストした作業の識別子 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -3208,12 +2429,1239 @@ POST /v1.0/db-instances/{dbInstanceId}/hba-rules/apply
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
+---
+
+### アクセス制御ルールの順序調整
+
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/hba-rules/orders
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceHba.Modify | DBインスタンス内のアクセス制御ルール修正 |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| hbaRuleIds | Body | Array | O | 整列されたアクセス制御ルールIDリスト(リクエストした順序どおりに保存) |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "hbaRuleIds": []
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
+
+### アクセス制御ルールの削除
+
+```http
+DELETE /v1.0/db-instances/{dbInstanceId}/hba-rules/{hbaRuleId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceHba.Delete | DBインスタンス内のアクセス制御ルール削除 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| hbaRuleId | URL | UUID | O | アクセス制御ルールの識別子 |
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
+
+### アクセス制御ルールの修正
+
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/hba-rules/{hbaRuleId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceHba.Modify | DBインスタンス内のアクセス制御ルール修正 |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| hbaRuleId | URL | UUID | O | アクセス制御ルールの識別子 |
+| connectionTypeCode | Body | Enum | X | アクセス制御レコードタイプ<br/>- HOST: `TCP/IP接続時に有効`<br/>- HOST_NO_SSL: `SSL暗号化を使用しない接続時のみ有効` |
+| databaseApplyType | Body | Enum | O | データベース適用タイプ<br/>- ENTIRE: `全体`<br/>- USER_CUSTOM: `ユーザー指定` |
+| dbUserApplyType | Body | Enum | O | DBユーザー適用タイプ<br/>- ENTIRE: `全体`<br/>- USER_CUSTOM: `ユーザー指定` |
+| databaseIds | Body | Array | X | データベースの識別子リスト |
+| dbUserIds | Body | Array | X | DBユーザーの識別子リスト |
+| address | Body | String | O | 接続アドレス |
+| authMethod | Body | Enum | O | 認証方式<br/>- TRUST: `トラスト(パスワード不要)`<br/>- REJECT: `接続ブロック`<br/>- SCRAM_SHA_256: `パスワード(SCRAM-SHA-256)` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "connectionTypeCode": "HOST",
+    "databaseApplyType": "ENTIRE",
+    "dbUserApplyType": "ENTIRE",
+    "databaseIds": [],
+    "dbUserIds": [],
+    "address": "address-example",
+    "authMethod": "TRUST"
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
+### 高可用性情報の照会
+
+```http
+GET /v1.0/db-instances/{dbInstanceId}/high-availability
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:HighAvailability.Get | 高可用性情報照会 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| haStatus | Body | Enum | 高可用性状態<br/>- CREATED: `作成済み`<br/>- STABLE: `正常`<br/>- PAUSING: `一時停止中`<br/>- DISABLE: `停止`<br/>- DISABLE_MASTER_IN_REPLICATION: `マスター異常複製検知による高可用性停止`<br/>- DISABLE_MHA_PROCESS: `高可用性プロセス停止`<br/>- DISABLE_REPLICATION_STOP: `複製停止による高可用性停止`<br/>- DISABLE_REPLICATION_DELAY: `複製遅延による高可用性停止`<br/>- FAILOVER_STARTED: `フェイルオーバー開始`<br/>- FAILOVER_FAILED: `フェイルオーバー失敗`<br/>- FAILOVER_COMPLETED: `フェイルオーバー完了`<br/>- DELETED: `削除済み`<br/>- PAUSED: `一時停止`<br/>- PAUSED_DUE_TO_TASK: `作業による一時停止`<br/>- MASTER_FAILURE_DETECTION: `マスター障害検知` |
+| pingInterval | Body | Number | Ping間隔(秒) |
+| failoverReplWaitingTime | Body | Number | フェイルオーバー複製遅延待機時間(秒) |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "haStatus": "CREATED",
+    "pingInterval": 1,
+    "failoverReplWaitingTime": 1
+}
+```
+
+</p>
+</details>
+
+---
+
+### 高可用性を修正する
+
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/high-availability
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:HighAvailability.Modify | 高可用性を修正する |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| useHighAvailability | Body | Boolean | O | 高可用性の使用有無 |
+| pingInterval | Body | Number | X | Ping間隔(秒)<br/>- 最小値: `1`<br/>- 最大値: `600` |
+| failoverReplWaitingTime | Body | Number | X | フェイルオーバー複製遅延待機時間(秒)<br/>- 最小値: `-1` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "useHighAvailability": false,
+    "pingInterval": 1,
+    "failoverReplWaitingTime": 1
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 高可用性の一時停止
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/high-availability/pause
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:HighAvailability.Pause | 高可用性の一時停止 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 高可用性の復旧
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/high-availability/repair
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:HighAvailability.Repair | 高可用性の復旧 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 高可用性の再起動
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/high-availability/resume
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:HighAvailability.Resume | 高可用性の再起動 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 高可用性の分離
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/high-availability/split
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:HighAvailability.Split | 高可用性の分離 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+### DBインスタンスメンテナンス情報照会
+
+```http
+GET /v1.0/db-instances/{dbInstanceId}/maintenance-info
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Get | DBインスタンスメンテナンス情報照会 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| allowAutoMaintenance | Body | Boolean | 自動メンテナンスを許可するかどうか |
+| useAutoStorageCleanup | Body | Boolean | 自動ストレージクリーンアップを使用するかどうか |
+| maintWndBgnTime | Body | Time | 自動メンテナンス開始時間 |
+| maintWndDuration | Body | Enum | メンテナンス期間<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+| logRetentionPeriod | Body | Number | ログ保管期間(日) |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "allowAutoMaintenance": false,
+    "useAutoStorageCleanup": false,
+    "maintWndBgnTime": "00:00:00",
+    "maintWndDuration": "HALF_AN_HOUR",
+    "logRetentionPeriod": 1
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBインスタンスメンテナンス情報修正
+
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/maintenance-info
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Modify | DBインスタンスメンテナンス情報修正 |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| allowAutoMaintenance | Body | Boolean | X | 自動メンテナンスを許可するかどうか |
+| useAutoStorageCleanup | Body | Boolean | X | 自動ストレージクリーンアップを使用するかどうか |
+| maintWndBgnTime | Body | Time | X | 自動メンテナンス開始時間 |
+| maintWndDuration | Body | Enum | X | メンテナンス期間<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+| logRetentionPeriod | Body | Number | X | ログ保管期間(日)<br/>- 最小値: `1`<br/>- 最大値: `30` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "allowAutoMaintenance": false,
+    "useAutoStorageCleanup": false,
+    "maintWndBgnTime": "00:00:00",
+    "maintWndDuration": "HALF_AN_HOUR",
+    "logRetentionPeriod": 1
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+### DBインスタンスネットワーク情報の照会
+
+```http
+GET /v1.0/db-instances/{dbInstanceId}/network-info
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Get | DBインスタンスネットワーク情報の照会 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| availabilityZone | Body | Enum | DBインスタンスを作成するアベイラビリティゾーン |
+| subnet | Body | Object | サブネットオブジェクト |
+| subnet.subnetId | Body | UUID | サブネットの識別子 |
+| subnet.subnetName | Body | String | サブネットを識別できる名前 |
+| subnet.subnetCidr | Body | String | サブネットのCIDR |
+| subnet.publicAccessible | Body | Boolean | 外部接続可否 |
+| endPoints | Body | Array | 接続情報リスト |
+| endPoints.domain | Body | String | ドメイン |
+| endPoints.ipAddress | Body | String | IPアドレス |
+| endPoints.endPointType | Body | String | 接続情報タイプ |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "availabilityZone": "kr-pub-a",
+    "subnet": {
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "subnetName": "subnetName-example",
+        "subnetCidr": "192.168.0.0/24",
+        "publicAccessible": false
+    },
+    "endPoints": [
+        {
+            "domain": "domain-example",
+            "ipAddress": "192.168.0.1",
+            "endPointType": "https://example.com"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBインスタンスネットワーク情報の修正
+
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/network-info
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Modify | DBインスタンスネットワーク情報の修正 |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| usePublicAccess | Body | Boolean | O | 外部接続可否 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "usePublicAccess": false
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBインスタンスの昇格
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/promote
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Promote | DBインスタンスの昇格 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+### リードレプリカの作成
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/replicate
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Replicate | リードレプリカの作成 |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceName | Body | String | O | DBインスタンスを識別できる名前 |
+| description | Body | String | X | DBインスタンスの追加情報 |
+| dbFlavorId | Body | UUID | X | DBインスタンス仕様の識別子 |
+| dbPort | Body | Number | X | DBポート<br/>- 最小値: 5432、最大値: 45432 |
+| parameterGroupId | Body | UUID | X | パラメータグループの識別子 |
+| dbSecurityGroupIds | Body | Array | X | DBセキュリティグループの識別子リスト |
+| userGroupIds | Body | Array | X | ユーザーグループの識別子リスト |
+| useDefaultNotification | Body | Boolean | X | 基本通知の使用有無<br/>- デフォルト値: `false` |
+| useDeletionProtection | Body | Boolean | X | 削除保護の有無<br/>- デフォルト値: `false` |
+| network | Body | Object | X | ネットワーク情報オブジェクト |
+| network.usePublicAccess | Body | Boolean | X | 外部接続可否<br/>- デフォルト値: `false` |
+| network.availabilityZone | Body | Enum | X | DBインスタンスを作成するアベイラビリティゾーン |
+| storage | Body | Object | X | ストレージ情報オブジェクト |
+| storage.storageType | Body | Enum | X | データストレージタイプ |
+| storage.storageSize | Body | Number | X | データストレージサイズ(GB)<br/>- 最小値: `20`<br/>- 最大値: `2048` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName-example",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useDefaultNotification": false,
+    "useDeletionProtection": false,
+    "network": {
+        "usePublicAccess": false,
+        "availabilityZone": "kr-pub-a"
+    },
+    "storage": {
+        "storageType": "General SSD",
+        "storageSize": 20
+    }
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBインスタンスの再起動
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/restart
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Restart | DBインスタンスの再起動 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBインスタンス復元情報の照会
+
+```http
+GET /v1.0/db-instances/{dbInstanceId}/restoration-info
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Get | DBインスタンス復元情報の照会 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| oldestRestorableYmdt | Body | DateTime | 最も古い復元可能時間 |
+| latestRestorableYmdt | Body | DateTime | 最も最新の復元可能時間 |
+| restorableBackups | Body | Array | 復元可能なバックアップリスト |
+| restorableBackups.backupId | Body | UUID | バックアップの識別子 |
+| restorableBackups.backupName | Body | String | バックアップ名 |
+| restorableBackups.backupStatus | Body | Enum | バックアップ状態<br/>- BACKING_UP: `バックアップ中(スピナー)`<br/>- VERIFYING: `検証中(スピナー)`<br/>- COMPLETED: `使用可能(緑色アイコン)`<br/>- DELETING: `削除中(スピナー)`<br/>- DELETED: `削除済み(グレーアイコン)`<br/>- ERROR: `エラー(赤色アイコン)` |
+| restorableBackups.dbInstanceId | Body | UUID | 原本DBインスタンスの識別子 |
+| restorableBackups.dbInstanceName | Body | String | 原本DBインスタンス名 |
+| restorableBackups.dbVersion | Body | Enum | DBエンジンタイプ |
+| restorableBackups.backupType | Body | Enum | バックアップタイプ<br/>- AUTO<br/>- MANUAL |
+| restorableBackups.backupSize | Body | Number | バックアップサイズ |
+| restorableBackups.failoverCount | Body | Number | フェイルオーバー回数 |
+| restorableBackups.walFileName | Body | String | WALファイル名 |
+| restorableBackups.createdYmdt | Body | DateTime | バックアップ作成日時 |
+| restorableBackups.updatedYmdt | Body | DateTime | バックアップ更新日時 |
+| restorableBackups.startYmdt | Body | DateTime | バックアップ開始日時 |
+| restorableBackups.completedYmdt | Body | DateTime | バックアップ完了日時 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "oldestRestorableYmdt": "2023-12-31T15:00:00+09:00",
+    "latestRestorableYmdt": "2023-12-31T15:00:00+09:00",
+    "restorableBackups": [
+        {
+            "backupId": "550e8400-e29b-41d4-a716-446655440000",
+            "backupName": "backupName-example",
+            "backupStatus": "BACKING_UP",
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbInstanceName": "dbInstanceName-example",
+            "dbVersion": "POSTGRESQL_V14_17",
+            "backupType": "AUTO",
+            "backupSize": 1,
+            "failoverCount": 1,
+            "walFileName": "walFileName-example",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00",
+            "startYmdt": "2023-12-31T15:00:00+09:00",
+            "completedYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBインスタンスの復元
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/restore
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Restore | DBインスタンスの復元 |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceName | Body | String | X | DBインスタンスを識別できる名前 |
+| dbInstanceCandidateName | Body | String | X | DBインスタンスを識別できる予備マスター名 |
+| description | Body | String | X | DBインスタンスの追加情報<br/>- 最大長: `100` |
+| dbFlavorId | Body | UUID | O | DBインスタンス仕様の識別子 |
+| dbPort | Body | Number | X | DBポート<br/>- 最小値: 5432、最大値: 45432 |
+| useHighAvailability | Body | Boolean | X | 高可用性の使用有無<br/>- デフォルト値: `false` |
+| imageId | Body | UUID | X | イメージの識別子 |
+| pingInterval | Body | Number | X | 高可用性使用時のPing間隔(秒)<br/>- 最小値: `1`<br/>- 最大値: `600` |
+| failoverReplWaitingTime | Body | Number | X | フェイルオーバー複製遅延待機時間(秒)<br/>- 最小値: `-1` |
+| storage | Body | Object | O | ストレージ情報オブジェクト |
+| storage.storageType | Body | Enum | O | ストレージタイプ |
+| storage.storageSize | Body | Number | O | データストレージサイズ(GB)<br/>- 最小値: `20` |
+| network | Body | Object | O | ネットワーク情報オブジェクト |
+| network.subnetId | Body | UUID | O | サブネットの識別子 |
+| network.usePublicAccess | Body | Boolean | X | 外部接続可否<br/>- デフォルト値: `false` |
+| network.availabilityZone | Body | Enum | X | DBインスタンスを作成するアベイラビリティゾーン |
+| backup | Body | Object | O | バックアップ情報オブジェクト |
+| backup.backupPeriod | Body | Number | O | バックアップの保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| backup.backupRetryCount | Body | Number | X | バックアップの再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| backup.replicationRegion | Body | Enum | X | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)`<br/>- KR2: `韓国(ピョンチョン)` |
+| backup.backupSchedules | Body | Array | O | バックアップスケジュールリスト |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | O | バックアップ開始時刻 |
+| backup.backupSchedules.backupWndDuration | Body | Enum | O | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+| restore | Body | Object | O | 復元情報オブジェクト |
+| restore.restoreType | Body | Enum | O | 復元タイプ<br/>- BACKUP: `既存のバックアップを利用した復元`<br/>- TIMESTAMP: `復元可能時間内の時間を利用した時点復元` |
+| restore.restoreYmdt | Body | DateTime | X | DBインスタンス復元日時 |
+| restore.backupId | Body | UUID | X | 復元に使用するバックアップの識別子 |
+| useDefaultNotification | Body | Boolean | X | 基本通知の使用有無<br/>- デフォルト値: `false` |
+| parameterGroupId | Body | UUID | O | パラメータグループの識別子 |
+| dbSecurityGroupIds | Body | Array | X | DBセキュリティグループの識別子リスト |
+| userGroupIds | Body | Array | X | ユーザーグループの識別子リスト |
+| useDeletionProtection | Body | Boolean | X | 削除保護の有無<br/>- デフォルト値: `false` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName-example",
+    "dbInstanceCandidateName": "dbInstanceCandidateName-example",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "useHighAvailability": false,
+    "imageId": "550e8400-e29b-41d4-a716-446655440000",
+    "pingInterval": 3,
+    "failoverReplWaitingTime": 60,
+    "storage": {
+        "storageType": "General SSD",
+        "storageSize": 20
+    },
+    "network": {
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
+        "availabilityZone": "kr-pub-a"
+    },
+    "backup": {
+        "backupPeriod": 0,
+        "backupRetryCount": 0,
+        "replicationRegion": "KR1",
+        "backupSchedules": [
+            {
+                "backupWndBgnTime": "00:00:00",
+                "backupWndDuration": "HALF_AN_HOUR"
+            }
+        ]
+    },
+    "restore": {
+        "restoreType": "BACKUP",
+        "restoreYmdt": "2023-12-31T15:00:00+09:00",
+        "backupId": "550e8400-e29b-41d4-a716-446655440000"
+    },
+    "useDefaultNotification": false,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useDeletionProtection": false
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+### DBインスタンス開始
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/start
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Start | DBインスタンス開始 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBインスタンス停止
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/stop
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Stop | DBインスタンスを停止する |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBインスタンスストレージ情報の照会
+
+```http
+GET /v1.0/db-instances/{dbInstanceId}/storage-info
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Get | DBインスタンスストレージ情報の照会 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| storageType | Body | Enum | データストレージタイプ |
+| storageSize | Body | Number | データストレージサイズ(GB) |
+| storageStatus | Body | Enum | データストレージの現在状態<br/>- DELETED: `削除済み`<br/>- PENDING_DELETION: `削除猶予中`<br/>- DELETION_RESERVED: `削除予約済み（スナップショット整理待ち）`<br/>- DETACHED: `デタッチ`<br/>- ATTACHED: `アタッチ` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "storageType": "General SSD",
+    "storageSize": 1,
+    "storageStatus": "DELETED"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBインスタンスストレージ情報の修正
+
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/storage-info
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Modify | DBインスタンスストレージ情報の修正 |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| storageSize | Body | Number | O | データストレージサイズ(GB)<br/>- 最大値:`2048` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "storageSize": 1
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
 ## バックアップ
+
+### バックアップ状態
+
+| 状態           | 説明                   |
+|--------------|----------------------|
+| `BACKING_UP` | バックアップ中の場合            |
+| `COMPLETED`  | バックアップが完了した場合         |
+| `DELETING`   | バックアップが削除中の場合         |
+| `DELETED`    | バックアップが削除された場合        |
+| `ERROR`      | エラーが発生した場合            |
 
 ### バックアップリスト照会
 
@@ -3223,40 +3671,34 @@ GET /v1.0/backups
 
 #### 必要権限
 
-| 権限名                         | 説明      |
-|------------------------------|----------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:Backup.List | バックアップリスト照会 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前          | 種類   | 形式    | 必須 | 説明                                                        |
-|--------------|-------|--------|----|------------------------------------------------------------|
-| page         | Query | Number | O  | 照会するリストのページ<br/>- 最小値:`1`                                 |
-| size         | Query | Number | O  | 照会するリストのページサイズ<br/>- 最小値:`1`<br/>- 最大値:`100`             |
-| backupType   | Query | Enum   | X  | バックアップタイプ<br/>- `AUTO`:自動<br/>- `MANUAL`: 手動<br/>- デフォルト値:`全体` |
-| dbInstanceId | Query | UUID   | X  | 原本DBインスタンスの識別子                                           |
-| dbVersion    | Query | Enum   | X  | DBバージョン情報                                                  |
-
 #### レスポンス
 
-| 名前                  | 種類  | 形式      | 説明                                                                                                                                                       |
-|----------------------|------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| totalCounts          | Body | Number   | 全体バックアップリスト数                                                                                                                                                |
-| backups              | Body | Array    | バックアップリスト                                                                                                                                                    |
-| backups.backupId     | Body | UUID     | バックアップの識別子                                                                                                                                                  |
-| backups.backupName   | Body | String   | バックアップを識別できる名前                                                                                                                                          |
-| backups.backupStatus | Body | Enum     | バックアップの現在状態<br/>- `BACKING_UP`:バックアップ中の場合<br/>- `COMPLETED`:バックアップが完了した場合<br/>- `DELETING`:バックアップが削除中の場合<br/>- `DELETED`:バックアップが削除された場合<br/>- `ERROR`:エラーが発生した場合 |
-| backups.dbInstanceId | Body | UUID     | 原本DBインスタンスの識別子                                                                                                                                          |
-| backups.dbVersion    | Body | Enum     | DBバージョン情報                                                                                                                                                 |
-| backups.backupType   | Body | Enum     | バックアップタイプ<br/>- `AUTO`:自動<br/>- `MANUAL`: 手動                                                                                                               |
-| backups.backupSize   | Body | Number   | バックアップのサイズ<br/>- 単位:`バイト`                                                                                                                                    |
-| createdYmdt          | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                         |
-| updatedYmdt          | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                         |
-| completedYmdt        | Body | DateTime | 完了日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                         |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | 全体バックアップリスト数 |
+| backups | Body | Array | バックアップリスト |
+| backups.backupId | Body | UUID | バックアップの識別子 |
+| backups.backupName | Body | String | バックアップを識別できる名前 |
+| backups.backupStatus | Body | Enum | バックアップの現在状態<br/>- BACKING_UP: `バックアップ中(スピナー)`<br/>- VERIFYING: `検証中(スピナー)`<br/>- COMPLETED: `使用可能(緑アイコン)`<br/>- DELETING: `削除中(スピナー)`<br/>- DELETED: `削除済み(グレーアイコン)`<br/>- ERROR: `エラー(赤アイコン)` |
+| backups.dbInstanceId | Body | UUID | 原本DBインスタンスの識別子 |
+| backups.dbVersion | Body | Enum | DBエンジンバージョン |
+| backups.backupType | Body | Enum | バックアップタイプ<br/>- AUTO<br/>- MANUAL |
+| backups.backupSize | Body | Number | バックアップのサイズ(バイト) |
+| backups.startYmdt | Body | DateTime | 開始日時 |
+| backups.createdYmdt | Body | DateTime | 作成日時 |
+| backups.updatedYmdt | Body | DateTime | 修正日時 |
+| backups.completedYmdt | Body | DateTime | 完了日時 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -3268,170 +3710,26 @@ GET /v1.0/backups
     "totalCounts": 1,
     "backups": [
         {
-            "backupId": "0017f136-3e01-4530-94aa-20661afe6632",
-            "backupName": "backup",
-            "backupStatus": "COMPLETED",
-            "dbInstanceId": "142e6ccc-3bfb-4e1e-84f7-38861284fafd",
-            "dbVersion": "POSTGRESQL_V17_6",
+            "backupId": "550e8400-e29b-41d4-a716-446655440000",
+            "backupName": "backupName-example",
+            "backupStatus": "BACKING_UP",
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbVersion": "POSTGRESQL_V14_17",
             "backupType": "AUTO",
-            "backupSize": 4996786,
-            "createdYmdt": "2023-02-21T00:35:00+09:00",
-            "updatedYmdt": "2023-02-22T00:35:32+09:00",
-            "completedYmdt": "2023-02-22T00:35:32+09:00"
+            "backupSize": 1,
+            "startYmdt": "2023-12-31T15:00:00+09:00",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00",
+            "completedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
+
+</p>
 </details>
 
-### オブジェクトストレージにバックアップをエクスポート
-
-```http
-POST /v1.0/backups/{backupId}/export
-```
-
-#### 必要権限
-
-| 権限名                           | 説明                |
-|--------------------------------|--------------------|
-| RDSforPostgreSQL:Backup.Export | オブジェクトストレージにバックアップをエクスポート |
-
-#### リクエスト
-
-| 名前             | 種類  | 形式    | 必須 | 説明                         |
-|-----------------|------|--------|----|-----------------------------|
-| backupId        | URL  | UUID   | O  | バックアップの識別子                    |
-| tenantId        | Body | String | O  | バックアップが保存されるオブジェクトストレージのテナントID   |
-| username        | Body | String | O  | NHN CloudアカウントまたはIAMアカウントID   |
-| password        | Body | String | O  | バックアップが保存されるオブジェクトストレージのAPIパスワード |
-| targetContainer | Body | String | O  | バックアップが保存されるオブジェクトストレージのコンテナ    |
-| objectPath      | Body | String | O  | コンテナに保存されるバックアップのパス           |
-
-<details><summary>例</summary>
-
-```json
-{
-    "tenantId": "399631c404744dbbb18ce4fa2dc71a5a",
-    "username": "gildong.hong@nhn.com",
-    "password": "password",
-    "targetContainer": "/container",
-    "objectPath": "/backups/backup_file"
-}
-```
-</details>
-
-#### レスポンス
-
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### バックアップの復元
-
-```http
-POST /v1.0/backups/{backupId}/restore
-```
-
-#### 必要権限
-
-| 権限名                            | 説明     |
-|---------------------------------|---------|
-| RDSforPostgreSQL:Backup.Restore | バックアップの復元 |
-
-#### リクエスト
-
-| 名前                                      | 種類  | 形式     | 必須 | 説明                                                                                                                                                                                                                       |
-|------------------------------------------|------|---------|----|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| backupId                                 | URL  | UUID    | O  | バックアップの識別子                                                                                                                                                                                                                  |
-| dbInstanceName                           | Body | String  | O  | DBインスタンスを識別できる名前                                                                                                                                                                                                     |
-| description                              | Body | String  | X  | DBインスタンスの追加情報                                                                                                                                                                                                        |
-| dbFlavorId                               | Body | UUID    | O  | DBインスタンス仕様の識別子                                                                                                                                                                                                          |
-| dbPort                                   | Body | Number  | O  | DBポート<br/>- 最小値:`5432`<br/>- 最大値:`45432`                                                                                                                                                                                |
-| parameterGroupId                         | Body | UUID    | O  | パラメータグループの識別子                                                                                                                                                                                                             |
-| dbSecurityGroupIds                       | Body | Array   | X  | DBセキュリティグループの識別子リスト                                                                                                                                                                                                         ||network|Body|Object|O|ネットワーク情報オブジェクト|
-| userGroupIds                             | Body | Array   | X  | ユーザーグループの識別子リスト                                                                                                                                                                                                           |
-| useDefaultNotification                   | Body | Boolean | X  | 基本通知の使用有無<br/>- デフォルト値:`false`                                                                                                                                                                                            |
-| useDeletionProtection                    | Body | Boolean | X  | 削除保護の有無<br/>- デフォルト値:`false`                                                                                                                                                                                               | 
-| useHighAvailability                      | Body | Boolean | X  | 高可用性の使用有無                                                                                                                                                                                                                |
-| pingInterval                             | Body | Number  | X  | 高可用性使用時のPing間隔(秒)<br/>- 最小値:`1`<br/>- 最大値:`600`                                                                                                                                                                      |
-| failoverReplWaitingTime                  | Body | Number  | X  | 高可用性使用時のフェイルオーバー待機時間<br/>- 最小値:`-1`<br/>- -1に設定時、複製遅延が解消されるまで待機し続けます。                                                                                                                                              |                                                                                                                                                                                                                      | userGroupIds                             | Body | Array   | X  | 基本通知受信用のユーザーグループの識別子リスト                                                                                                                                                                                            |
-| network                                  | Body | Object  | O  | ネットワーク情報オブジェクト                                                                                                                                                                                                               |
-| network.subnetId                         | Body | UUID    | O  | サブネットの識別子                                                                                                                                                                                                                 |
-| network.usePublicAccess                  | Body | Boolean | X  | 外部接続可否<br/>- デフォルト値:`false`                                                                                                                                                                                            |
-| network.availabilityZone                 | Body | Enum    | X  | DBインスタンスを作成するアベイラビリティゾーン<br/>- 例:`kr-pub-a`<br/>- デフォルト値:`任意のアベイラビリティゾーン`                                                                                                                                                          |
-| storage                                  | Body | Object  | O  | ストレージ情報オブジェクト                                                                                                                                                                                                               |    
-| storage.storageType                      | Body | Enum    | O  | データストレージタイプ<br/>- 例:`General SSD`                                                                                                                                                                                       |
-| storage.storageSize                      | Body | Number  | O  | データストレージサイズ<br/>- 単位: `ギガバイト`<br/>- 最小値:`20`<br/>- 最大値:`2048`                                                                                                                                                           |
-| backup                                   | Body | Object  | O  | バックアップ情報オブジェクト                                                                                                                                                                                                                 |
-| backup.backupPeriod                      | Body | Number  | O  | バックアップの保管期間(日)<br/>- 最小値:`0`<br/>- 最大値:`730`                                                                                                                                                                               |
-| backup.backupRetryCount                  | Body | Number  | X  | バックアップの再試行回数<br/>- デフォルト値:`0`<br/>- 最小値:`0`<br/>- 最大値:`10`                                                                                                                                                                   |
-| backup.backupSchedules                   | Body | Array   | X  | バックアップスケジュールリスト                                                                                                                                                                                                                |
-| backup.backupSchedules.backupWndBgnTime  | Body | String  | O  | バックアップ開始時間<br/>- 例:`00:00:00`                                                                                                                                                                                             |
-| backup.backupSchedules.backupWndDuration | Body | Enum    | O  | バックアップDuration<br/>バックアップ開始時間から設定された期間内に自動バックアップが実行されます。<br/>- `HALF_AN_HOUR`:30分<br/>- `ONE_HOUR`:1時間<br/>- `ONE_HOUR_AND_HALF`:1時間30分<br/>- `TWO_HOURS`:2時間<br/>- `TWO_HOURS_AND_HALF`:2時間30分<br/>- `THREE_HOURS`:3時間 |
-
-<details><summary>例</summary>
-
-```json
-
-{
-  "dbInstanceName": "db-instance-restore",
-  "dbFlavorId": "50be6d9c-02d6-4594-a2d4-12010eb65ec0",
-  "dbPort": 15432,
-  "parameterGroupId": "132d383c-38e3-468a-a826-5e9a8fff15d0",
-  "network": {
-    "subnetId": "e721a9dd-dad0-4cf0-a53b-dd654ebfc683"
-  },
-  "storage": {
-    "storageType": "General SSD",
-    "storageSize": 20
-  },
-  "backup": {
-    "backupPeriod": 1,
-    "backupSchedules": [
-      {
-        "backupWndBgnTime": "00:00:00",
-        "backupWndDuration": "HALF_AN_HOUR",
-        "backupRetryExpireTime": "00:30:00"
-      }
-    ]
-  }
-}
-```
-</details>
-
-#### レスポンス
-
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
+---
 
 ### バックアップ削除
 
@@ -3441,25 +3739,26 @@ DELETE /v1.0/backups/{backupId}
 
 #### 必要権限
 
-| 権限名                           | 説明     |
-|--------------------------------|---------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:Backup.Delete | バックアップ削除 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前      | 種類 | 形式  | 必須 | 説明     |
-|----------|-----|------|----|---------|
-| backupId | URL | UUID | O  | バックアップの識別子 |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | O | バックアップの識別子 |
 
 #### レスポンス
 
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | リクエストした作業の識別子 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -3468,12 +3767,200 @@ DELETE /v1.0/backups/{backupId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
+---
+
+### バックアップをエクスポート
+
+```http
+POST /v1.0/backups/{backupId}/export
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:Backup.Export | バックアップをエクスポート |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | O | バックアップの識別子 |
+| tenantId | Body | String | O | バックアップが保存されるオブジェクトストレージのテナントID<br/>- 最小長: `32`<br/>- 最大長: `32` |
+| username | Body | String | O | NHN CloudアカウントまたはIAMメンバーID |
+| password | Body | String | O | バックアップが保存されるオブジェクトストレージのAPIパスワード |
+| targetContainer | Body | String | O | バックアップが保存されるオブジェクトストレージのコンテナ |
+| objectPath | Body | String | O | コンテナに保存されるバックアップのパス |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "tenantId": "0123456789abcdef0123456789abcdef",
+    "username": "username-example",
+    "password": "password-example",
+    "targetContainer": "targetContainer-example",
+    "objectPath": "objectPath-example"
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### バックアップの復元
+
+```http
+POST /v1.0/backups/{backupId}/restore
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:Backup.Restore | バックアップの復元 |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | O | バックアップの識別子 |
+| dbInstanceName | Body | String | O | DBインスタンスを識別できる名前 |
+| dbInstanceCandidateName | Body | String | X | DBインスタンスを識別できる予備マスター名 |
+| description | Body | String | X | DBインスタンスの追加情報 |
+| dbFlavorId | Body | UUID | O | DBインスタンス仕様の識別子 |
+| dbPort | Body | Number | O | DBポート<br/>- 最小値: 5432、最大値: 45432 |
+| parameterGroupId | Body | UUID | O | パラメータグループの識別子 |
+| dbSecurityGroupIds | Body | Array | X | DBセキュリティグループの識別子リスト |
+| userGroupIds | Body | Array | X | ユーザーグループの識別子リスト |
+| useHighAvailability | Body | Boolean | X | 高可用性の使用有無<br/>- デフォルト値: `false` |
+| useDefaultNotification | Body | Boolean | X | 基本通知の使用有無<br/>- デフォルト値: `false` |
+| useDeletionProtection | Body | Boolean | X | 削除保護の有無<br/>- デフォルト値: `false` |
+| pingInterval | Body | Number | X | Ping間隔(秒)<br/>- 最小値: `1`<br/>- 最大値: `600` |
+| failoverReplWaitingTime | Body | Number | X | フェイルオーバー複製遅延待機時間(秒)<br/>- 最小値: `-1` |
+| network | Body | Object | O | ネットワーク情報オブジェクト |
+| network.subnetId | Body | UUID | O | サブネットの識別子 |
+| network.usePublicAccess | Body | Boolean | X | 外部接続可否<br/>- デフォルト値: `false` |
+| network.availabilityZone | Body | Enum | X | DBインスタンスを作成するアベイラビリティゾーン |
+| storage | Body | Object | O | ストレージ情報オブジェクト |
+| storage.storageType | Body | Enum | O | ストレージタイプ |
+| storage.storageSize | Body | Number | O | データストレージサイズ(GB)<br/>- 最小値: `20` |
+| backup | Body | Object | O | バックアップ情報オブジェクト |
+| backup.backupPeriod | Body | Number | O | バックアップの保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| backup.backupRetryCount | Body | Number | X | バックアップの再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| backup.backupSchedules | Body | Array | O | バックアップスケジュールリスト |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | O | バックアップ開始時間 |
+| backup.backupSchedules.backupWndDuration | Body | Enum | O | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName-example",
+    "dbInstanceCandidateName": "dbInstanceCandidateName-example",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useHighAvailability": false,
+    "useDefaultNotification": false,
+    "useDeletionProtection": false,
+    "pingInterval": 1,
+    "failoverReplWaitingTime": 1,
+    "network": {
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
+        "availabilityZone": "kr-pub-a"
+    },
+    "storage": {
+        "storageType": "General SSD",
+        "storageSize": 20
+    },
+    "backup": {
+        "backupPeriod": 0,
+        "backupRetryCount": 0,
+        "backupSchedules": [
+            {
+                "backupWndBgnTime": "00:00:00",
+                "backupWndDuration": "HALF_AN_HOUR"
+            }
+        ]
+    }
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
 ## DBセキュリティグループ
+
+### DBセキュリティグループの進行状態
+
+| 状態              | 説明                     |
+|-----------------|--------------------------|
+| `NONE`          | 進行中の作業なし           |
+| `CREATING_RULE` | ルールポリシー作成中       |
+| `UPDATING_RULE` | ルールポリシー修正中       |
+| `DELETING_RULE` | ルールポリシー削除中       |
 
 ### DBセキュリティグループリストを表示
 
@@ -3483,8 +3970,8 @@ GET /v1.0/db-security-groups
 
 #### 必要権限
 
-| 権限名                                  | 説明            |
-|---------------------------------------|----------------|
+| 権限名                                  | 説明                       |
+|---------------------------------------|--------------------------|
 | RDSforPostgreSQL:DbSecurityGroup.List | DBセキュリティグループリストを表示 |
 
 #### リクエスト
@@ -3493,18 +3980,19 @@ GET /v1.0/db-security-groups
 
 #### レスポンス
 
-| 名前                                    | 種類  | 形式      | 説明                                                                                                                                                                                            |
-|----------------------------------------|------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroups                       | Body | Array    | DBセキュリティグループリスト                                                                                                                                                                                   |
-| dbSecurityGroups.dbSecurityGroupId     | Body | UUID     | DBセキュリティグループの識別子                                                                                                                                                                                 |
-| dbSecurityGroups.dbSecurityGroupName   | Body | String   | DBセキュリティグループを識別できる名前                                                                                                                                                                         |
-| dbSecurityGroups.dbSecurityGroupStatus | Body | Enum     | DBセキュリティグループの現在状態<br/>- `CREATED`:作成済み<br/>- `DELETED`:削除済み                                                                                                                                     |
-| dbSecurityGroups.description           | Body | String   | DBセキュリティグループの追加情報                                                                                                                                                                            |
-| dbSecurityGroups.progressStatus        | Body | Enum     | DBセキュリティグループの現在の進行状態<br/>- `NONE`:進行中の作業なし<br/>- `CREATING_RULE`:ルールポリシー作成中<br/>- `UPDATING_RULE`:ルールポリシー修正中<br/>- `DELETING_RULE`:ルールポリシー削除中<br/>- `APPLYING_DEFAULT_RULE`:基本ルール適用中 |
-| dbSecurityGroups.createdYmdt           | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                              |
-| dbSecurityGroups.updatedYmdt           | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                              |
+| 名前                                    | 種類  | 形式      | 説明                                                                                                                                                                                                                                                              |
+|----------------------------------------|------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| dbSecurityGroups                       | Body | Array    | DBセキュリティグループリスト                                                                                                                                                                                                                                              |
+| dbSecurityGroups.dbSecurityGroupId     | Body | UUID     | DBセキュリティグループの識別子                                                                                                                                                                                                                                            |
+| dbSecurityGroups.dbSecurityGroupName   | Body | String   | DBセキュリティグループを識別できる名前                                                                                                                                                                                                                                    |
+| dbSecurityGroups.dbSecurityGroupStatus | Body | Enum     | DBセキュリティグループの現在状態<br/>- CREATED: `作成済み`<br/>- DELETED: `削除済み`                                                                                                                                                                                       |
+| dbSecurityGroups.description           | Body | String   | DBセキュリティグループの追加情報                                                                                                                                                                                                                                         |
+| dbSecurityGroups.progressStatus        | Body | Enum     | DBセキュリティグループの現在の進行状態<br/>- NONE: `進行中の作業なし`<br/>- CREATING_RULE: `ルールポリシー作成中`<br/>- UPDATING_RULE: `ルールポリシー修正中`<br/>- DELETING_RULE: `ルールポリシー削除中`<br/>- APPLYING_DEFAULT_RULE: `基本ルール適用中` |
+| dbSecurityGroups.createdYmdt           | Body | DateTime | 作成日時                                                                                                                                                                                                                                                          |
+| dbSecurityGroups.updatedYmdt           | Body | DateTime | 修正日時                                                                                                                                                                                                                                                          |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -3515,100 +4003,22 @@ GET /v1.0/db-security-groups
     },
     "dbSecurityGroups": [
         {
-            "dbSecurityGroupId": "fe4f2aee-afbb-4c19-a5e9-eb2eab394708",
-            "dbSecurityGroupName": "dbSecurityGroup",
+            "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbSecurityGroupName": "dbSecurityGroupName-example",
             "dbSecurityGroupStatus": "CREATED",
-            "description": "description",
+            "description": "description-example",
             "progressStatus": "NONE",
-            "createdYmdt": "2023-02-19T19:18:13+09:00",
-            "updatedYmdt": "2022-02-19T19:18:13+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
+
+</p>
 </details>
 
-### DBセキュリティグループ詳細を表示
-
-```http
-GET /v1.0/db-security-groups/{dbSecurityGroupId}
-```
-
-#### 必要権限
-
-| 権限名                                 | 説明            |
-|--------------------------------------|----------------|
-| RDSforPostgreSQL:DbSecurityGroup.Get | DBセキュリティグループ詳細を表示 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前               | 種類 | 形式  | 必須 | 説明           |
-|-------------------|-----|------|----|---------------|
-| dbSecurityGroupId | URL | UUID | O  | DBセキュリティグループの識別子 |
-
-#### レスポンス
-
-| 名前                   | 種類  | 形式      | 説明                                                                                                                                                                                           |
-|-----------------------|------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId     | Body | UUID     | DBセキュリティグループの識別子                                                                                                                                                                                |
-| dbSecurityGroupName   | Body | String   | DBセキュリティグループを識別できる名前                                                                                                                                                                        |
-| dbSecurityGroupStatus | Body | Enum     | DBセキュリティグループの現在状態<br/>- `CREATED`:作成済み<br/>- `DELETED`:削除済み                                                                                                                                    |
-| description           | Body | String   | DBセキュリティグループの追加情報                                                                                                                                                                           |
-| progressStatus        | Body | Enum     | DBセキュリティグループの現在の進行状態<br/>- `NONE`:進行中の作業なし<br/>- `CREATING_RULE`:ルールポリシー作成中<br/>- `UPDATING_RULE`:ルールポリシー修正中<br/>- `DELETING_RULE`:ルールポリシー削除中<br/>- `APPLYING_DEFAULT_RULE`:基本ルール適用中 |
-| rules                 | Body | Array    | DBセキュリティグループルールリスト                                                                                                                                                                               |
-| rules.ruleId          | Body | UUID     | DBセキュリティグループルールの識別子                                                                                                                                                                             |
-| rules.description     | Body | String   | DBセキュリティグループルールの追加情報                                                                                                                                                                        |
-| rules.direction       | Body | Enum     | 通信方向<br/>- `INGRESS`:受信<br/>- `EGRESS`:送信                                                                                                                                                 |
-| rules.etherType       | Body | Enum     | Etherタイプ<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                                |
-| rules.port            | Body | Object   | ポートオブジェクト                                                                                                                                                                                        |
-| rules.port.portType   | Body | Enum     | ポートタイプ<br/>- `DB_PORT`:各DBインスタンスポート値で設定されます。<br/>- `PORT`:指定されたポート値で設定されます。<br/>- `PORT_RANGE`:指定されたポート範囲で設定されます。                                                                            |
-| rules.port.minPort    | Body | Number   | 最小ポート範囲                                                                                                                                                                                     |
-| rules.port.maxPort    | Body | Number   | 最大ポート範囲                                                                                                                                                                                     |
-| rules.cidr            | Body | String   | 許可するトラフィックの遠隔ソース                                                                                                                                                                               |
-| rules.createdYmdt     | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                             |
-| rules.updatedYmdt     | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                             |
-| createdYmdt           | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                             |
-| updatedYmdt           | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                             |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbSecurityGroup": {
-        "dbSecurityGroupId": "fe4f2aee-afbb-4c19-a5e9-eb2eab394708",
-        "dbSecurityGroupName": "dbSecurityGroup",
-        "dbSecurityGroupStatus": "CREATED",
-        "description": "description",
-        "progressStatus": "NONE",
-        "rules": [
-            {
-                "ruleId": "17c88ef6-95f1-4678-84f9-fee1b22e250d",
-                "description": "description",
-                "direction": "INGRESS",
-                "etherType": "IPV4",
-                "port": {
-                    "portType": "PORT_RANGE",
-                    "minPort": 10000,
-                    "maxPort": 10005
-                },
-                "cidr": "0.0.0.0/0",
-                "createdYmdt": "2023-02-19T19:18:13+09:00",
-                "updatedYmdt": "2023-02-19T19:18:13+09:00"
-            }
-        ],
-        "createdYmdt": "2023-02-19T19:18:13+09:00",
-        "updatedYmdt": "2023-02-19T19:18:13+09:00"
-    }
-}
-```
-</details>
+---
 
 ### DBセキュリティグループの作成
 
@@ -3618,55 +4028,60 @@ POST /v1.0/db-security-groups
 
 #### 必要権限
 
-| 権限名                                    | 説明           |
-|-----------------------------------------|---------------|
+| 権限名                                    | 説明                    |
+|-----------------------------------------|------------------------|
 | RDSforPostgreSQL:DbSecurityGroup.Create | DBセキュリティグループ作成 |
 
 #### リクエスト
 
-| 名前                 | 種類  | 形式    | 必須 | 説明                                                                                                                                                                                      |
-|---------------------|------|--------|----|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupName | Body | String | O  | DBセキュリティグループを識別できる名前                                                                                                                                                                   |
-| description         | Body | String | X  | DBセキュリティグループの追加情報                                                                                                                                                                      |
-| rules               | Body | Array  | O  | DBセキュリティグループルールリスト                                                                                                                                                                          |
-| rules.description   | Body | String | X  | DBセキュリティグループルールの追加情報                                                                                                                                                                   |
-| rules.direction     | Body | Enum   | O  | 通信方向<br/>- `INGRESS`:受信<br/>- `EGRESS`:送信                                                                                                                                            |
-| rules.etherType     | Body | Enum   | O  | Etherタイプ<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                           |
-| rules.cidr          | Body | String | O  | 許可するトラフィックの遠隔ソース<br/>- 例:`1.1.1.1/32`                                                                                                                                                    |
-| rules.port          | Body | Object | O  | ポートオブジェクト                                                                                                                                                                                   |
-| rules.port.portType | Body | Enum   | O  | ポートタイプ<br/>- `DB_PORT`:各DBインスタンスポート値で設定されます。`minPort`値と`maxPort`値を必要としません。<br/>- `PORT`:指定されたポート値で設定されます。`minPort`値と`maxPort`値が同じである必要があります。<br/>- `PORT_RANGE`:指定されたポート範囲で設定されます。 |
-| rules.port.minPort  | Body | Number | X  | 最小ポート範囲<br/>- 受信最小値:5432<br/>- 送信最小値:1                                                                                                                                              |
-| rules.port.maxPort  | Body | Number | X  | 最大ポート範囲<br/>- 受信最大値:45432<br/>- 送信最大値:65535                                                                                                                                         |
+| 名前                 | 種類  | 形式    | 必須 | 説明                                                                                                                                                                                                                                                              |
+|---------------------|------|--------|-----|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| dbSecurityGroupName | Body | String | O   | DBセキュリティグループを識別できる名前                                                                                                                                                                                                                                |
+| description         | Body | String | X   | DBセキュリティグループの追加情報                                                                                                                                                                                                                                     |
+| rules               | Body | Array  | O   | DBセキュリティグループルール情報                                                                                                                                                                                                                                     |
+| rules.direction     | Body | Enum   | O   | 通信方向<br/>- INGRESS: `受信`<br/>- EGRESS: `送信`                                                                                                                                                                                                               |
+| rules.etherType     | Body | Enum   | O   | Etherタイプ<br/>- IPV4: `IPv4形式`<br/>- IPV6: `IPv6形式`                                                                                                                                                                                                        |
+| rules.port          | Body | Object | O   | ポートオブジェクト                                                                                                                                                                                                                                                  |
+| rules.port.portType | Body | Enum   | O   | ポートタイプ<br/>- ALL: `ポート範囲全体(ユーザーコンソールでは使用しない)`<br/>- PORT: `特定ポート`<br/>- DB_PORT: `DB受信ポート`<br/>- PORT_RANGE: `ポート範囲`                                                                                                           |
+| rules.port.minPort  | Body | Number | X   | 最小ポート範囲<br/>- 最小値: `1`                                                                                                                                                                                                                                    |
+| rules.port.maxPort  | Body | Number | X   | 最大ポート範囲<br/>- 最大値: `65535`                                                                                                                                                                                                                               |
+| rules.cidr          | Body | String | O   | CIDR                                                                                                                                                                                                                                                             |
+| rules.description   | Body | String | X   | DBセキュリティグループルールの追加情報                                                                                                                                                                                                                               |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
-    "dbSecurityGroupName": "dbSecurityGroup",
-    "description": "description",
+    "dbSecurityGroupName": "dbSecurityGroupName-example",
+    "description": "description-example",
     "rules": [
         {
             "direction": "INGRESS",
             "etherType": "IPV4",
             "port": {
-                "portType": "PORT_RANGE",
-                "minPort": 10000,
-                "maxPort": 10005
+                "portType": "ALL",
+                "minPort": 1,
+                "maxPort": 1
             },
-            "cidr": "0.0.0.0/0"
+            "cidr": "192.168.0.0/24",
+            "description": "description-example"
         }
     ]
 }
 ```
+
+</p>
 </details>
 
 #### レスポンス
 
-| 名前               | 種類  | 形式  | 説明           |
-|-------------------|------|------|---------------|
+| 名前               | 種類  | 形式  | 説明                      |
+|-------------------|------|------|--------------------------|
 | dbSecurityGroupId | Body | UUID | DBセキュリティグループの識別子 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -3675,57 +4090,14 @@ POST /v1.0/db-security-groups
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "dbSecurityGroupId": "fe4f2aee-afbb-4c19-a5e9-eb2eab394708"
+    "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-### DBセキュリティグループの修正
-
-```http
-PUT /v1.0/db-security-groups/{dbSecurityGroupId}
-```
-
-#### 必要権限
-
-| 権限名                                    | 説明           |
-|-----------------------------------------|---------------|
-| RDSforPostgreSQL:DbSecurityGroup.Modify | DBセキュリティグループの修正 |
-
-#### リクエスト
-
-| 名前                 | 種類  | 形式    | 必須 | 説明                   |
-|---------------------|------|--------|----|-----------------------|
-| dbSecurityGroupId   | URL  | UUID   | O  | DBセキュリティグループの識別子        |
-| dbSecurityGroupName | Body | String | X  | DBセキュリティグループを識別できる名前 |
-| description         | Body | String | X  | DBセキュリティグループの追加情報   |
-
-<details><summary>例</summary>
-
-```json
-{
-    "dbSecurityGroupName": "dbSecurityGroup",
-    "description": "description"
-}
-```
-</details>
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
+---
 
 ### DBセキュリティグループの削除
 
@@ -3735,23 +4107,71 @@ DELETE /v1.0/db-security-groups/{dbSecurityGroupId}
 
 #### 必要権限
 
-| 権限名                                    | 説明           |
-|-----------------------------------------|---------------|
+| 権限名                                    | 説明                    |
+|-----------------------------------------|------------------------|
 | RDSforPostgreSQL:DbSecurityGroup.Delete | DBセキュリティグループの削除 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前               | 種類 | 形式  | 必須 | 説明           |
-|-------------------|-----|------|----|---------------|
-| dbSecurityGroupId | URL | UUID | O  | DBセキュリティグループの識別子 |
+| 名前               | 種類 | 形式  | 必須 | 説明 |
+|-------------------|-----|------|----|-----|
+| dbSecurityGroupId | URL | UUID | O  |     |
 
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
 
+---
+
+### DBセキュリティグループ詳細を表示
+
+```http
+GET /v1.0/db-security-groups/{dbSecurityGroupId}
+```
+
+#### 必要権限
+
+| 権限名                                 | 説明                         |
+|--------------------------------------|------------------------------|
+| RDSforPostgreSQL:DbSecurityGroup.Get | DBセキュリティグループ詳細を表示 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前               | 種類 | 形式  | 必須 | 説明                      |
+|-------------------|-----|------|----|--------------------------|
+| dbSecurityGroupId | URL | UUID | O  |                          |
+
+#### レスポンス
+
+| 名前                                    | 種類  | 形式      | 説明                                                                                                                                                                                                                                                                 |
+|-----------------------------------------|------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| dbSecurityGroup                         | Body | Object   | DBセキュリティグループ                                                                                                                                                                                                                                                  |
+| dbSecurityGroup.dbSecurityGroupId       | Body | UUID     | DBセキュリティグループの識別子                                                                                                                                                                                                                                           |
+| dbSecurityGroup.dbSecurityGroupName     | Body | String   | DBセキュリティグループを識別できる名前                                                                                                                                                                                                                                   |
+| dbSecurityGroup.dbSecurityGroupStatus   | Body | Enum     | DBセキュリティグループの現在状態<br/>- CREATED: `作成済み`<br/>- DELETED: `削除済み`                                                                                                                                                                                      |
+| dbSecurityGroup.description             | Body | String   | DBセキュリティグループの追加情報                                                                                                                                                                                                                                        |
+| dbSecurityGroup.progressStatus          | Body | Enum     | DBセキュリティグループの現在の進行状態<br/>- NONE: `進行中の作業なし`<br/>- CREATING_RULE: `ルールポリシー作成中`<br/>- UPDATING_RULE: `ルールポリシー修正中`<br/>- DELETING_RULE: `ルールポリシー削除中`<br/>- APPLYING_DEFAULT_RULE: `基本ルール適用中` |
+| dbSecurityGroup.rules                   | Body | Array    | DBセキュリティグループルールリスト                                                                                                                                                                                                                                      |
+| dbSecurityGroup.rules.ruleId            | Body | UUID     | DBセキュリティグループルールの識別子                                                                                                                                                                                                                                    |
+| dbSecurityGroup.rules.description       | Body | String   | DBセキュリティグループルールの追加情報                                                                                                                                                                                                                                  |
+| dbSecurityGroup.rules.direction         | Body | Enum     | 通信方向<br/>- INGRESS: `受信`<br/>- EGRESS: `送信`                                                                                                                                                                                                                  |
+| dbSecurityGroup.rules.etherType         | Body | Enum     | Etherタイプ<br/>- IPV4: `IPv4形式`<br/>- IPV6: `IPv6形式`                                                                                                                                                                                                           |
+| dbSecurityGroup.rules.port              | Body | Object   | ポートオブジェクト                                                                                                                                                                                                                                                      |
+| dbSecurityGroup.rules.port.portType     | Body | Enum     | ポートタイプ<br/>- ALL: `ポート範囲全体(ユーザーコンソールでは使用しない)`<br/>- PORT: `特定ポート`<br/>- DB_PORT: `DB受信ポート`<br/>- PORT_RANGE: `ポート範囲`                                                                                                            |
+| dbSecurityGroup.rules.port.minPort      | Body | Number   | 最小ポート範囲                                                                                                                                                                                                                                                        |
+| dbSecurityGroup.rules.port.maxPort      | Body | Number   | 最大ポート範囲                                                                                                                                                                                                                                                        |
+| dbSecurityGroup.rules.cidr              | Body | String   | CIDR                                                                                                                                                                                                                                                                |
+| dbSecurityGroup.rules.createdYmdt       | Body | DateTime | 作成日時                                                                                                                                                                                                                                                            |
+| dbSecurityGroup.rules.updatedYmdt       | Body | DateTime | 修正日時                                                                                                                                                                                                                                                            |
+| dbSecurityGroup.createdYmdt             | Body | DateTime | 作成日時                                                                                                                                                                                                                                                            |
+| dbSecurityGroup.updatedYmdt             | Body | DateTime | 修正日時                                                                                                                                                                                                                                                            |
+
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -3759,133 +4179,78 @@ DELETE /v1.0/db-security-groups/{dbSecurityGroupId}
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
+    },
+    "dbSecurityGroup": {
+        "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
+        "dbSecurityGroupName": "dbSecurityGroupName-example",
+        "dbSecurityGroupStatus": "CREATED",
+        "description": "description-example",
+        "progressStatus": "NONE",
+        "rules": [
+            {
+                "ruleId": "550e8400-e29b-41d4-a716-446655440000",
+                "description": "description-example",
+                "direction": "INGRESS",
+                "etherType": "IPV4",
+                "port": {
+                    "portType": "ALL",
+                    "minPort": 1,
+                    "maxPort": 1
+                },
+                "cidr": "192.168.0.0/24",
+                "createdYmdt": "2023-12-31T15:00:00+09:00",
+                "updatedYmdt": "2023-12-31T15:00:00+09:00"
+            }
+        ],
+        "createdYmdt": "2023-12-31T15:00:00+09:00",
+        "updatedYmdt": "2023-12-31T15:00:00+09:00"
     }
 }
 ```
+
+</p>
 </details>
 
-### DBセキュリティグループルールの作成
+---
+
+### DBセキュリティグループの修正
 
 ```http
-POST /v1.0/db-security-groups/{dbSecurityGroupId}/rules
+PUT /v1.0/db-security-groups/{dbSecurityGroupId}
 ```
 
 #### 必要権限
 
-| 権限名                                        | 説明              |
-|---------------------------------------------|------------------|
-| RDSforPostgreSQL:DbSecurityGroupRule.Create | DBセキュリティグループルールの作成 |
+| 権限名                                    | 説明                    |
+|-----------------------------------------|------------------------|
+| RDSforPostgreSQL:DbSecurityGroup.Modify | DBセキュリティグループの修正 |
 
 #### リクエスト
 
-| 名前               | 種類  | 形式    | 必須 | 説明                                                                                                                                                                                      |
-|-------------------|------|--------|----|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId | URL  | UUID   | O  | DBセキュリティグループの識別子                                                                                                                                                                           |
-| description       | Body | String | X  | DBセキュリティグループルールの追加情報                                                                                                                                                                   |
-| direction         | Body | Enum   | O  | 通信方向<br/>- `INGRESS`:受信<br/>- `EGRESS`:送信                                                                                                                                            |
-| etherType         | Body | Enum   | O  | Etherタイプ<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                           |
-| port              | Body | Object | O  | ポートオブジェクト                                                                                                                                                                                   |
-| port.portType     | Body | Enum   | O  | ポートタイプ<br/>- `DB_PORT`:各DBインスタンスポート値で設定されます。`minPort`値と`maxPort`値を必要としません。<br/>- `PORT`:指定されたポート値で設定されます。`minPort`値と`maxPort`値が同じである必要があります。<br/>- `PORT_RANGE`:指定されたポート範囲で設定されます。 |
-| port.minPort      | Body | Number | X  | 最小ポート範囲<br/>- 受信最小値:5432<br/>- 送信最小値:1                                                                                                                                              |
-| port.maxPort      | Body | Number | X  | 最大ポート範囲<br/>- 受信最大値:45432<br/>- 送信最大値:65535                                                                                                                                         |
-| cidr              | Body | String | O  | 許可するトラフィックの遠隔ソース<br/>- 例:`1.1.1.1/32`                                                                                                                                                    |
+| 名前                 | 種類  | 形式    | 必須 | 説明                                    |
+|---------------------|------|--------|-----|----------------------------------------|
+| dbSecurityGroupId   | URL  | UUID   | O   |                                        |
+| dbSecurityGroupName | Body | String | O   | DBセキュリティグループを識別できる名前       |
+| description         | Body | String | X   | DBセキュリティグループの追加情報            |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
-    "direction": "INGRESS",
-    "etherType": "IPV4",
-    "port": {
-        "portType": "PORT",
-        "minPort": 10000,
-        "maxPort": 10000
-    },
-    "cidr": "0.0.0.0/0"
+    "dbSecurityGroupName": "dbSecurityGroupName-example",
+    "description": "description-example"
 }
 ```
+
+</p>
 </details>
 
 #### レスポンス
 
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
+このAPIはレスポンス本文を返しません。
 
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### DBセキュリティグループルールの修正
-
-```http
-PUT /v1.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
-```
-
-#### 必要権限
-
-| 権限名                                        | 説明              |
-|---------------------------------------------|------------------|
-| RDSforPostgreSQL:DbSecurityGroupRule.Modify | DBセキュリティグループルールの修正 |
-
-#### リクエスト
-
-| 名前               | 種類  | 形式    | 必須 | 説明                                                                                                                                                                                      |
-|-------------------|------|--------|----|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId | URL  | UUID   | O  | DBセキュリティグループの識別子                                                                                                                                                                           |
-| ruleId            | URL  | UUID   | O  | DBセキュリティグループルールの識別子                                                                                                                                                                        |
-| description       | Body | String | X  | DBセキュリティグループルールの追加情報                                                                                                                                                                   |
-| direction         | Body | Enum   | O  | 通信方向<br/>- `INGRESS`:受信<br/>- `EGRESS`:送信                                                                                                                                            |
-| etherType         | Body | Enum   | O  | Etherタイプ<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                           |
-| port              | Body | Object | O  | ポートオブジェクト                                                                                                                                                                                   |
-| port.portType     | Body | Enum   | O  | ポートタイプ<br/>- `DB_PORT`:各DBインスタンスポート値で設定されます。`minPort`値と`maxPort`値を必要としません。<br/>- `PORT`:指定されたポート値で設定されます。`minPort`値と`maxPort`値が同じである必要があります。<br/>- `PORT_RANGE`:指定されたポート範囲で設定されます。 |
-| port.minPort      | Body | Number | X  | 最小ポート範囲<br/>- 受信最小値:5432<br/>- 送信最小値:1                                                                                                                                              |
-| port.maxPort      | Body | Number | X  | 最大ポート範囲<br/>- 受信最大値:45432<br/>- 送信最大値:65535                                                                                                                                         |
-| cidr              | Body | String | O  | 許可するトラフィックの遠隔ソース<br/>- 例:`1.1.1.1/32`                                                                                                                                                    |
-
-<details><summary>例</summary>
-
-```json
-{
-    "direction": "INGRESS",
-    "etherType": "IPV4",
-    "port": {
-        "portType": "DB_PORT"
-    },
-    "cidr": "0.0.0.0/0"
-}
-```
-</details>
-
-#### レスポンス
-
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
+---
 
 ### DBセキュリティグループルールの削除
 
@@ -3895,26 +4260,27 @@ DELETE /v1.0/db-security-groups/{dbSecurityGroupId}/rules
 
 #### 必要権限
 
-| 権限名                                        | 説明              |
-|---------------------------------------------|------------------|
-| RDSforPostgreSQL:DbSecurityGroupRule.Create | DBセキュリティグループルールの削除 |
+| 権限名                                        | 説明                         |
+|---------------------------------------------|------------------------------|
+| RDSforPostgreSQL:DbSecurityGroupRule.Delete | DBセキュリティグループルールの削除 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前               | 種類   | 形式   | 必須 | 説明                 |
-|-------------------|-------|-------|----|---------------------|
-| dbSecurityGroupId | URL   | UUID  | O  | DBセキュリティグループの識別子      |
-| ruleIds           | Query | Array | O  | DBセキュリティグループルールの識別子リスト |
+| 名前               | 種類   | 形式    | 必須 | 説明                             |
+|-------------------|-------|--------|-----|----------------------------------|
+| dbSecurityGroupId | URL   | UUID   | O   |                                  |
+| ruleIds           | Query | String | O   | DBセキュリティグループルールIDリスト |
 
 #### レスポンス
 
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
+| 名前   | 種類  | 形式  | 説明                    |
+|-------|------|------|------------------------|
 | jobId | Body | UUID | リクエストした作業の識別子 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -3923,11 +4289,157 @@ DELETE /v1.0/db-security-groups/{dbSecurityGroupId}/rules
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
+---
+
+### DBセキュリティグループルールの作成
+
+```http
+POST /v1.0/db-security-groups/{dbSecurityGroupId}/rules
+```
+
+#### 必要権限
+
+| 権限名                                        | 説明                         |
+|---------------------------------------------|------------------------------|
+| RDSforPostgreSQL:DbSecurityGroupRule.Create | DBセキュリティグループルールの作成 |
+
+#### リクエスト
+
+| 名前               | 種類  | 形式    | 必須 | 説明                                                                                                                                                                                                               |
+|-------------------|------|--------|-----|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| dbSecurityGroupId | URL  | UUID   | O   |                                                                                                                                                                                                                    |
+| direction         | Body | Enum   | O   | 通信方向<br/>- INGRESS: `受信`<br/>- EGRESS: `送信`                                                                                                                                                               |
+| etherType         | Body | Enum   | O   | Etherタイプ<br/>- IPV4: `IPv4形式`<br/>- IPV6: `IPv6形式`                                                                                                                                                        |
+| port              | Body | Object | O   | ポート情報                                                                                                                                                                                                         |
+| port.portType     | Body | Enum   | O   | ポートタイプ<br/>- ALL: `ポート範囲全体(ユーザーコンソールでは使用しない)`<br/>- PORT: `特定ポート`<br/>- DB_PORT: `DB受信ポート`<br/>- PORT_RANGE: `ポート範囲`                                                       |
+| port.minPort      | Body | Number | X   | 最小ポート範囲<br/>- 最小値: `1`                                                                                                                                                                                   |
+| port.maxPort      | Body | Number | X   | 最大ポート範囲<br/>- 最大値: `65535`                                                                                                                                                                              |
+| cidr              | Body | String | O   | CIDR                                                                                                                                                                                                              |
+| description       | Body | String | X   | DBセキュリティグループルールの追加情報                                                                                                                                                                               |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "direction": "INGRESS",
+    "etherType": "IPV4",
+    "port": {
+        "portType": "ALL",
+        "minPort": 1,
+        "maxPort": 1
+    },
+    "cidr": "192.168.0.0/24",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前   | 種類  | 形式  | 説明                    |
+|-------|------|------|------------------------|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBセキュリティグループルールの修正
+
+```http
+PUT /v1.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
+```
+
+#### 必要権限
+
+| 権限名                                        | 説明                         |
+|---------------------------------------------|------------------------------|
+| RDSforPostgreSQL:DbSecurityGroupRule.Modify | DBセキュリティグループルールの修正 |
+
+#### リクエスト
+
+| 名前               | 種類  | 形式    | 必須 | 説明                                                                                                                                                                                                               |
+|-------------------|------|--------|-----|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| dbSecurityGroupId | URL  | UUID   | O   |                                                                                                                                                                                                                    |
+| ruleId            | URL  | UUID   | O   |                                                                                                                                                                                                                    |
+| direction         | Body | Enum   | O   | 通信方向<br/>- INGRESS: `受信`<br/>- EGRESS: `送信`                                                                                                                                                               |
+| etherType         | Body | Enum   | O   | Etherタイプ<br/>- IPV4: `IPv4形式`<br/>- IPV6: `IPv6形式`                                                                                                                                                        |
+| port              | Body | Object | O   | ポート情報                                                                                                                                                                                                         |
+| port.portType     | Body | Enum   | O   | ポートタイプ<br/>- ALL: `ポート範囲全体(ユーザーコンソールでは使用しない)`<br/>- PORT: `特定ポート`<br/>- DB_PORT: `DB受信ポート`<br/>- PORT_RANGE: `ポート範囲`                                                       |
+| port.minPort      | Body | Number | X   | 最小ポート範囲<br/>- 最小値: `1`                                                                                                                                                                                   |
+| port.maxPort      | Body | Number | X   | 最大ポート範囲<br/>- 最大値: `65535`                                                                                                                                                                              |
+| cidr              | Body | String | O   | CIDR                                                                                                                                                                                                              |
+| description       | Body | String | X   | DBセキュリティグループルールの追加情報                                                                                                                                                                               |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "direction": "INGRESS",
+    "etherType": "IPV4",
+    "port": {
+        "portType": "ALL",
+        "minPort": 1,
+        "maxPort": 1
+    },
+    "cidr": "192.168.0.0/24",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前   | 種類  | 形式  | 説明                    |
+|-------|------|------|------------------------|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
 ## パラメータグループ
 
 ### パラメータグループリストを表示
@@ -3938,32 +4450,29 @@ GET /v1.0/parameter-groups
 
 #### 必要権限
 
-| 権限名                                 | 説明           |
-|--------------------------------------|---------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:ParameterGroup.List | パラメータグループリストを表示 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前       | 種類   | 形式  | 必須 | 説明      |
-|-----------|-------|------|----|----------|
-| dbVersion | Query | Enum | X  | DBバージョン情報 |
-
 #### レスポンス
 
-| 名前                                  | 種類  | 形式      | 説明                                                               |
-|--------------------------------------|------|----------|-------------------------------------------------------------------|
-| parameterGroups                      | Body | Array    | パラメータグループリスト                                                       |
-| parameterGroups.parameterGroupId     | Body | UUID     | パラメータグループの識別子                                                     |
-| parameterGroups.parameterGroupName   | Body | String   | パラメータグループを識別できる名前                                             |
-| parameterGroups.parameterGroupStatus | Body | Enum     | パラメータグループの現在状態<br/>- `STABLE`:適用完了<br/>- `NEED_TO_APPLY`:適用必要 |
-| parameterGroups.description          | Body | String   | パラメータグループの追加情報                                                |
-| parameterGroups.dbVersion            | Body | Enum     | DBバージョン情報                                                         |
-| parameterGroups.createdYmdt          | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                 |
-| parameterGroups.updatedYmdt          | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                 |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| parameterGroups | Body | Array | パラメータグループリスト |
+| parameterGroups.parameterGroupId | Body | UUID | パラメータグループの識別子 |
+| parameterGroups.parameterGroupName | Body | String | パラメータグループを識別できる名前 |
+| parameterGroups.description | Body | String | パラメータグループの追加情報 |
+| parameterGroups.dbVersion | Body | Enum | DBバージョン情報 |
+| parameterGroups.parameterGroupStatus | Body | Enum | パラメータグループの現在状態<br/>- STABLE: `適用完了`<br/>- NEED_TO_APPLY: `適用必要`<br/>- DELETED: `削除済み` |
+| parameterGroups.createdYmdt | Body | DateTime | 作成日時 |
+| parameterGroups.updatedYmdt | Body | DateTime | 修正日時 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -3974,96 +4483,22 @@ GET /v1.0/parameter-groups
     },
     "parameterGroups": [
         {
-            "parameterGroupId": "404e8a89-ca4d-4fca-96c2-1518754d50b7",
-            "parameterGroupName": "parameter-group",
+            "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "parameterGroupName": "parameterGroupName-example",
+            "description": "description-example",
+            "dbVersion": "POSTGRESQL_V14_17",
             "parameterGroupStatus": "STABLE",
-            "description": null,
-            "dbVersion": "POSTGRESQL_V17_6",
-            "createdYmdt": "2023-02-31T15:28:17+09:00",
-            "updatedYmdt": "2023-02-31T15:28:17+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
+
+</p>
 </details>
 
-
-### パラメータグループ詳細を表示
-
-```http
-GET /v1.0/parameter-groups/{parameterGroupId}
-```
-
-#### 必要権限
-
-| 権限名                                | 説明           |
-|-------------------------------------|---------------|
-| RDSforPostgreSQL:ParameterGroup.Get | パラメータグループ詳細を表示 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前              | 種類 | 形式  | 必須 | 説明          |
-|------------------|-----|------|----|--------------|
-| parameterGroupId | URL | UUID | O  | パラメータグループの識別子 |
-
-#### レスポンス
-
-| 名前                          | 種類  | 形式      | 説明                                                                                                                                                                                                                                                                                                                                                |
-|------------------------------|------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| parameterGroupId             | Body | UUID     | パラメータグループの識別子                                                                                                                                                                                                                                                                                                                                      |
-| parameterGroupName           | Body | String   | パラメータグループを識別できる名前                                                                                                                                                                                                                                                                                                                              |
-| description                  | Body | String   | パラメータグループの追加情報                                                                                                                                                                                                                                                                                                                                 |
-| dbVersion                    | Body | Enum     | DBバージョン情報                                                                                                                                                                                                                                                                                                                                          |
-| parameterGroupStatus         | Body | Enum     | パラメータグループの現在状態<br/>- `STABLE`:適用完了<br/>- `NEED_TO_APPLY`:適用必要<br/>- `DELETED`:削除済み                                                                                                                                                                                                                                                            |
-| parameters                   | Body | Array    | パラメータリスト                                                                                                                                                                                                                                                                                                                                           |
-| parameters.parameterCategory | Body | String   | パラメータカテゴリー                                                                                                                                                                                                                                                                                                                                         |
-| parameters.parameterName     | Body | String   | パラメータ名                                                                                                                                                                                                                                                                                                                                           |
-| parameters.value             | Body | String   | 現在設定されている値                                                                                                                                                                                                                                                                                                                                          |
-| parameters.valueUnit         | Body | Enum     | 現在設定されている値の単位<br/>- `B`:バイト<br/>- `kB`:キロバイト<br/>- `MB`:メガバイト<br/>- `GB`:ギガバイト<br/>- `TB`:テラバイト<br/>- `us`:マイクロ秒<br/>- `ms`:ミリ秒<br/>- `s`:秒<br/>- `min`:分<br/>- `h`:時間<br/>- `d`:日                                                                                                                                                        |
-| parameters.defaultValue      | Body | String   | デフォルト値                                                                                                                                                                                                                                                                                                                                               |
-| parameters.allowedValue      | Body | String   | 許可された値                                                                                                                                                                                                                                                                                                                                             |
-| parameters.valueType         | Body | Enum     | 値タイプ<br/>- `BOOLEAN`:ブーリアンタイプ<br/>- `STRING`:文字列タイプ<br/>- `NUMERIC`:整数および浮動小数点タイプ<br/>- `NUMERIC_WITH_BYTE_UNIT`:バイト単位の数字タイプ(例：120KB、100MB)<br/>- `NUMERIC_WITH_TIME_UNIT`:時間単位の数字タイプ(例：120ms、100s、1d)<br/>- `ENUMERATED`:許可された値に宣言された値の中から1つを入力<br/>- `MULTI_ENUMERATED`:許可された値に宣言された値の中から複数個を入力(コンマ(,)で区分される)<br/>- `TIMEZONE`:タイムゾーンタイプ |
-| parameters.updateType        | Body | Enum     | 修正タイプ<br/>- `VARIABLE`:常に修正可能<br/>- `CONSTANT`:修正 不可能                                                                                                                                                                                                                                                                                        |
-| parameters.applyType         | Body | Enum     | 適用タイプ<br/>- `SESSION`:セッション適用<br/>- `FILE`:設定ファイル適用(再起動必要)<br/>- `BOTH`:全体                                                                                                                                                                                                                                                                      | 
-| createdYmdt                  | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                                                                                                                                                                                  |
-| updatedYmdt                  | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                                                                                                                                                                                  |
-| expressionAvailable          | Body | Boolean  | 数式の使用可否                                                                                                                                                                                                                                                                                                                                           |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroupId": "404e8a89-ca4d-4fca-96c2-1518754d50b7",
-    "parameterGroupName": "parameter-group",
-    "description": null,
-    "dbVersion": "POSTGRESQL_V17_6",
-    "parameterGroupStatus": "STABLE",
-    "parameters": [
-        {
-            "parameterCategory": "Write-Ahead Log / Checkpoints",
-            "parameterName": "checkpoint_timeout",
-            "value": "300s",
-            "defaultValue": "300s",
-            "allowedValue": "30~86400s",
-            "valueType": "NUMERIC_WITH_TIME_UNIT",
-            "updateType": "VARIABLE",
-            "applyType": "BOTH",
-            "expressionAvailable": true
-        }
-    ],
-    "createdYmdt": "2023-03-13T11:02:28+09:00",
-    "updatedYmdt": "2023-03-13T11:02:28+09:00"
-}
-```
-</details>
-
+---
 
 ### パラメータグループの作成
 
@@ -4073,36 +4508,40 @@ POST /v1.0/parameter-groups
 
 #### 必要権限
 
-| 権限名                                   | 説明          |
-|----------------------------------------|--------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:ParameterGroup.Create | パラメータグループの作成 |
 
 #### リクエスト
 
-| 名前                | 種類  | 形式    | 必須 | 説明                  |
-|--------------------|------|--------|----|----------------------|
-| parameterGroupName | Body | String | O  | パラメータグループを識別できる名前 |
-| description        | Body | String | X  | パラメータグループの追加情報   |
-| dbVersion          | Body | Enum   | O  | DBバージョン情報            |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupName | Body | String | O | パラメータグループを識別できる名前 |
+| description | Body | String | X | パラメータグループの追加情報 |
+| dbVersion | Body | Enum | O | DBバージョン情報 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
-    "parameterGroupName": "parameter-group",
-    "description": "description",
-    "dbVersion": "POSTGRESQL_V17_6"
+    "parameterGroupName": "parameterGroupName-example",
+    "description": "description-example",
+    "dbVersion": "POSTGRESQL_V14_17"
 }
 ```
+
+</p>
 </details>
 
 #### レスポンス
 
-| 名前              | 種類  | 形式  | 説明          |
-|------------------|------|------|--------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | parameterGroupId | Body | UUID | パラメータグループの識別子 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -4111,194 +4550,14 @@ POST /v1.0/parameter-groups
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "parameterGroupId": "404e8a89-ca4d-4fca-96c2-1518754d50b7"
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-### パラメータグループのコピー
-
-```http
-POST /v1.0/parameter-groups/{parameterGroupId}/copy
-```
-
-#### 必要権限
-
-| 権限名                                 | 説明          |
-|--------------------------------------|--------------|
-| RDSforPostgreSQL:ParameterGroup.Copy | パラメータグループのコピー |
-
-#### リクエスト
-
-| 名前                | 種類  | 形式    | 必須 | 説明                  |
-|--------------------|------|--------|----|----------------------|
-| parameterGroupId   | URL  | UUID   | O  | パラメータグループの識別子        |
-| parameterGroupName | Body | String | O  | パラメータグループを識別できる名前 |
-| description        | Body | String | X  | パラメータグループの追加情報   |
-
-<details><summary>例</summary>
-
-```json
-{
-    "parameterGroupName": "parameter-group-copy",
-    "description": "copy"
-}
-```
-</details>
-
-#### レスポンス
-
-| 名前              | 種類  | 形式  | 説明          |
-|------------------|------|------|--------------|
-| parameterGroupId | Body | UUID | パラメータグループの識別子 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroupId": "404e8a89-ca4d-4fca-96c2-1518754d50b7"
-}
-```
-</details>
-
-### パラメータグループの修正
-
-```http
-PUT /v1.0/parameter-groups/{parameterGroupId}
-```
-
-#### 必要権限
-
-| 権限名                                   | 説明          |
-|----------------------------------------|--------------|
-| RDSforPostgreSQL:ParameterGroup.Modify | パラメータグループの修正 |
-
-#### リクエスト
-
-| 名前                | 種類  | 形式    | 必須 | 説明                  |
-|--------------------|------|--------|----|----------------------|
-| parameterGroupId   | URL  | UUID   | O  | パラメータグループの識別子        |
-| parameterGroupName | Body | String | X  | パラメータグループを識別できる名前 |
-| description        | Body | String | X  | パラメータグループの追加情報   |
-
-<details><summary>例</summary>
-
-```json
-{
-    "parameterGroupName": "parameter-group",
-    "description": "description"
-}
-```
-</details>
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
-
-### パラメータ修正
-
-```http
-PUT /v1.0/parameter-groups/{parameterGroupId}/parameters
-```
-
-#### 必要権限
-
-| 権限名                                   | 説明          |
-|----------------------------------------|--------------|
-| RDSforPostgreSQL:ParameterGroup.Modify | パラメータグループの修正 |
-
-#### リクエスト
-
-| 名前                              | 種類  | 形式    | 必須 | 説明          |
-|----------------------------------|------|--------|----|--------------|
-| parameterGroupId                 | URL  | UUID   | O  | パラメータグループの識別子 |
-| modifiedParameters               | Body | Array  | O  | 変更するパラメータリスト |
-| modifiedParameters.parameterName | Body | UUID   | O  | パラメータ名     |
-| modifiedParameters.value         | Body | String | O  | 変更するパラメータ値  |
-
-<details><summary>例</summary>
-
-```json
-{
-   "modifiedParameters": [
-       {
-           "parameterName": "checkpoint_timeout",
-           "value": "100s"
-       }
-   ]
-}
-```
-</details>
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
-
-### パラメータグループの再設定
-
-```http
-PUT /v1.0/parameter-groups/{parameterGroupId}/reset
-```
-
-#### 必要権限
-
-| 権限名                                  | 説明           |
-|---------------------------------------|---------------|
-| RDSforPostgreSQL:ParameterGroup.Reset | パラメータグループの再設定 |
-
-#### リクエスト
-
-| 名前              | 種類 | 形式  | 必須 | 説明          |
-|------------------|-----|------|----|--------------|
-| parameterGroupId | URL | UUID | O  | パラメータグループの識別子 |
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
+---
 
 ### パラメータグループの削除
 
@@ -4308,23 +4567,69 @@ DELETE /v1.0/parameter-groups/{parameterGroupId}
 
 #### 必要権限
 
-| 権限名                                   | 説明          |
-|----------------------------------------|--------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:ParameterGroup.Delete | パラメータグループの削除 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前              | 種類 | 形式  | 必須 | 説明          |
-|------------------|-----|------|----|--------------|
-| parameterGroupId | URL | UUID | O  | パラメータグループの識別子 |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O | パラメータグループの識別子 |
 
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
 
+---
+
+### パラメータグループ詳細を表示
+
+```http
+GET /v1.0/parameter-groups/{parameterGroupId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:ParameterGroup.Get | パラメータグループ詳細を表示 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O | パラメータグループの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| parameterGroupId | Body | UUID | パラメータグループの識別子 |
+| parameterGroupName | Body | String | パラメータグループを識別できる名前 |
+| description | Body | String | パラメータグループの追加情報 |
+| dbVersion | Body | Enum | DBバージョン情報 |
+| parameterGroupStatus | Body | Enum | パラメータグループの現在状態<br/>- STABLE: `適用完了`<br/>- NEED_TO_APPLY: `適用必要`<br/>- DELETED: `削除済み` |
+| parameters | Body | Array | パラメータリスト |
+| parameters.parameterCategory | Body | String | パラメータカテゴリー |
+| parameters.parameterName | Body | String | パラメータ名 |
+| parameters.value | Body | String | 現在設定されている値 |
+| parameters.valueUnit | Body | String | 値の単位(バイト: B,kB,MB,GB,TB、時間: us,ms,s,min,h,d) |
+| parameters.defaultValue | Body | String | デフォルト値 |
+| parameters.allowedValue | Body | String | 許可された値 |
+| parameters.valueType | Body | Enum | 値タイプ<br/>- BOOLEAN: `ブーリアンタイプ`<br/> `* ex) on, off, true, false, yes, no, 1, 0`<br/>- STRING: `文字列タイプ`<br/>- NUMERIC: `整数および浮動小数点タイプ`<br/>- NUMERIC_WITH_BYTE_UNIT: `バイト単位の数字タイプ`<br/> `* ex) 120kB, 100MB`<br/> `* 許可されたバイト単位: B (bytes), kB (kilobytes), MB (megabytes), GB (gigabytes), and TB (terabytes)`<br/>- NUMERIC_WITH_TIME_UNIT: `時間単位の数字タイプ`<br/> `* ex) 120ms, 100s, 1d`<br/> `* 許可された時間単位: us (microseconds), ms (milliseconds), s (seconds), min (minutes), h (hours), and d (days)`<br/>- ENUMERATED: `許可された値に宣言された値の中から1つを選択(コンマ(,)で区分される)`<br/>- MULTI_ENUMERATED: `許可された値に宣言された値の中から複数個を選択(コンマ(,)で区分される)` |
+| parameters.updateType | Body | Enum | 修正タイプ<br/>- VARIABLE: `常に修正可能`<br/>- CONSTANT: `修正不可能` |
+| parameters.applyType | Body | Enum | 適用タイプ<br/>- BOTH: `セッション、設定ファイルの両方に適用`<br/>- SESSION: `セッションにのみ適用`<br/>- FILE: `設定ファイルにのみ適用` |
+| parameters.expressionAvailable | Body | Boolean | 数式の使用可否 |
+| createdYmdt | Body | DateTime | 作成日時 |
+| updatedYmdt | Body | DateTime | 修正日時 |
+
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -4332,11 +4637,202 @@ DELETE /v1.0/parameter-groups/{parameterGroupId}
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "parameterGroupName": "parameterGroupName-example",
+    "description": "description-example",
+    "dbVersion": "POSTGRESQL_V14_17",
+    "parameterGroupStatus": "STABLE",
+    "parameters": [
+        {
+            "parameterCategory": "parameterCategory-example",
+            "parameterName": "parameterName-example",
+            "value": "value-example",
+            "valueUnit": "valueUnit-example",
+            "defaultValue": "defaultValue-example",
+            "allowedValue": "allowedValue-example",
+            "valueType": "BOOLEAN",
+            "updateType": "VARIABLE",
+            "applyType": "BOTH",
+            "expressionAvailable": false
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
+
+</p>
 </details>
 
+---
+
+### パラメータグループの修正
+
+```http
+PUT /v1.0/parameter-groups/{parameterGroupId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:ParameterGroup.Modify | パラメータグループの修正 |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O | パラメータグループの識別子 |
+| parameterGroupName | Body | String | X | パラメータグループを識別できる名前 |
+| description | Body | String | X | パラメータグループの追加情報 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "parameterGroupName": "parameterGroupName-example",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
+
+### パラメータグループのコピー
+
+```http
+POST /v1.0/parameter-groups/{parameterGroupId}/copy
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:ParameterGroup.Copy | パラメータグループのコピー |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O | パラメータグループの識別子 |
+| parameterGroupName | Body | String | O | パラメータグループを識別できる名前 |
+| description | Body | String | X | パラメータグループの追加情報 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "parameterGroupName": "parameterGroupName-example",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| parameterGroupId | Body | UUID | パラメータグループの識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### パラメータ修正
+
+```http
+PUT /v1.0/parameter-groups/{parameterGroupId}/parameters
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:ParameterGroup.Modify | パラメータグループの修正 |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O | パラメータグループの識別子 |
+| modifiedParameters | Body | Array | O | 変更するパラメータリスト |
+| modifiedParameters.parameterName | Body | String | O | パラメータ名 |
+| modifiedParameters.value | Body | String | O | 変更するパラメータ値 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "modifiedParameters": [
+        {
+            "parameterName": "parameterName-example",
+            "value": "value-example"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
+
+### パラメータグループの再設定
+
+```http
+PUT /v1.0/parameter-groups/{parameterGroupId}/reset
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:ParameterGroup.Reset | パラメータグループの再設定 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O | パラメータグループの識別子 |
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
 ## ユーザーグループ
 
 ### ユーザーグループリストを表示
@@ -4347,8 +4843,8 @@ GET /v1.0/user-groups
 
 #### 必要権限
 
-| 権限名                            | 説明          |
-|---------------------------------|--------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:UserGroup.List | ユーザーグループリストを表示 |
 
 #### リクエスト
@@ -4357,16 +4853,17 @@ GET /v1.0/user-groups
 
 #### レスポンス
 
-| 名前                      | 種類  | 形式      | 説明                                                     |
-|--------------------------|------|----------|---------------------------------------------------------|
-| userGroups               | Body | Array    | ユーザーグループリスト                                              |
-| userGroups.userGroupId   | Body | UUID     | ユーザーグループの識別子                                            |
-| userGroups.userGroupName | Body | String   | ユーザーグループを識別できる名前                                    |
-| userGroupStatus          | Body | Enum     | ユーザーグループの現在状態<br/>- `CREATED`:作成済み<br/>- `DELETED`:削除済み |
-| userGroups.createdYmdt   | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                       |
-| userGroups.updatedYmdt   | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                       |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| userGroups | Body | Array | ユーザーグループリスト |
+| userGroups.userGroupId | Body | UUID | ユーザーグループの識別子 |
+| userGroups.userGroupName | Body | String | ユーザーグループを識別できる名前 |
+| userGroupStatus | Body | Enum | ユーザーグループの現在状態<br/>- CREATED<br/>- DELETED |
+| userGroups.createdYmdt | Body | DateTime | 作成日時 |
+| userGroups.updatedYmdt | Body | DateTime | 修正日時 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -4377,75 +4874,20 @@ GET /v1.0/user-groups
     },
     "userGroups": [
         {
-            "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-            "userGroupName": "dev-team",
+            "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "userGroupName": "userGroupName-example",
             "userGroupStatus": "CREATED",
-            "createdYmdt": "2023-02-23T10:07:54+09:00",
-            "updatedYmdt": "2023-02-26T01:15:50+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
+
+</p>
 </details>
 
-
-### ユーザーグループ詳細を表示
-
-```http
-GET /v1.0/user-groups/{userGroupId}
-```
-
-#### 必要権限
-
-| 権限名                           | 説明          |
-|--------------------------------|--------------|
-| RDSforPostgreSQL:UserGroup.Get | ユーザーグループ詳細を表示 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前         | 種類 | 形式  | 必須 | 説明         |
-|-------------|-----|------|----|-------------|
-| userGroupId | URL | UUID | O  | ユーザーグループの識別子 |
-
-#### レスポンス
-
-| 名前               | 種類  | 形式      | 説明                                                                                                       |
-|-------------------|------|----------|-----------------------------------------------------------------------------------------------------------|
-| userGroupId       | Body | UUID     | ユーザーグループの識別子                                                                                              |
-| userGroupName     | Body | String   | ユーザーグループを識別できる名前                                                                                      |
-| userGroupTypeCode | Body | Enum     | ユーザーグループ種類<br />`ENTIRE`:プロジェクトメンバー全体を含むユーザーグループ<br />`INDIVIDUAL_MEMBER`:特定プロジェクトメンバーを含むユーザーグループ |
-| userGroupStatus   | Body | Enum     | ユーザーグループの現在状態<br/>- `CREATED`:作成済み<br/>- `DELETED`:削除済み                                                  |
-| members           | Body | Array    | プロジェクトメンバーリスト                                                                                               |
-| members.memberId  | Body | UUID     | プロジェクトメンバーの識別子                                                                                             |
-| createdYmdt       | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                         |
-| updatedYmdt       | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                         |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-    "userGroupName": "dev-team",
-    "userGroupStatus": "CREATED",
-	"userGroupTypeCode": "INDIVIDUAL_MEMBER",
-    "members": [
-        {
-            "memberId": "1321e759-2ef3-4b85-9921-b13e918b24b5"
-        }
-    ],
-    "createdYmdt": "2023-02-23T10:07:54+09:00",
-    "updatedYmdt": "2023-02-26T01:15:50+09:00"
-}
-```
-</details>
-
+---
 
 ### ユーザーグループの作成
 
@@ -4455,78 +4897,40 @@ POST /v1.0/user-groups
 
 #### 必要権限
 
-| 権限名                              | 説明         |
-|-----------------------------------|-------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:UserGroup.Create | ユーザーグループの作成 |
 
 #### リクエスト
 
-| 名前           | 種類  | 形式     | 必須 | 説明                                                             |
-|---------------|------|---------|----|-----------------------------------------------------------------|
-| userGroupName | Body | String  | O  | ユーザーグループを識別できる名前                                            |
-| memberIds     | Body | Array   | O  | プロジェクトメンバーの識別子リスト<br />`selectAllYN`がtrueの場合、該当フィールド値は無視される |
-| selectAllYN   | Body | Boolean | X  | プロジェクトメンバー全体の有無<br />trueの場合、該当グループは全メンバーに対して設定される              |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| userGroupName | Body | String | O | ユーザーグループを識別できる名前 |
+| memberIds | Body | Array | O | プロジェクトメンバーの識別子リスト |
+| selectAllYN | Body | Boolean | O | プロジェクトメンバー全体の有無<br/>- デフォルト値: `false` |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
-    "userGroupName": "dev-team",
-    "memberIds": ["1321e759-2ef3-4b85-9921-b13e918b24b5"]
+    "userGroupName": "userGroupName-example",
+    "memberIds": [],
+    "selectAllYN": false
 }
 ```
 
-```json
-{
-    "userGroupName": "dev-team",
-    "selectAllYN":true
-}
-```
+</p>
 </details>
 
 #### レスポンス
 
-| 名前         | 種類  | 形式  | 説明         |
-|-------------|------|------|-------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | userGroupId | Body | UUID | ユーザーグループの識別子 |
 
-
-### ユーザーグループの修正
-
-```http
-PUT /v1.0/user-groups/{userGroupId}
-```
-
-#### 必要権限
-
-| 権限名                              | 説明         |
-|-----------------------------------|-------------|
-| RDSforPostgreSQL:UserGroup.Modify | ユーザーグループの修正 |
-
-#### リクエスト
-
-| 名前           | 種類  | 形式     | 必須 | 説明                                                |
-|---------------|------|---------|----|----------------------------------------------------|
-| userGroupId   | URL  | UUID    | O  | ユーザーグループの識別子                                       |
-| userGroupName | Body | String  | X  | ユーザーグループを識別できる名前                               |
-| memberIds     | Body | Array   | X  | プロジェクトメンバーの識別子リスト                                   |
-| selectAllYN   | Body | Boolean | X  | プロジェクトメンバー全体の有無<br />trueの 場合、該当グループは全メンバーに対して設定される |
-
 <details><summary>例</summary>
-
-```json
-{
-    "userGroupName": "dev-team",
-    "memberIds": ["1321e759-2ef3-4b85-9921-b13e918b24b5","f9064b09-2b15-442e-a4b0-3a5a2754555e"]
-}
-```
-</details>
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
-
-<details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -4534,10 +4938,15 @@ PUT /v1.0/user-groups/{userGroupId}
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "userGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
+
+---
 
 ### ユーザーグループの削除
 
@@ -4547,21 +4956,59 @@ DELETE /v1.0/user-groups/{userGroupId}
 
 #### 必要権限
 
-| 権限名                              | 説明         |
-|-----------------------------------|-------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:UserGroup.Delete | ユーザーグループの削除 |
 
 #### リクエスト
 
-| 名前         | 種類 | 形式  | 必須 | 説明         |
-|-------------|-----|------|----|-------------|
-| userGroupId | URL | UUID | O  | ユーザーグループの識別子 |
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | O | ユーザーグループの識別子 |
 
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
 
+---
+
+### ユーザーグループ詳細を表示
+
+```http
+GET /v1.0/user-groups/{userGroupId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:UserGroup.Get | ユーザーグループ詳細を表示 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | O | ユーザーグループの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| userGroupId | Body | UUID | ユーザーグループの識別子 |
+| userGroupName | Body | String | ユーザーグループを識別できる名前 |
+| userGroupTypeCode | Body | Enum | ユーザーグループ種類<br/>- ENTIRE: `プロジェクトメンバー全体`<br/>- INDIVIDUAL_MEMBER: `ユーザー指定` |
+| userGroupStatus | Body | Enum | ユーザーグループの現在状態<br/>- CREATED<br/>- DELETED |
+| members | Body | Array | プロジェクトメンバーリスト |
+| members.memberId | Body | UUID | プロジェクトメンバーの識別子 |
+| createdYmdt | Body | DateTime | 作成日時 |
+| updatedYmdt | Body | DateTime | 修正日時 |
+
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -4569,11 +5016,66 @@ DELETE /v1.0/user-groups/{userGroupId}
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "userGroupName": "userGroupName-example",
+    "userGroupTypeCode": "ENTIRE",
+    "userGroupStatus": "CREATED",
+    "members": [
+        {
+            "memberId": "550e8400-e29b-41d4-a716-446655440000"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
+
+</p>
 </details>
 
+---
+
+### ユーザーグループの修正
+
+```http
+PUT /v1.0/user-groups/{userGroupId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:UserGroup.Modify | ユーザーグループの修正 |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | O | ユーザーグループの識別子 |
+| userGroupName | Body | String | X | ユーザーグループを識別できる名前 |
+| memberIds | Body | Array | X | プロジェクトメンバーの識別子リスト |
+| selectAllYN | Body | Boolean | O | プロジェクトメンバー全体の有無<br/>- デフォルト値: `false` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "userGroupName": "userGroupName-example",
+    "memberIds": [],
+    "selectAllYN": false
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
 ## 通知グループ
 
 ### 通知グループリストを表示
@@ -4584,8 +5086,8 @@ GET /v1.0/notification-groups
 
 #### 必要権限
 
-| 権限名                                    | 説明         |
-|-----------------------------------------|-------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:NotificationGroup.List | 通知グループリストを表示 |
 
 #### リクエスト
@@ -4594,19 +5096,20 @@ GET /v1.0/notification-groups
 
 #### レスポンス
 
-| 名前                                        | 種類  | 形式      | 説明                                                    |
-|--------------------------------------------|------|----------|--------------------------------------------------------|
-| notificationGroups                         | Body | Array    | 通知グループリスト                                              |
-| notificationGroups.notificationGroupId     | Body | UUID     | 通知グループの識別子                                            |
-| notificationGroups.notificationGroupName   | Body | String   | 通知グループを識別できる名前                                    |
-| notificationGroups.notificationGroupStatus | Body | Enum     | 通知グループの現在状態<br/>- `CREATED`:作成済み<br/>- `DELETED`:削除済み |
-| notificationGroups.notifyEmail             | Body | Boolean  | メール通知の有無                                              |
-| notificationGroups.notifySms               | Body | Boolean  | SMS通知の有無                                              |
-| notificationGroups.isEnabled               | Body | Boolean  | 有効かどうか                                                 |
-| notificationGroups.createdYmdt             | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                      |
-| notificationGroups.updatedYmdt             | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                      |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| notificationGroups | Body | Array |  |
+| notificationGroups.notificationGroupId | Body | UUID | 通知グループの識別子 |
+| notificationGroups.notificationGroupName | Body | String | 通知グループを識別できる名前 |
+| notificationGroups.notificationGroupStatus | Body | Enum | 通知グループの現在状態<br/>- CREATED: `作成済み`<br/>- DELETED: `削除済み` |
+| notificationGroups.notifyEmail | Body | Boolean | メール通知の有無 |
+| notificationGroups.notifySms | Body | Boolean | SMS通知の有無 |
+| notificationGroups.isEnabled | Body | Boolean | 有効かどうか |
+| notificationGroups.createdYmdt | Body | DateTime | 作成日時 |
+| notificationGroups.updatedYmdt | Body | DateTime | 修正日時 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -4617,91 +5120,23 @@ GET /v1.0/notification-groups
     },
     "notificationGroups": [
         {
-            "notificationGroupId": "b3901f17-9971-4d1e-8a81-8448cf533dc7",
-            "notificationGroupName": "dev-team-noti",
-            "notifyEmail": true,
+            "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "notificationGroupName": "notificationGroupName-example",
+            "notificationGroupStatus": "CREATED",
+            "notifyEmail": false,
             "notifySms": false,
-            "isEnabled": true,
-            "createdYmdt": "2023-02-20T13:34:13+09:00",
-            "updatedYmdt": "2023-02-20T13:34:13+09:00"
+            "isEnabled": false,
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
+
+</p>
 </details>
 
-
-### 通知グループ詳細を表示
-
-```http
-GET /v1.0/notification-groups/{notificationGroupId}
-```
-
-#### 必要権限
-
-| 権限名                                   | 説明         |
-|----------------------------------------|-------------|
-| RDSforPostgreSQL:NotificationGroup.Get | 通知グループ詳細を表示 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前                 | 種類 | 形式  | 必須 | 説明        |
-|---------------------|-----|------|----|------------|
-| notificationGroupId | URL | UUID | O  | 通知グループの識別子 |
-
-#### レスポンス
-
-| 名前                        | 種類  | 形式      | 説明                                                    |
-|----------------------------|------|----------|--------------------------------------------------------|
-| notificationGroupId        | Body | UUID     | 通知グループの識別子                                            |
-| notificationGroupName      | Body | String   | 通知グループを識別できる名前                                    |
-| notificationGroupStatus    | Body | Enum     | 通知グループの現在状態<br/>- `CREATED`:作成済み<br/>- `DELETED`:削除済み |
-| notifyEmail                | Body | Boolean  | メール通知の有無                                              |
-| notifySms                  | Body | Boolean  | SMS通知の有無                                              |
-| isEnabled                  | Body | Boolean  | 有効かどうか                                                 |
-| dbInstances                | Body | Array    | 監視対象のDBインスタンスリスト                                      |
-| dbInstances.dbInstanceId   | Body | UUID     | DBインスタンスの識別子                                          |
-| dbInstances.dbInstanceName | Body | String   | DBインスタンスを識別できる名前                                  |
-| userGroups                 | Body | Array    | ユーザーグループリスト                                             |
-| userGroups.userGroupId     | Body | UUID     | ユーザーグループの識別子                                           |
-| userGroups.userGroupName   | Body | String   | ユーザーグループを識別できる名前                                   |
-| createdYmdt                | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                      |
-| updatedYmdt                | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                      |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "notificationGroupId": "b3901f17-9971-4d1e-8a81-8448cf533dc7",
-    "notificationGroupName": "dev-team-noti",
-    "notifyEmail": true,
-    "notifySms": false,
-    "isEnabled": true,
-    "dbInstances": [
-        {
-            "dbInstanceId": "ed5cb985-526f-4c54-9ae0-40288593de65",
-            "dbInstanceName": "database"
-        }
-    ],
-    "userGroups": [
-        {
-            "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-            "userGroupName": "dev-team"
-        }
-    ],
-    "createdYmdt": "2023-02-20T13:34:13+09:00",
-    "updatedYmdt": "2023-02-20T13:34:13+09:00"
-}
-```
-</details>
-
+---
 
 ### 通知グループの作成
 
@@ -4711,80 +5146,46 @@ POST /v1.0/notification-groups
 
 #### 必要権限
 
-| 権限名                                      | 説明        |
-|-------------------------------------------|------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:NotificationGroup.Create | 通知グループの作成 |
 
 #### リクエスト
 
-| 名前                   | 種類  | 形式     | 必須 | 説明                         |
-|-----------------------|------|---------|----|-----------------------------|
-| notificationGroupName | Body | String  | O  | 通知グループを識別できる名前         |
-| notifyEmail           | Body | Boolean | X  | メール通知の有無<br/>- デフォルト値:`true` |
-| notifySms             | Body | Boolean | X  | SMS通知の有無<br/>- デフォルト値:`true` |
-| isEnabled             | Body | Boolean | X  | 有効かどうか<br/>- デフォルト値:`true`    |
-| dbInstanceIds         | Body | Array   | X  | 監視対象のDBインスタンスの識別子リスト      |
-| userGroupIds          | Body | Array   | X  | ユーザーグループの識別子リスト             |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| notificationGroupName | Body | String | O | 通知グループを識別できる名前 |
+| notifyEmail | Body | Boolean | X | メール通知の有無<br/>- デフォルト値: `true` |
+| notifySms | Body | Boolean | X | SMS通知の有無<br/>- デフォルト値: `true` |
+| isEnabled | Body | Boolean | X | 有効かどうか<br/>- デフォルト値: `true` |
+| dbInstanceIds | Body | Array | O | 監視対象のDBインスタンスの識別子リスト |
+| userGroupIds | Body | Array | O | ユーザーグループの識別子リスト |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
-    "notificationGroupName": "dev-team-noti",
-    "notifyEmail": false,
-    "isEnable": true,
-    "dbInstanceIds": ["ed5cb985-526f-4c54-9ae0-40288593de65"],
-    "userGroupIds": ["1aac0437-f32d-4923-ad3c-ac61c1cfdfe0"]
+    "notificationGroupName": "notificationGroupName-example",
+    "notifyEmail": true,
+    "notifySms": true,
+    "isEnabled": true,
+    "dbInstanceIds": [],
+    "userGroupIds": []
 }
 ```
+
+</p>
 </details>
 
 #### レスポンス
 
-| 名前                 | 種類  | 形式  | 説明        |
-|---------------------|------|------|------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | notificationGroupId | Body | UUID | 通知グループの識別子 |
 
-
-### 通知グループの修正
-
-```http
-PUT /v1.0/notification-groups/{notificationGroupId}
-```
-
-#### 必要権限
-
-| 権限名                                      | 説明        |
-|-------------------------------------------|------------|
-| RDSforPostgreSQL:NotificationGroup.Modify | 通知グループの修正 |
-
-#### リクエスト
-
-| 名前                   | 種類  | 形式     | 必須 | 説明                   |
-|-----------------------|------|---------|----|-----------------------|
-| notificationGroupId   | URL  | UUID    | O  | 通知グループの識別子           |
-| notificationGroupName | Body | String  | X  | 通知グループを識別できる名前   |
-| notifyEmail           | Body | Boolean | X  | メール通知の有無             |
-| notifySms             | Body | Boolean | X  | SMS通知の有無             |
-| isEnabled             | Body | Boolean | X  | 有効かどうか                |
-| dbInstanceIds         | Body | Array   | X  | 監視対象のDBインスタンスの識別子リスト |
-| userGroupIds          | Body | Array   | X  | ユーザーグループの識別子リスト       |
-
 <details><summary>例</summary>
-
-```json
-{
-    "notifyEmail": true,
-    "dbInstanceIds": ["ed5cb985-526f-4c54-9ae0-40288593de65", "d51b7da0-682f-47ff-b588-b739f6adc740"]
-}
-```
-</details>
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
-
-<details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -4792,10 +5193,15 @@ PUT /v1.0/notification-groups/{notificationGroupId}
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
+
+---
 
 ### 通知グループの削除
 
@@ -4805,23 +5211,65 @@ DELETE /v1.0/notification-groups/{notificationGroupId}
 
 #### 必要権限
 
-| 権限名                                      | 説明        |
-|-------------------------------------------|------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:NotificationGroup.Delete | 通知グループの削除 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前                 | 種類 | 形式  | 必須 | 説明        |
-|---------------------|-----|------|----|------------|
-| notificationGroupId | URL | UUID | O  | 通知グループの識別子 |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O | 通知グループの識別子 |
 
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
 
+---
+
+### 通知グループ詳細を表示
+
+```http
+GET /v1.0/notification-groups/{notificationGroupId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:NotificationGroup.Get | 通知グループ詳細を表示 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O | 通知グループの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| notificationGroupId | Body | UUID | 通知グループの識別子 |
+| notificationGroupName | Body | String | 通知グループを識別できる名前 |
+| notificationGroupStatus | Body | Enum | 通知グループの現在状態<br/>- CREATED: `作成済み`<br/>- DELETED: `削除済み` |
+| notifyEmail | Body | Boolean | メール通知の有無 |
+| notifySms | Body | Boolean | SMS通知の有無 |
+| isEnabled | Body | Boolean | 有効かどうか |
+| dbInstances | Body | Array | 監視対象のDBインスタンスリスト |
+| dbInstances.dbInstanceId | Body | UUID | DBインスタンスの識別子 |
+| dbInstances.dbInstanceName | Body | String | DBインスタンスを識別できる名前 |
+| userGroups | Body | Array | ユーザーグループリスト |
+| userGroups.userGroupId | Body | UUID | ユーザーグループの識別子 |
+| userGroups.userGroupName | Body | String | ユーザーグループを識別できる名前 |
+| createdYmdt | Body | DateTime | 作成日時 |
+| updatedYmdt | Body | DateTime | 修正日時 |
+
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -4829,10 +5277,81 @@ DELETE /v1.0/notification-groups/{notificationGroupId}
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "notificationGroupName": "notificationGroupName-example",
+    "notificationGroupStatus": "CREATED",
+    "notifyEmail": false,
+    "notifySms": false,
+    "isEnabled": false,
+    "dbInstances": [
+        {
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbInstanceName": "dbInstanceName-example"
+        }
+    ],
+    "userGroups": [
+        {
+            "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "userGroupName": "userGroupName-example"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
+
+</p>
 </details>
+
+---
+
+### 通知グループの修正
+
+```http
+PUT /v1.0/notification-groups/{notificationGroupId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:NotificationGroup.Modify | 通知グループの修正 |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O | 通知グループの識別子 |
+| notificationGroupName | Body | String | X | 通知グループを識別できる名前 |
+| notifyEmail | Body | Boolean | X | メール通知の有無<br/>- デフォルト値: `false` |
+| notifySms | Body | Boolean | X | SMS通知の有無<br/>- デフォルト値: `false` |
+| isEnabled | Body | Boolean | X | 有効かどうか<br/>- デフォルト値: `false` |
+| dbInstanceIds | Body | Array | O | 監視対象のDBインスタンスの識別子リスト |
+| userGroupIds | Body | Array | O | ユーザーグループの識別子リスト |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "notificationGroupName": "notificationGroupName-example",
+    "notifyEmail": false,
+    "notifySms": false,
+    "isEnabled": false,
+    "dbInstanceIds": [],
+    "userGroupIds": []
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
 
 ### 監視設定リストを表示
 
@@ -4842,28 +5361,32 @@ GET /v1.0/notification-groups/{notificationGroupId}/watchdogs
 
 #### 必要権限
 
-| 権限名                                       | 説明         |
-|--------------------------------------------|-------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:NotificationWatchdog.List | 監視設定リストを表示 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O | 通知グループの識別子 |
+
 #### レスポンス
 
-| 名前                          | 種類  | 形式      | 説明                                                                    |
-|------------------------------|------|----------|------------------------------------------------------------------------|
-| notificationGroupId          | URL  | UUID     | 通知グループの識別子                                                            | 通知グループの識別子                                                           |
-| watchdogs                    | Body | Array    | 監視設定リスト                                                              |
-| watchdogs.watchdogId         | Body | UUID     | 監視設定の識別子                                                            |
-| watchdogs.metricName         | Body | Enum     | 監視対象の性能指標<br/>- 設定可能な性能指標は[性能指標リスト表示](#性能-指標-リスト-表示)項目を参照してください。 |
-| watchdogs.comparisonOperator | Body | Enum     | 監視対象の比較方法<br/>- `LE`: <=<br/>- `LT`: <<br/>- `GE`: >=<br/>- `GT`: >  |
-| watchdogs.threshold          | Body | Long     | 監視対象のしきい値                                                             |
-| watchdogs.duration           | Body | Long     | 監視対象の持続時間<br/>- 単位:`分`                                              |
-| watchdogs.createdYmdt        | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                      |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| notificationWatchdogs | Body | Array | 監視設定情報 |
+| notificationWatchdogs.watchdogId | Body | UUID | 監視設定の識別子 |
+| notificationWatchdogs.metricName | Body | String | 監視対象の性能指標 |
+| notificationWatchdogs.comparisonOperator | Body | Enum | 監視対象の比較方法<br/>- LE: `<=`<br/>- LT: `<`<br/>- GE: `>=`<br/>- GT: `>` |
+| notificationWatchdogs.threshold | Body | Number | 監視対象のしきい値 |
+| notificationWatchdogs.duration | Body | Number | 監視対象の持続時間 |
+| notificationWatchdogs.createdYmdt | Body | DateTime | 作成日時 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -4872,20 +5395,23 @@ GET /v1.0/notification-groups/{notificationGroupId}/watchdogs
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "watchdogs": [
+    "notificationWatchdogs": [
         {
-            "watchdogId": "b3901f17-9971-4d1e-8a81-8448cf533dc7",
-            "metricName": "DATABASE_STATUS",
+            "watchdogId": "550e8400-e29b-41d4-a716-446655440000",
+            "metricName": "metricName-example",
             "comparisonOperator": "LE",
-            "threshold": 0,
-            "duration": 5,
-            "createdYmdt": "2023-02-20T13:34:13+09:00",
-            "updatedYmdt": "2023-02-20T13:34:13+09:00"
+            "threshold": 1,
+            "duration": 1,
+            "createdYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
+
+</p>
 </details>
+
+---
 
 ### 監視設定の作成
 
@@ -4895,38 +5421,86 @@ POST /v1.0/notification-groups/{notificationGroupId}/watchdogs
 
 #### 必要権限
 
-| 権限名                                         | 説明        |
-|----------------------------------------------|------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:NotificationWatchdog.Create | 監視設定の作成 |
 
 #### リクエスト
 
-| 名前                 | 種類  | 形式  | 必須 | 説明                                                                    |
-|---------------------|------|------|----|------------------------------------------------------------------------|
-| notificationGroupId | URL  | UUID | O  | 通知グループの識別子                                                            |
-| metricName          | Body | Enum | O  | 監視対象の性能指標<br/>- 設定可能な性能指標は[性能指標リスト表示](#性能-指標-リスト-表示)項目を参照してください。 |
-| comparisonOperator  | Body | Enum | O  | 監視対象の比較方法<br/>- `LE`: <=<br/>- `LT`: <<br/>- `GE`: >=<br/>- `GT`: >  |
-| threshold           | Body | Long | O  | 監視対象しきい値                                                             |
-| duration            | Body | Long | O  | 監視対象持続時間<br/>- 単位:`分`                                              |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O | 通知グループの識別子 |
+| metricName | Body | String | O | 監視対象の性能指標 |
+| comparisonOperator | Body | Enum | O | 監視対象の比較方法<br/>- LE: `<=`<br/>- LT: `<`<br/>- GE: `>=`<br/>- GT: `>` |
+| threshold | Body | Number | O | 監視対象のしきい値<br/>- 最小値: `0` |
+| duration | Body | Number | O | 監視対象の持続時間（分）<br/>- 最小値: `0` |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
-    "metricName": "DATABASE_STATUS",
+    "metricName": "metricName-example",
     "comparisonOperator": "LE",
     "threshold": 0,
-    "duration": 5
+    "duration": 0
 }
 ```
+
+</p>
 </details>
 
 #### レスポンス
 
-| 名前        | 種類  | 形式  | 説明        |
-|------------|------|------|------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | watchdogId | Body | UUID | 監視設定の識別子 |
 
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "watchdogId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 通知グループの削除
+
+```http
+DELETE /v1.0/notification-groups/{notificationGroupId}/watchdogs/{watchdogId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:NotificationWatchdog.Delete | 通知グループの削除 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O | 通知グループの識別子 |
+| watchdogId | URL | UUID | O | 監視設定の識別子 |
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
 
 ### 監視設定の修正
 
@@ -4936,89 +5510,64 @@ PUT /v1.0/notification-groups/{notificationGroupId}/watchdogs/{watchdogId}
 
 #### 必要権限
 
-| 権限名                                         | 説明        |
-|----------------------------------------------|------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:NotificationWatchdog.Modify | 監視設定の修正 |
 
 #### リクエスト
 
-| 名前                 | 種類  | 形式  | 必須 | 説明                                                                    |
-|---------------------|------|------|----|------------------------------------------------------------------------|
-| notificationGroupId | URL  | UUID | O  | 通知グループの識別子                                                            |
-| watchdogId          | URL  | UUID | O  | 監視設定の識別子                                                            |
-| metricName          | Body | Enum | O  | 監視対象の性能指標<br/>- 設定可能な性能指標は[性能指標リスト表示](#性能-指標-リスト-表示)項目を参照してください。 |
-| comparisonOperator  | Body | Enum | O  | 監視対象の比較方法<br/>- `LE`: <=<br/>- `LT`: <<br/>- `GE`: >=<br/>- `GT`: >  |
-| threshold           | Body | Long | O  | 監視対象のしきい値                                                             |
-| duration            | Body | Long | O  | 監視対象の持続時間<br/>- 単位:`分`                                              |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O | 通知グループの識別子 |
+| watchdogId | URL | UUID | O | 監視設定の識別子 |
+| metricName | Body | String | O | 監視対象の性能指標 |
+| comparisonOperator | Body | Enum | O | 監視対象の比較方法<br/>- LE: `<=`<br/>- LT: `<`<br/>- GE: `>=`<br/>- GT: `>` |
+| threshold | Body | Number | O | 監視対象のしきい値<br/>- 最小値: `0` |
+| duration | Body | Number | O | 監視対象の持続時間（分）<br/>- 最小値: `0` |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
-    "metricName": "DATABASE_STATUS",
+    "metricName": "metricName-example",
     "comparisonOperator": "LE",
     "threshold": 0,
-    "duration": 10
+    "duration": 0
 }
 ```
+
+</p>
 </details>
 
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
 
-<details><summary>例</summary>
+---
+## モニタリング
 
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
-
-### 監視設定の削除
+### 統計情報照会
 
 ```http
-DELETE /v1.0/notification-groups/{notificationGroupId}/watchdogs/{watchdogId}
+GET /v1.0/metric-statistics
 ```
 
 #### 必要権限
 
-| 権限名                                         | 説明        |
-|----------------------------------------------|------------|
-| RDSforPostgreSQL:NotificationWatchdog.Delete | 監視設定の削除 |
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:Metric.List | 統計情報照会 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前                 | 種類 | 形式  | 必須 | 説明        |
-|---------------------|-----|------|----|------------|
-| notificationGroupId | URL | UUID | O  | 通知グループの識別子 |
-| watchdogId          | URL | UUID | O  | 監視設定の識別子 |
-
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
 
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
-
-## モニタリング
+---
 
 ### 性能指標リストを表示
 
@@ -5028,9 +5577,9 @@ GET /v1.0/metrics
 
 #### 必要権限
 
-| 権限名                         | 説明      |
-|------------------------------|----------|
-| RDSforPostgreSQL:Metric.List | 統計情報照会 |
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:Metric.List | 性能指標リストを表示 |
 
 #### リクエスト
 
@@ -5038,13 +5587,14 @@ GET /v1.0/metrics
 
 #### レスポンス
 
-| 名前                | 種類  | 形式    | 説明      |
-|--------------------|------|--------|----------|
-| metrics            | Body | Array  | 性能指標リスト |
-| metrics.metricName | Body | Enum   | 性能指標タイプ |
-| metrics.unit       | Body | String | 測定値単位  |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| metrics | Body | Array | 性能指標リスト |
+| metrics.metricName | Body | String | 性能指標タイプ |
+| metrics.unit | Body | String | 測定値単位 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -5055,159 +5605,32 @@ GET /v1.0/metrics
     },
     "metrics": [
         {
-            "metricName": "CPU_USAGE",
-            "unit": "%"
+            "metricName": "metricName-example",
+            "unit": "unit-example"
         }
     ]
 }
 ```
+
+</p>
 </details>
 
-### 統計情報照会
-
-```http
-GET /v1.0/metric-statistics
-```
-
-#### 必要権限
-
-| 権限名                         | 説明      |
-|------------------------------|----------|
-| RDSforPostgreSQL:Metric.List | 統計情報照会 |
-
-#### リクエスト
-
-| 名前          | 種類   | 形式      | 必須 | 説明                                                       |
-|--------------|-------|----------|----|-----------------------------------------------------------|
-| dbInstanceId | Query | UUID     | O  | DBインスタンスの識別子                                             |
-| metricNames  | Query | Array    | O  | 照会する性能指標リスト<br/>- 最小サイズ:`1`                             |
-| from         | Query | Datetime | O  | 開始日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                         |
-| to           | Query | Datetime | O  | 終了日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                         |
-| interval     | Query | Number   | X  | 照会間隔<br/>- 単位:`分`<br/>- デフォルト値:開始/終了日時に応じて適切な値を自動選択する |
-
-#### レスポンス
-
-| 名前                               | 種類  | 形式       | 説明      |
-|-----------------------------------|------|-----------|----------|
-| metricStatistics                  | Body | Array     | 統計情報リスト |
-| metricStatistics.metricName       | Body | Enum      | 性能指標タイプ |
-| metricStatistics.unit             | Body | String    | 測定値単位  |
-| metricStatistics.values           | Body | Array     | 測定値リスト  |
-| metricStatistics.values.timestamp | Body | Timestamp | 測定時間   |
-| metricStatistics.values.value     | Body | Object    | 測定値     |
-
-<details><summary>例</summary>
-
-```json
-{
-    "metricStatistics": [
-        {
-            "metricName": "DATABASE_STATUS",
-            "unit": "",
-            "values": [
-                [
-                    1679298540,
-                    "1"
-                ],
-                [
-                    1679298600,
-                    "1"
-                ],
-                [
-                    1679298660,
-                    "1"
-                ]
-            ]
-        }
-    ]
-}
-```
-</details>
+---
 
 ## イベント
 
-### イベントリストを表示
+### イベントカテゴリー
 
-```
-GET /v1.0/events
-```
+イベントはカテゴリーで分類でき、以下のとおりです。
 
-#### 必要権限
-
-| 権限名                        | 説明       |
-|-----------------------------|-----------|
-| RDSforPostgreSQL:Event.List | イベントリスト表示 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前               | 種類   | 形式      | 必須 | 説明                                                                                                                                                                              |
-|-------------------|-------|----------|----|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| page              | Query | Number   | O  | 照会するリストのページ<br/>- 最小値:`1`                                                                                                                                                       |
-| size              | Query | Number   | O  | 照会するリストのページサイズ<br/>- 最小値:`1`<br/>- 最大値:`100`                                                                                                                                   |
-| from              | Query | Datetime | O  | 開始日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                |
-| to                | Query | Datetime | O  | 終了日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                |
-| eventCategoryType | Query | Enum     | O  | 照会するイベントカテゴリータイプ<br/>- `ALL`:全体<br/>- `BACKUP`:バックアップ<br/>- `DB_INSTANCE`:DBインスタンス<br/>- `DB_SECURITY_GROUP`:DBセキュリティグループ<br/>- `JOB`:作業<br/>- `TENANT`:テナント<br/>- `MONITORING`:モニタリング |
-| sourceId          | Query | String   | X  | イベントが発生した対象リソースの識別子                                                                                                                                                            |
-| keyword           | Query | String   | X  | イベントメッセージに含まれた文字列検索ワード                                                                                                                                                            |
-
-#### レスポンス
-
-| 名前                      | 種類  | 形式      | 説明                                                |
-|--------------------------|------|----------|----------------------------------------------------|
-| totalCounts              | Body | Number   | 全体のイベントリスト数                                        |
-| events                   | Body | Array    | イベントリスト                                            |
-| events.eventCategoryType | Body | Enum     | イベントカテゴリータイプ                                       |
-| events.eventCode         | Body | Enum     | 発生したイベントのタイプ<br/>- 詳細は[イベント](event/)項目を参照してください。 |
-| events.sourceId          | Body | String   | イベントソースの識別子                                       |
-| events.sourceName        | Body | String   | イベントソースを識別できる名前                               |
-| events.messages          | Body | Array    | イベントメッセージリスト                                        |
-| events.messages.langCode | Body | String   | 言語コード                                             |
-| events.messages.message  | Body | String   | イベントメッセージ                                           |
-| events.eventYmdt         | Body | DateTime | イベント発生日時(YYYY-MM-DDThh:mm:ss.SSSTZD)              |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 28,
-    "events": [
-        {
-            "eventCategoryType": "DB_INSTANCE",
-            "eventCode": "DB_INSTANCE_02_01",
-            "sourceId": "76f00947-356e-4a20-8922-428368cc45ed",
-            "sourceName": "db-instance",
-            "messages": [
-                {
-                    "langCode": "EN",
-                    "message": "DB instance started"
-                },
-                {
-                    "langCode": "JA",
-                    "message": "DBインスタンスの起動"
-                },
-                {
-                    "langCode": "KO",
-                    "message": "DBインスタンス開始"
-                },
-                {
-                    "langCode": "ZH",
-                    "message": "DB instance started"
-                }
-            ],
-            "eventYmdt": "2023-03-20T16:31:59+09:00"
-        }
-    ]
-}
-```
-</details>
-
+| イベントカテゴリー | 説明 |
+|-------------|---------|
+| ALL         | 全体 |
+| BACKUP      | バックアップ |
+| DB_INSTANCE | DBインスタンス |
+| JOB         | 作業 |
+| TENANT      | テナント |
+| MONITORING  | モニタリング |
 
 ### 購読可能なイベントコードリストを表示
 
@@ -5217,9 +5640,9 @@ GET /v1.0/event-codes
 
 #### 必要権限
 
-| 権限名                        | 説明       |
-|-----------------------------|-----------|
-| RDSforPostgreSQL:Event.List | イベントリストを表示 |
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:Event.List | 購読可能なイベントコードリストを表示 |
 
 #### リクエスト
 
@@ -5227,13 +5650,14 @@ GET /v1.0/event-codes
 
 #### レスポンス
 
-| 名前                          | 種類  | 形式   | 説明         |
-|------------------------------|------|-------|-------------|
-| eventCodes                   | Body | Array | イベントコードリスト  |
-| eventCodes.eventCode         | Body | Enum  | イベントコード     |
-| eventCodes.eventCategoryType | Body | Enum  | イベントカテゴリータイプ |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| eventCodes | Body | Array | イベントコードリスト |
+| eventCodes.eventCode | Body | Enum | イベントコード |
+| eventCodes.eventCategoryType | Body | Enum | イベントカテゴリータイプ<br/>- ALL: `全体`<br/>- DB_INSTANCE: `DBインスタンスで発生したイベント`<br/>- DB_SECURITY_GROUP: `DBセキュリティグループで発生したイベント`<br/>- MONITORING: `モニタリングで発生したイベント`<br/>- JOB: `JOBで発生したイベント`<br/>- BACKUP: `バックアップで発生したイベント`<br/>- TENANT: `テナントで発生したイベント` |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -5244,10 +5668,79 @@ GET /v1.0/event-codes
     },
     "eventCodes": [
         {
-            "eventCode": "DB_INSTANCE_02_01",
-            "eventCategoryType": "DB_INSTANCE"
+            "eventCode": "ENUM_VALUE",
+            "eventCategoryType": "ALL"
         }
     ]
 }
 ```
+
+</p>
 </details>
+
+---
+
+### イベントリストを表示
+
+```http
+GET /v1.0/events
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:Event.List | イベントリストを表示 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | 全体のイベントリスト数 |
+| events | Body | Array | イベントリスト |
+| events.eventCategoryType | Body | Enum | イベントカテゴリータイプ<br/>- ALL: `全体`<br/>- DB_INSTANCE: `DBインスタンスで発生したイベント`<br/>- DB_SECURITY_GROUP: `DBセキュリティグループで発生したイベント`<br/>- MONITORING: `モニタリングで発生したイベント`<br/>- JOB: `JOBで発生したイベント`<br/>- BACKUP: `バックアップで発生したイベント`<br/>- TENANT: `テナントで発生したイベント` |
+| events.eventCode | Body | Enum | 発生したイベントのタイプ |
+| events.sourceId | Body | UUID | イベントソースの識別子 |
+| events.sourceName | Body | String | イベントソースを識別できる名前 |
+| events.messages | Body | Array | イベントメッセージリスト |
+| events.messages.langCode | Body | Enum | 言語コード<br/>- KO<br/>- EN<br/>- JA<br/>- ZH |
+| events.messages.message | Body | String | イベントメッセージ |
+| events.eventYmdt | Body | DateTime | イベント発生日時 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "totalCounts": 1,
+    "events": [
+        {
+            "eventCategoryType": "ALL",
+            "eventCode": "ENUM_VALUE",
+            "sourceId": "550e8400-e29b-41d4-a716-446655440000",
+            "sourceName": "sourceName-example",
+            "messages": [
+                {
+                    "langCode": "KO",
+                    "message": "message-example"
+                }
+            ],
+            "eventYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---

--- a/ko/api-guide-v1.0.md
+++ b/ko/api-guide-v1.0.md
@@ -1119,7 +1119,7 @@ POST /v1.0/db-instances/restore-from-obs
         ]
     },
     "restore": {
-        "tenantId": "tenantId-example",
+        "tenantId": "0123456789abcdef0123456789abcdef",
         "username": "username-example",
         "password": "password-example",
         "targetContainer": "targetContainer-example",
@@ -1685,7 +1685,7 @@ POST /v1.0/db-instances/{dbInstanceId}/backup-to-object-storage
 
 ```json
 {
-    "tenantId": "tenantId-example",
+    "tenantId": "0123456789abcdef0123456789abcdef",
     "username": "username-example",
     "password": "password-example",
     "targetContainer": "targetContainer-example",
@@ -3814,7 +3814,7 @@ POST /v1.0/backups/{backupId}/export
 
 ```json
 {
-    "tenantId": "tenantId-example",
+    "tenantId": "0123456789abcdef0123456789abcdef",
     "username": "username-example",
     "password": "password-example",
     "targetContainer": "targetContainer-example",
@@ -5724,7 +5724,7 @@ GET /v1.0/events
 | events | Body | Array | 이벤트 목록 |
 | events.eventCategoryType | Body | Enum | 이벤트 카테고리 유형<br/>- ALL: `전체`<br/>- DB_INSTANCE: `DB 인스턴스로 발생한 이벤트`<br/>- DB_SECURITY_GROUP: `DB 보안 그룹으로 발생한 이벤트`<br/>- MONITORING: `모니터링으로 발생한 이벤트`<br/>- JOB: `JOB으로 발생한 이벤트`<br/>- BACKUP: `백업으로 발생한 이벤트`<br/>- TENANT: `테넌트로 발생한 이벤트` |
 | events.eventCode | Body | Enum | 발생한 이벤트의 유형 |
-| events.sourceId | Body | String | 이벤트 소스의 식별자 |
+| events.sourceId | Body | UUID | 이벤트 소스의 식별자 |
 | events.sourceName | Body | String | 이벤트 소스를 식별할 수 있는 이름 |
 | events.messages | Body | Array | 이벤트 메세지 목록 |
 | events.messages.langCode | Body | Enum | 언어 코드<br/>- KO<br/>- EN<br/>- JA<br/>- ZH |
@@ -5746,7 +5746,7 @@ GET /v1.0/events
         {
             "eventCategoryType": "ALL",
             "eventCode": "ENUM_VALUE",
-            "sourceId": "sourceId-example",
+            "sourceId": "550e8400-e29b-41d4-a716-446655440000",
             "sourceName": "sourceName-example",
             "messages": [
                 {

--- a/ko/api-guide-v1.0.md
+++ b/ko/api-guide-v1.0.md
@@ -54,21 +54,12 @@ API 요청 시 인증에 실패하거나 권한이 없을 경우 다음과 같�
 | 한국(판교) 리전 | https://kr1-rds-postgres.api.nhncloudservice.com |
 | 한국(평촌) 리전 | https://kr2-rds-postgres.api.nhncloudservice.com |
 
-## DB 보안 그룹
+## DB 버전
 
-### DB 보안 그룹 진행 상태
-
-| 상태              | 설명           |
-|-----------------|--------------|
-| `NONE`          | 진행 중인 작업이 없음 |
-| `CREATING_RULE` | 규칙 정책 생성 중   |
-| `UPDATING_RULE` | 규칙 정책 수정 중   |
-| `DELETING_RULE` | 규칙 정책 삭제 중   |
-
-### DB 보안 그룹 목록 보기
+### DB 버전 목록 보기
 
 ```http
-GET /v1.0/db-security-groups
+GET /v1.0/db-versions
 ```
 
 #### 요청
@@ -79,14 +70,11 @@ GET /v1.0/db-security-groups
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| dbSecurityGroups | Body | Array | DB 보안 그룹 목록 |
-| dbSecurityGroups.dbSecurityGroupId | Body | String | DB 보안 그룹의 식별자 |
-| dbSecurityGroups.dbSecurityGroupName | Body | String | DB 보안 그룹을 식별할 수 있는 이름 |
-| dbSecurityGroups.dbSecurityGroupStatus | Body | Enum | DB 보안 그룹의 현재 상태<br/>- CREATED: `생성됨`<br/>- DELETED: `삭제됨` |
-| dbSecurityGroups.description | Body | String | DB 보안 그룹에 대한 추가 정보 |
-| dbSecurityGroups.progressStatus | Body | Enum | DB 보안 그룹의 현재 진행 상태<br/>- NONE: `없음`<br/>- CREATING_RULE: `규칙 생성중`<br/>- UPDATING_RULE: `규칙 수정중`<br/>- DELETING_RULE: `규칙 삭제중`<br/>- APPLYING_DEFAULT_RULE: `기본 규칙 적용중` |
-| dbSecurityGroups.createdYmdt | Body | DateTime | 생성 일시 |
-| dbSecurityGroups.updatedYmdt | Body | DateTime | 수정 일시 |
+| dbVersions | Body | Array | DB 버전 정보 |
+| dbVersions.dbVersionCode | Body | Enum | DB 버전 코드<br/>- MYSQL_V5633<br/>- MYSQL_V5715<br/>- MYSQL_V5719<br/>- MYSQL_V5726<br/>- MYSQL_V5731<br/>- MYSQL_V5733<br/>- MYSQL_V5737<br/>- MYSQL_V8018<br/>- MYSQL_V8023<br/>- MYSQL_V8028<br/>- MYSQL_V8032<br/>- MYSQL_V8033<br/>- MYSQL_V8034<br/>- MYSQL_V8035<br/>- MYSQL_V8036<br/>- MYSQL_V8040<br/>- MYSQL_V8041<br/>- MYSQL_V8042<br/>- MYSQL_V8043<br/>- MYSQL_V8044<br/>- MYSQL_V8045<br/>- MYSQL_V8405<br/>- MYSQL_V8406<br/>- MYSQL_V8407<br/>- MYSQL_V8408<br/>- MARIADB_V10330<br/>- MARIADB_V10611<br/>- MARIADB_V10612<br/>- MARIADB_V10616<br/>- MARIADB_V10622<br/>- MARIADB_V10625<br/>- MARIADB_V101107<br/>- MARIADB_V101108<br/>- MARIADB_V101113<br/>- MARIADB_V101116<br/>- MARIADB_V11407<br/>- MARIADB_V11410<br/>- MARIADB_V11806<br/>- POSTGRESQL_V14_6<br/>- POSTGRESQL_V14_15<br/>- POSTGRESQL_V14_17<br/>- POSTGRESQL_V14_19<br/>- POSTGRESQL_V17_2<br/>- POSTGRESQL_V17_4<br/>- POSTGRESQL_V17_6 |
+| dbVersions.dbMajorVersionCode | Body | Enum | DB 메이저 버전 코드<br/>- MYSQL_V56<br/>- MYSQL_V57<br/>- MYSQL_V80<br/>- MYSQL_V84<br/>- MARIADB_V103<br/>- MARIADB_V106<br/>- MARIADB_V1011<br/>- MARIADB_V114<br/>- MARIADB_V118<br/>- POSTGRES_V14<br/>- POSTGRES_V17 |
+| dbVersions.name | Body | String | DB 버전명 |
+| dbVersions.canCreate | Body | Boolean | 신규 생성 가능 여부 |
 
 <details><summary>예시</summary>
 <p>
@@ -98,7 +86,339 @@ GET /v1.0/db-security-groups
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "dbSecurityGroups": [
+    "dbVersions": [
+        {
+            "canCreate": false
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+## DB 인스턴스 사양
+
+### DB 인스턴스 유형 목록 보기
+
+```http
+GET /v1.0/db-flavors
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| dbFlavors | Body | Array | DB 인스턴스 사양 정보 |
+| dbFlavors.dbFlavorId | Body | String | DB 인스턴스 사양의 식별자 |
+| dbFlavors.dbFlavorName | Body | String | DB 인스턴스 사양명 |
+| dbFlavors.ram | Body | Number | 메모리 용량(MB) |
+| dbFlavors.vcpus | Body | Number | CPU 코어 수 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "dbFlavors": [
+        {
+            "vcpus": 2
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+## 프로젝트 정보
+
+### 프로젝트의 멤버 목록 조회
+
+```http
+GET /v1.0/project/members
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| projectMembers | Body | Array | 프로젝트 멤버 정보 |
+| projectMembers.memberId | Body | String | 프로젝트 멤버의 식별자 |
+| projectMembers.memberName | Body | String | 프로젝트 멤버의 이름 |
+| projectMembers.emailAddress | Body | String | 프로젝트 멤버의 이메일 주소 |
+| projectMembers.phoneNumber | Body | String | 프로젝트 멤버의 전화번호 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "projectMembers": [
+        {
+            "phoneNumber": "phoneNumber-example"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### 프로젝트의 리전 목록 조회
+
+```http
+GET /v1.0/project/regions
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| regions | Body | Array | 리전 정보 |
+| regions.regionCode | Body | Enum | 리전 코드<br/>- KR1: `한국(판교)`<br/>- KR2: `한국(평촌)` |
+| regions.isEnabled | Body | Boolean | 리전의 활성화 여부 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "regions": [
+        {
+            "isEnabled": false
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+## 네트워크
+
+### 서브넷 목록 보기
+
+```http
+GET /v1.0/network/subnets
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| subnets | Body | Array | 서브넷 정보 |
+| subnets.subnetId | Body | String | 서브넷의 식별자 |
+| subnets.subnetName | Body | String | 서브넷을 식별할 수 있는 이름 |
+| subnets.subnetCidr | Body | String | 서브넷의 CIDR |
+| subnets.usingGateway | Body | Boolean | 게이트웨이 사용 여부 |
+| subnets.availableIpCount | Body | Number | 사용 가능한 IP 수 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "subnets": [
+        {
+            "availableIpCount": 1
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+## 스토리지
+
+### 스토리지 유형 목록 보기
+
+```http
+GET /v1.0/storage-types
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| storageTypes | Body | Array | 스토리지 유형 정보 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "storageTypes": []
+}
+```
+
+</p>
+</details>
+
+---
+
+## 작업 정보
+
+### 작업 상태
+
+| 상태명                | 설명                   |
+|--------------------|----------------------|
+| `PREPARING`        | 작업이 준비 중인 경우         |
+| `READY`            | 작업이 준비 완료된 경우        |
+| `RUNNING`          | 작업이 진행 중인 경우         |
+| `COMPLETED`        | 작업이 완료된 경우           |
+| `REGISTERED`       | 작업이 등록된 경우           |
+| `WAIT_TO_REGISTER` | 작업 등록 대기 중인 경우       |
+| `INTERRUPTED`      | 작업 진행 중 인터럽트가 발생한 경우 |
+| `CANCELED`         | 작업이 취소된 경우           |
+| `FAILED`           | 작업이 실패한 경우           |
+| `ERROR`            | 작업 진행 중 오류가 발생한 경우   |
+| `DELETED`          | 작업이 삭제된 경우           |
+| `FAIL_TO_READY`    | 작업 준비에 실패한 경우        |
+
+### 작업 정보 상세 보기
+
+```http
+GET /v1.0/jobs/{jobId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| jobId | URL | UUID | O |  |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | String | 작업의 식별자 |
+| jobStatus | Body | Enum | 작업의 현재 상태<br/>- DELETED<br/>- CANNOT_PROGRESS<br/>- FAILED<br/>- ERROR<br/>- CANCELED<br/>- INTERRUPTED<br/>- COMPLETED<br/>- COMPLETED_WITH_ERROR<br/>- RUNNING<br/>- PREPARING<br/>- READY<br/>- CREATED<br/>- FAIL_TO_READY<br/>- REGISTERED<br/>- FAIL_TO_REGISTER<br/>- WAIT_TO_REGISTER |
+| resourceRelations | Body | Array | 연관 리소스 목록 |
+| resourceRelations.resourceType | Body | String | 연관 리소스 유형 |
+| resourceRelations.resourceId | Body | String | 연관 리소스의 식별자 |
+| createdYmdt | Body | DateTime | 생성 일시 |
+| updatedYmdt | Body | DateTime | 수정 일시 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "jobId-example",
+    "jobStatus": "DELETED",
+    "resourceRelations": [
+        {
+            "resourceId": "resourceId-example"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+```
+
+</p>
+</details>
+
+---
+
+## DB 인스턴스 그룹
+
+### DB 인스턴스 그룹 목록 보기
+
+```http
+GET /v1.0/db-instance-groups
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceGroups | Body | Array | DB 인스턴스 그룹 정보 |
+| dbInstanceGroups.dbInstanceGroupId | Body | String | DB 인스턴스 그룹의 식별자 |
+| dbInstanceGroups.dbInstanceGroupStatus | Body | Enum | DB 인스턴스 그룹의 현재 형태<br/>- CREATED: `생성됨`<br/>- DELETED: `삭제됨` |
+| dbInstanceGroups.replicationType | Body | Enum | DB 인스턴스 그룹의 복제 형태<br/>- STANDALONE: `고가용성 사용 안함`<br/>- HIGH_AVAILABILITY: `고가용성 사용` |
+| dbInstanceGroups.createdYmdt | Body | DateTime | 생성 일시 |
+| dbInstanceGroups.updatedYmdt | Body | DateTime | 수정 일시 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "dbInstanceGroups": [
         {
             "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
@@ -111,51 +431,92 @@ GET /v1.0/db-security-groups
 
 ---
 
-### DB 보안 그룹 생성하기
+### DB 인스턴스 그룹 상세 보기
 
 ```http
-POST /v1.0/db-security-groups
+GET /v1.0/db-instance-groups/{dbInstanceGroupId}
 ```
 
 #### 요청
 
+이 API는 요청 본문을 요구하지 않습니다.
+
 | 이름 | 종류 | 형식 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbSecurityGroupName | Body | String | O | DB 보안 그룹을 식별할 수 있는 이름 |
-| description | Body | String | X | DB 보안 그룹에 대한 추가 정보 |
-| rules | Body | Array | O | DB 보안 그룹 규칙 정보 |
-| rules.direction | Body | Enum | O | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
-| rules.etherType | Body | Enum | O | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
-| rules.port | Body | Object | O | 포트 객체 |
-| rules.port.portType | Body | Enum | O | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
-| rules.port.minPort | Body | Number | X | 최소 포트 범위<br/>- 최솟값: `1` |
-| rules.port.maxPort | Body | Number | X | 최대 포트 범위<br/>- 최댓값: `65535` |
-| rules.cidr | Body | String | O | CIDR |
-| rules.description | Body | String | X | 보안 그룹 규칙에 대한 추가 정보 |
+| dbInstanceGroupId | URL | UUID | O |  |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceGroupId | Body | String | DB 인스턴스 그룹의 식별자 |
+| dbInstanceGroupStatus | Body | Enum | DB 인스턴스 그룹의 현재 상태<br/>- CREATED: `생성됨`<br/>- DELETED: `삭제됨` |
+| replicationType | Body | Enum | DB 인스턴스 그룹의 복제 형태<br/>- STANDALONE: `고가용성 사용 안함`<br/>- HIGH_AVAILABILITY: `고가용성 사용` |
+| dbInstances | Body | Array | DB 인스턴스 그룹에 속한 DB 인스턴스 목록 |
+| dbInstances.dbInstanceId | Body | String | DB 인스턴스의 식별자 |
+| dbInstances.dbInstanceType | Body | Enum | DB 인스턴스의 역할 타입<br/>- MASTER: `마스터`<br/>- FAILED_MASTER: `장애 마스터`<br/>- CANDIDATE_MASTER: `예비 마스터`<br/>- READ_ONLY_SLAVE: `읽기 복제본` |
+| dbInstances.dbInstanceStatus | Body | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전 (회색)`<br/>- AVAILABLE: `사용 가능 (녹색)`<br/>- STORAGE_FULL: `용량 부족 (적색)`<br/>- FAIL_TO_CREATE: `생성 실패 (적색)`<br/>- FAIL_TO_CONNECT: `연결 실패 (적색)`<br/>- REPLICATION_STOP: `복제 중단 (적색)`<br/>- REPLICATION_DELAY: `복제 지연 (황색)`<br/>- FAILOVER: `장애 조치 완료 (적색)`<br/>- SHUTDOWN: `중지 됨 (회색)`<br/>- DELETED: `삭제됨 (회색)` |
+| createdYmdt | Body | DateTime | 생성 일시 |
+| updatedYmdt | Body | DateTime | 수정 일시 |
 
 <details><summary>예시</summary>
 <p>
 
 ```json
 {
-    "dbSecurityGroupName": "dbSecurityGroupName-example",
-    "description": "description-example",
-    "rules": [
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "dbInstanceGroupId": "dbInstanceGroupId-example",
+    "dbInstanceGroupStatus": "CREATED",
+    "replicationType": "STANDALONE",
+    "dbInstances": [
         {
-            "description": "description-example"
+            "dbInstanceStatus": "BEFORE_CREATE"
         }
-    ]
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
 </p>
 </details>
 
+---
+
+### 확장 리스트 조회
+
+```http
+GET /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | O | DB 인스턴스 그룹 ID |
+
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| dbSecurityGroupId | Body | String | DB 보안 그룹의 식별자 |
+| extensions | Body | Array | 확장 정보 |
+| extensions.extensionId | Body | String | 확장 ID |
+| extensions.extensionName | Body | String | 확장 이름 |
+| extensions.extensionStatus | Body | Enum | 확장 상태<br/>- AVAILABLE: `사용 가능`<br/>- NEED_TO_APPLY: `적용 필요`<br/>- APPLYING: `적용 중` |
+| extensions.databases | Body | Array | 데이터베이스 정보 |
+| extensions.databases.dbInstanceGroupExtensionId | Body | String | DB 인스턴스 그룹 확장 ID |
+| extensions.databases.databaseId | Body | String | 데이터베이스 ID |
+| extensions.databases.databaseName | Body | String | 데이터베이스 이름 |
+| extensions.databases.dbInstanceGroupExtensionStatus | Body | Enum | 데이터베이스 확장 설치 상태<br/>- CREATED: `생성 됨`<br/>- INSTALLED: `설치 됨`<br/>- INSTALLING: `설치 중`<br/>- INSTALL_ERROR: `설치 에러`<br/>- DELETED: `삭제 됨`<br/>- DELETING: `삭제 중`<br/>- DELETE_ERROR: `삭제 에러` |
+| extensions.databases.reservedAction | Body | Enum | 예약 작업<br/>- NONE: `없음`<br/>- INSTALL: `설치 예약 (적용 필요)`<br/>- INSTALL_WITH_CASCADE: `강제 설치 예약 (적용 필요)`<br/>- DELETE: `삭제 예약 (적용 필요)`<br/>- DELETE_WITH_CASCADE: `강제 삭제 예약 (적용 필요)` |
+| extensions.databases.errorReason | Body | String | 에러 원인 |
+| isNeedToApply | Body | Boolean | 적용 필요 여부 |
 
 <details><summary>예시</summary>
 <p>
@@ -167,98 +528,14 @@ POST /v1.0/db-security-groups
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "dbSecurityGroupId": "dbSecurityGroupId-example"
-}
-```
-
-</p>
-</details>
-
----
-
-### DB 보안 그룹 삭제하기
-
-```http
-DELETE /v1.0/db-security-groups/{dbSecurityGroupId}
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
----
-
-### DB 보안 그룹 상세 보기
-
-```http
-GET /v1.0/db-security-groups/{dbSecurityGroupId}
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| dbSecurityGroup | Body | Object | DB 보안 그룹 |
-| dbSecurityGroup.dbSecurityGroupId | Body | String | DB 보안 그룹의 식별자 |
-| dbSecurityGroup.dbSecurityGroupName | Body | String | DB 보안 그룹을 식별할 수 있는 이름 |
-| dbSecurityGroup.dbSecurityGroupStatus | Body | Enum | DB 보안 그룹의 현재 상태<br/>- CREATED: `생성됨`<br/>- DELETED: `삭제됨` |
-| dbSecurityGroup.description | Body | String | DB 보안 그룹에 대한 추가 정보 |
-| dbSecurityGroup.progressStatus | Body | Enum | DB 보안 그룹의 현재 진행 상태<br/>- NONE: `없음`<br/>- CREATING_RULE: `규칙 생성중`<br/>- UPDATING_RULE: `규칙 수정중`<br/>- DELETING_RULE: `규칙 삭제중`<br/>- APPLYING_DEFAULT_RULE: `기본 규칙 적용중` |
-| dbSecurityGroup.rules | Body | Array | DB 보안 그룹 규칙 목록 |
-| dbSecurityGroup.rules.ruleId | Body | String | DB 보안 그룹 규칙의 식별자 |
-| dbSecurityGroup.rules.description | Body | String | DB 보안 그룹 규칙에 대한 추가 정보 |
-| dbSecurityGroup.rules.direction | Body | Enum | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
-| dbSecurityGroup.rules.etherType | Body | Enum | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
-| dbSecurityGroup.rules.port | Body | Object | 포트 객체 |
-| dbSecurityGroup.rules.port.portType | Body | Enum | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
-| dbSecurityGroup.rules.port.minPort | Body | Number | 최소 포트 범위 |
-| dbSecurityGroup.rules.port.maxPort | Body | Number | 최대 포트 범위 |
-| dbSecurityGroup.rules.cidr | Body | String | CIDR |
-| dbSecurityGroup.rules.createdYmdt | Body | DateTime | 생성 일시 |
-| dbSecurityGroup.rules.updatedYmdt | Body | DateTime | 수정 일시 |
-| dbSecurityGroup.createdYmdt | Body | DateTime | 생성 일시 |
-| dbSecurityGroup.updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbSecurityGroup": {
-        "dbSecurityGroupId": "dbSecurityGroupId-example",
-        "dbSecurityGroupName": "dbSecurityGroupName-example",
-        "dbSecurityGroupStatus": "CREATED",
-        "description": "description-example",
-        "progressStatus": "NONE",
-        "rules": [
-            {
-                "updatedYmdt": "2023-12-31T15:00:00+09:00"
+    "extensions": [
+        {
+            "databases": {
+                "errorReason": "errorReason-example"
             }
-        ],
-        "createdYmdt": "2023-12-31T15:00:00+09:00",
-        "updatedYmdt": "2023-12-31T15:00:00+09:00"
-    }
+        }
+    ],
+    "isNeedToApply": false
 }
 ```
 
@@ -267,27 +544,130 @@ GET /v1.0/db-security-groups/{dbSecurityGroupId}
 
 ---
 
-### DB 보안 그룹 수정하기
+### 확장 변경사항 적용
 
 ```http
-PUT /v1.0/db-security-groups/{dbSecurityGroupId}
+POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/apply
 ```
 
 #### 요청
 
+이 API는 요청 본문을 요구하지 않습니다.
+
 | 이름 | 종류 | 형식 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
-| dbSecurityGroupName | Body | String | O | DB 보안 그룹을 식별할 수 있는 이름 |
-| description | Body | String | X | DB 보안 그룹에 대한 추가 정보 |
+| dbInstanceGroupId | URL | UUID | O | DB 인스턴스 그룹 ID |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
 
 <details><summary>예시</summary>
 <p>
 
 ```json
 {
-    "dbSecurityGroupName": "dbSecurityGroupName-example",
-    "description": "description-example"
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 확장 동기화
+
+```http
+POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/sync
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | O | DB 인스턴스 그룹 ID |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 확장 삭제(취소)
+
+```http
+DELETE /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{dbInstanceGroupExtensionId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | O | DB 인스턴스 그룹 ID |
+| dbInstanceGroupExtensionId | URL | UUID | O | DB 인스턴스 그룹 확장 ID |
+| withCascade | Query | Boolean | O | 강제 삭제 여부 |
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### 확장 설치
+
+```http
+POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{extensionId}
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | O | DB 인스턴스 그룹 ID |
+| extensionId | URL | UUID | O | 확장 ID |
+| databaseId | Body | UUID | O | 데이터베이스 ID |
+| schemaName | Body | String | O | 스키마 이름 |
+| withCascade | Body | Boolean | X | 연관 정보 자동 설치 여부<br/>- 기본값: `false` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "databaseId": "550e8400-e29b-41d4-a716-446655440000",
+    "schemaName": "schemaName-example",
+    "withCascade": false
 }
 ```
 
@@ -297,177 +677,6 @@ PUT /v1.0/db-security-groups/{dbSecurityGroupId}
 #### 응답
 
 이 API는 응답 본문을 반환하지 않습니다.
-
----
-
-### DB 보안 그룹 규칙 삭제하기
-
-```http
-DELETE /v1.0/db-security-groups/{dbSecurityGroupId}/rules
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
-| ruleIds | Query | String | O | DB 보안 그룹 규칙 ID 리스트 |
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
-}
-```
-
-</p>
-</details>
-
----
-
-### DB 보안 그룹 규칙 생성하기
-
-```http
-POST /v1.0/db-security-groups/{dbSecurityGroupId}/rules
-```
-
-#### 요청
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
-| direction | Body | Enum | O | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
-| etherType | Body | Enum | O | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
-| port | Body | Object | O | 포트 정보 |
-| port.portType | Body | Enum | O | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
-| port.minPort | Body | Number | X | 최소 포트 범위<br/>- 최솟값: `1` |
-| port.maxPort | Body | Number | X | 최대 포트 범위<br/>- 최댓값: `65535` |
-| cidr | Body | String | O | CIDR |
-| description | Body | String | X | DB 보안 그룹 규칙에 대한 추가 정보 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "direction": "INGRESS",
-    "etherType": "IPV4",
-    "port": {
-        "portType": "ALL",
-        "minPort": 1,
-        "maxPort": 1
-    },
-    "cidr": "cidr-example",
-    "description": "description-example"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
-}
-```
-
-</p>
-</details>
-
----
-
-### DB 보안 그룹 규칙 수정하기
-
-```http
-PUT /v1.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
-```
-
-#### 요청
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
-| ruleId | URL | UUID | O |  |
-| direction | Body | Enum | O | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
-| etherType | Body | Enum | O | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
-| port | Body | Object | O | 포트 정보 |
-| port.portType | Body | Enum | O | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
-| port.minPort | Body | Number | X | 최소 포트 범위<br/>- 최솟값: `1` |
-| port.maxPort | Body | Number | X | 최대 포트 범위<br/>- 최댓값: `65535` |
-| cidr | Body | String | O | CIDR |
-| description | Body | String | X | DB 보안 그룹 규칙에 대한 추가 정보 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "direction": "INGRESS",
-    "etherType": "IPV4",
-    "port": {
-        "portType": "ALL",
-        "minPort": 1,
-        "maxPort": 1
-    },
-    "cidr": "cidr-example",
-    "description": "description-example"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
-}
-```
-
-</p>
-</details>
 
 ---
 
@@ -2982,629 +3191,6 @@ PUT /v1.0/db-instances/{dbInstanceId}/storage-info
 
 ---
 
-## DB 인스턴스 그룹
-
-### DB 인스턴스 그룹 목록 보기
-
-```http
-GET /v1.0/db-instance-groups
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| dbInstanceGroups | Body | Array | DB 인스턴스 그룹 정보 |
-| dbInstanceGroups.dbInstanceGroupId | Body | String | DB 인스턴스 그룹의 식별자 |
-| dbInstanceGroups.dbInstanceGroupStatus | Body | Enum | DB 인스턴스 그룹의 현재 형태<br/>- CREATED: `생성됨`<br/>- DELETED: `삭제됨` |
-| dbInstanceGroups.replicationType | Body | Enum | DB 인스턴스 그룹의 복제 형태<br/>- STANDALONE: `고가용성 사용 안함`<br/>- HIGH_AVAILABILITY: `고가용성 사용` |
-| dbInstanceGroups.createdYmdt | Body | DateTime | 생성 일시 |
-| dbInstanceGroups.updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceGroups": [
-        {
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### DB 인스턴스 그룹 상세 보기
-
-```http
-GET /v1.0/db-instance-groups/{dbInstanceGroupId}
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceGroupId | URL | UUID | O |  |
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| dbInstanceGroupId | Body | String | DB 인스턴스 그룹의 식별자 |
-| dbInstanceGroupStatus | Body | Enum | DB 인스턴스 그룹의 현재 상태<br/>- CREATED: `생성됨`<br/>- DELETED: `삭제됨` |
-| replicationType | Body | Enum | DB 인스턴스 그룹의 복제 형태<br/>- STANDALONE: `고가용성 사용 안함`<br/>- HIGH_AVAILABILITY: `고가용성 사용` |
-| dbInstances | Body | Array | DB 인스턴스 그룹에 속한 DB 인스턴스 목록 |
-| dbInstances.dbInstanceId | Body | String | DB 인스턴스의 식별자 |
-| dbInstances.dbInstanceType | Body | Enum | DB 인스턴스의 역할 타입<br/>- MASTER: `마스터`<br/>- FAILED_MASTER: `장애 마스터`<br/>- CANDIDATE_MASTER: `예비 마스터`<br/>- READ_ONLY_SLAVE: `읽기 복제본` |
-| dbInstances.dbInstanceStatus | Body | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전 (회색)`<br/>- AVAILABLE: `사용 가능 (녹색)`<br/>- STORAGE_FULL: `용량 부족 (적색)`<br/>- FAIL_TO_CREATE: `생성 실패 (적색)`<br/>- FAIL_TO_CONNECT: `연결 실패 (적색)`<br/>- REPLICATION_STOP: `복제 중단 (적색)`<br/>- REPLICATION_DELAY: `복제 지연 (황색)`<br/>- FAILOVER: `장애 조치 완료 (적색)`<br/>- SHUTDOWN: `중지 됨 (회색)`<br/>- DELETED: `삭제됨 (회색)` |
-| createdYmdt | Body | DateTime | 생성 일시 |
-| updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceGroupId": "dbInstanceGroupId-example",
-    "dbInstanceGroupStatus": "CREATED",
-    "replicationType": "STANDALONE",
-    "dbInstances": [
-        {
-            "dbInstanceStatus": "BEFORE_CREATE"
-        }
-    ],
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
-}
-```
-
-</p>
-</details>
-
----
-
-### 확장 리스트 조회
-
-```http
-GET /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceGroupId | URL | UUID | O | DB 인스턴스 그룹 ID |
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| extensions | Body | Array | 확장 정보 |
-| extensions.extensionId | Body | String | 확장 ID |
-| extensions.extensionName | Body | String | 확장 이름 |
-| extensions.extensionStatus | Body | Enum | 확장 상태<br/>- AVAILABLE: `사용 가능`<br/>- NEED_TO_APPLY: `적용 필요`<br/>- APPLYING: `적용 중` |
-| extensions.databases | Body | Array | 데이터베이스 정보 |
-| extensions.databases.dbInstanceGroupExtensionId | Body | String | DB 인스턴스 그룹 확장 ID |
-| extensions.databases.databaseId | Body | String | 데이터베이스 ID |
-| extensions.databases.databaseName | Body | String | 데이터베이스 이름 |
-| extensions.databases.dbInstanceGroupExtensionStatus | Body | Enum | 데이터베이스 확장 설치 상태<br/>- CREATED: `생성 됨`<br/>- INSTALLED: `설치 됨`<br/>- INSTALLING: `설치 중`<br/>- INSTALL_ERROR: `설치 에러`<br/>- DELETED: `삭제 됨`<br/>- DELETING: `삭제 중`<br/>- DELETE_ERROR: `삭제 에러` |
-| extensions.databases.reservedAction | Body | Enum | 예약 작업<br/>- NONE: `없음`<br/>- INSTALL: `설치 예약 (적용 필요)`<br/>- INSTALL_WITH_CASCADE: `강제 설치 예약 (적용 필요)`<br/>- DELETE: `삭제 예약 (적용 필요)`<br/>- DELETE_WITH_CASCADE: `강제 삭제 예약 (적용 필요)` |
-| extensions.databases.errorReason | Body | String | 에러 원인 |
-| isNeedToApply | Body | Boolean | 적용 필요 여부 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "extensions": [
-        {
-            "databases": {
-                "errorReason": "errorReason-example"
-            }
-        }
-    ],
-    "isNeedToApply": false
-}
-```
-
-</p>
-</details>
-
----
-
-### 확장 변경사항 적용
-
-```http
-POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/apply
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceGroupId | URL | UUID | O | DB 인스턴스 그룹 ID |
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
-}
-```
-
-</p>
-</details>
-
----
-
-### 확장 동기화
-
-```http
-POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/sync
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceGroupId | URL | UUID | O | DB 인스턴스 그룹 ID |
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
-}
-```
-
-</p>
-</details>
-
----
-
-### 확장 삭제(취소)
-
-```http
-DELETE /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{dbInstanceGroupExtensionId}
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceGroupId | URL | UUID | O | DB 인스턴스 그룹 ID |
-| dbInstanceGroupExtensionId | URL | UUID | O | DB 인스턴스 그룹 확장 ID |
-| withCascade | Query | Boolean | O | 강제 삭제 여부 |
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
----
-
-### 확장 설치
-
-```http
-POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{extensionId}
-```
-
-#### 요청
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceGroupId | URL | UUID | O | DB 인스턴스 그룹 ID |
-| extensionId | URL | UUID | O | 확장 ID |
-| databaseId | Body | UUID | O | 데이터베이스 ID |
-| schemaName | Body | String | O | 스키마 이름 |
-| withCascade | Body | Boolean | X | 연관 정보 자동 설치 여부<br/>- 기본값: `false` |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "databaseId": "550e8400-e29b-41d4-a716-446655440000",
-    "schemaName": "schemaName-example",
-    "withCascade": false
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
----
-
-## db-flavors
-
-### DB 인스턴스 유형 목록 보기
-
-```http
-GET /v1.0/db-flavors
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| dbFlavors | Body | Array | DB 인스턴스 사양 정보 |
-| dbFlavors.dbFlavorId | Body | String | DB 인스턴스 사양의 식별자 |
-| dbFlavors.dbFlavorName | Body | String | DB 인스턴스 사양명 |
-| dbFlavors.ram | Body | Number | 메모리 용량(MB) |
-| dbFlavors.vcpus | Body | Number | CPU 코어 수 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbFlavors": [
-        {
-            "vcpus": 2
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-## db-versions
-
-### DB 버전 목록 보기
-
-```http
-GET /v1.0/db-versions
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| dbVersions | Body | Array | DB 버전 정보 |
-| dbVersions.dbVersionCode | Body | Enum | DB 버전 코드<br/>- MYSQL_V5633<br/>- MYSQL_V5715<br/>- MYSQL_V5719<br/>- MYSQL_V5726<br/>- MYSQL_V5731<br/>- MYSQL_V5733<br/>- MYSQL_V5737<br/>- MYSQL_V8018<br/>- MYSQL_V8023<br/>- MYSQL_V8028<br/>- MYSQL_V8032<br/>- MYSQL_V8033<br/>- MYSQL_V8034<br/>- MYSQL_V8035<br/>- MYSQL_V8036<br/>- MYSQL_V8040<br/>- MYSQL_V8041<br/>- MYSQL_V8042<br/>- MYSQL_V8043<br/>- MYSQL_V8044<br/>- MYSQL_V8045<br/>- MYSQL_V8405<br/>- MYSQL_V8406<br/>- MYSQL_V8407<br/>- MYSQL_V8408<br/>- MARIADB_V10330<br/>- MARIADB_V10611<br/>- MARIADB_V10612<br/>- MARIADB_V10616<br/>- MARIADB_V10622<br/>- MARIADB_V10625<br/>- MARIADB_V101107<br/>- MARIADB_V101108<br/>- MARIADB_V101113<br/>- MARIADB_V101116<br/>- MARIADB_V11407<br/>- MARIADB_V11410<br/>- MARIADB_V11806<br/>- POSTGRESQL_V14_6<br/>- POSTGRESQL_V14_15<br/>- POSTGRESQL_V14_17<br/>- POSTGRESQL_V14_19<br/>- POSTGRESQL_V17_2<br/>- POSTGRESQL_V17_4<br/>- POSTGRESQL_V17_6 |
-| dbVersions.dbMajorVersionCode | Body | Enum | DB 메이저 버전 코드<br/>- MYSQL_V56<br/>- MYSQL_V57<br/>- MYSQL_V80<br/>- MYSQL_V84<br/>- MARIADB_V103<br/>- MARIADB_V106<br/>- MARIADB_V1011<br/>- MARIADB_V114<br/>- MARIADB_V118<br/>- POSTGRES_V14<br/>- POSTGRES_V17 |
-| dbVersions.name | Body | String | DB 버전명 |
-| dbVersions.canCreate | Body | Boolean | 신규 생성 가능 여부 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbVersions": [
-        {
-            "canCreate": false
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-## event-codes
-
-### 구독 가능한 이벤트 코드 목록 보기
-
-```http
-GET /v1.0/event-codes
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| eventCodes | Body | Array | 이벤트 코드 목록 |
-| eventCodes.eventCode | Body | Enum | 이벤트 코드 |
-| eventCodes.eventCategoryType | Body | Enum | 이벤트 카테고리 유형<br/>- ALL: `전체`<br/>- DB_INSTANCE: `DB 인스턴스로 발생한 이벤트`<br/>- DB_SECURITY_GROUP: `DB 보안 그룹으로 발생한 이벤트`<br/>- MONITORING: `모니터링으로 발생한 이벤트`<br/>- JOB: `JOB으로 발생한 이벤트`<br/>- BACKUP: `백업으로 발생한 이벤트`<br/>- TENANT: `테넌트로 발생한 이벤트` |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "eventCodes": [
-        {
-            "eventCategoryType": "ALL"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-## events
-
-### 이벤트 목록 보기
-
-```http
-GET /v1.0/events
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | 전체 이벤트 목록 수 |
-| events | Body | Array | 이벤트 목록 |
-| events.eventCategoryType | Body | Enum | 이벤트 카테고리 유형<br/>- ALL: `전체`<br/>- DB_INSTANCE: `DB 인스턴스로 발생한 이벤트`<br/>- DB_SECURITY_GROUP: `DB 보안 그룹으로 발생한 이벤트`<br/>- MONITORING: `모니터링으로 발생한 이벤트`<br/>- JOB: `JOB으로 발생한 이벤트`<br/>- BACKUP: `백업으로 발생한 이벤트`<br/>- TENANT: `테넌트로 발생한 이벤트` |
-| events.eventCode | Body | Enum | 발생한 이벤트의 유형 |
-| events.sourceId | Body | String | 이벤트 소스의 식별자 |
-| events.sourceName | Body | String | 이벤트 소스를 식별할 수 있는 이름 |
-| events.messages | Body | Array | 이벤트 메세지 목록 |
-| events.messages.langCode | Body | Enum | 언어 코드<br/>- KO<br/>- EN<br/>- JA<br/>- ZH |
-| events.messages.message | Body | String | 이벤트 메세지 |
-| events.eventYmdt | Body | DateTime | 이벤트 발생 일시 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 1,
-    "events": [
-        {
-            "eventYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-## metric-statistics
-
-### 통계 정보 조회
-
-```http
-GET /v1.0/metric-statistics
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
----
-
-## metrics
-
-### 성능 지표 목록 보기
-
-```http
-GET /v1.0/metrics
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| metrics | Body | Array | Metric 목록 |
-| metrics.metricName | Body | String | 조회 지표 유형 |
-| metrics.unit | Body | String | 측정값 단위 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "metrics": [
-        {
-            "unit": "unit-example"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-## network
-
-### 서브넷 목록 보기
-
-```http
-GET /v1.0/network/subnets
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| subnets | Body | Array | 서브넷 정보 |
-| subnets.subnetId | Body | String | 서브넷의 식별자 |
-| subnets.subnetName | Body | String | 서브넷을 식별할 수 있는 이름 |
-| subnets.subnetCidr | Body | String | 서브넷의 CIDR |
-| subnets.usingGateway | Body | Boolean | 게이트웨이 사용 여부 |
-| subnets.availableIpCount | Body | Number | 사용 가능한 IP 수 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "subnets": [
-        {
-            "availableIpCount": 1
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-## storage-types
-
-### 스토리지 유형 목록 보기
-
-```http
-GET /v1.0/storage-types
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| storageTypes | Body | Array | 스토리지 유형 정보 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "storageTypes": []
-}
-```
-
-</p>
-</details>
-
----
-
 ## 백업
 
 ### 백업 상태
@@ -3868,6 +3454,758 @@ POST /v1.0/backups/{backupId}/restore
 
 </p>
 </details>
+
+---
+
+## DB 보안 그룹
+
+### DB 보안 그룹 진행 상태
+
+| 상태              | 설명           |
+|-----------------|--------------|
+| `NONE`          | 진행 중인 작업이 없음 |
+| `CREATING_RULE` | 규칙 정책 생성 중   |
+| `UPDATING_RULE` | 규칙 정책 수정 중   |
+| `DELETING_RULE` | 규칙 정책 삭제 중   |
+
+### DB 보안 그룹 목록 보기
+
+```http
+GET /v1.0/db-security-groups
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| dbSecurityGroups | Body | Array | DB 보안 그룹 목록 |
+| dbSecurityGroups.dbSecurityGroupId | Body | String | DB 보안 그룹의 식별자 |
+| dbSecurityGroups.dbSecurityGroupName | Body | String | DB 보안 그룹을 식별할 수 있는 이름 |
+| dbSecurityGroups.dbSecurityGroupStatus | Body | Enum | DB 보안 그룹의 현재 상태<br/>- CREATED: `생성됨`<br/>- DELETED: `삭제됨` |
+| dbSecurityGroups.description | Body | String | DB 보안 그룹에 대한 추가 정보 |
+| dbSecurityGroups.progressStatus | Body | Enum | DB 보안 그룹의 현재 진행 상태<br/>- NONE: `없음`<br/>- CREATING_RULE: `규칙 생성중`<br/>- UPDATING_RULE: `규칙 수정중`<br/>- DELETING_RULE: `규칙 삭제중`<br/>- APPLYING_DEFAULT_RULE: `기본 규칙 적용중` |
+| dbSecurityGroups.createdYmdt | Body | DateTime | 생성 일시 |
+| dbSecurityGroups.updatedYmdt | Body | DateTime | 수정 일시 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "dbSecurityGroups": [
+        {
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 보안 그룹 생성하기
+
+```http
+POST /v1.0/db-security-groups
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupName | Body | String | O | DB 보안 그룹을 식별할 수 있는 이름 |
+| description | Body | String | X | DB 보안 그룹에 대한 추가 정보 |
+| rules | Body | Array | O | DB 보안 그룹 규칙 정보 |
+| rules.direction | Body | Enum | O | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
+| rules.etherType | Body | Enum | O | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
+| rules.port | Body | Object | O | 포트 객체 |
+| rules.port.portType | Body | Enum | O | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
+| rules.port.minPort | Body | Number | X | 최소 포트 범위<br/>- 최솟값: `1` |
+| rules.port.maxPort | Body | Number | X | 최대 포트 범위<br/>- 최댓값: `65535` |
+| rules.cidr | Body | String | O | CIDR |
+| rules.description | Body | String | X | 보안 그룹 규칙에 대한 추가 정보 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "dbSecurityGroupName": "dbSecurityGroupName-example",
+    "description": "description-example",
+    "rules": [
+        {
+            "description": "description-example"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| dbSecurityGroupId | Body | String | DB 보안 그룹의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "dbSecurityGroupId": "dbSecurityGroupId-example"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 보안 그룹 삭제하기
+
+```http
+DELETE /v1.0/db-security-groups/{dbSecurityGroupId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### DB 보안 그룹 상세 보기
+
+```http
+GET /v1.0/db-security-groups/{dbSecurityGroupId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| dbSecurityGroup | Body | Object | DB 보안 그룹 |
+| dbSecurityGroup.dbSecurityGroupId | Body | String | DB 보안 그룹의 식별자 |
+| dbSecurityGroup.dbSecurityGroupName | Body | String | DB 보안 그룹을 식별할 수 있는 이름 |
+| dbSecurityGroup.dbSecurityGroupStatus | Body | Enum | DB 보안 그룹의 현재 상태<br/>- CREATED: `생성됨`<br/>- DELETED: `삭제됨` |
+| dbSecurityGroup.description | Body | String | DB 보안 그룹에 대한 추가 정보 |
+| dbSecurityGroup.progressStatus | Body | Enum | DB 보안 그룹의 현재 진행 상태<br/>- NONE: `없음`<br/>- CREATING_RULE: `규칙 생성중`<br/>- UPDATING_RULE: `규칙 수정중`<br/>- DELETING_RULE: `규칙 삭제중`<br/>- APPLYING_DEFAULT_RULE: `기본 규칙 적용중` |
+| dbSecurityGroup.rules | Body | Array | DB 보안 그룹 규칙 목록 |
+| dbSecurityGroup.rules.ruleId | Body | String | DB 보안 그룹 규칙의 식별자 |
+| dbSecurityGroup.rules.description | Body | String | DB 보안 그룹 규칙에 대한 추가 정보 |
+| dbSecurityGroup.rules.direction | Body | Enum | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
+| dbSecurityGroup.rules.etherType | Body | Enum | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
+| dbSecurityGroup.rules.port | Body | Object | 포트 객체 |
+| dbSecurityGroup.rules.port.portType | Body | Enum | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
+| dbSecurityGroup.rules.port.minPort | Body | Number | 최소 포트 범위 |
+| dbSecurityGroup.rules.port.maxPort | Body | Number | 최대 포트 범위 |
+| dbSecurityGroup.rules.cidr | Body | String | CIDR |
+| dbSecurityGroup.rules.createdYmdt | Body | DateTime | 생성 일시 |
+| dbSecurityGroup.rules.updatedYmdt | Body | DateTime | 수정 일시 |
+| dbSecurityGroup.createdYmdt | Body | DateTime | 생성 일시 |
+| dbSecurityGroup.updatedYmdt | Body | DateTime | 수정 일시 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "dbSecurityGroup": {
+        "dbSecurityGroupId": "dbSecurityGroupId-example",
+        "dbSecurityGroupName": "dbSecurityGroupName-example",
+        "dbSecurityGroupStatus": "CREATED",
+        "description": "description-example",
+        "progressStatus": "NONE",
+        "rules": [
+            {
+                "updatedYmdt": "2023-12-31T15:00:00+09:00"
+            }
+        ],
+        "createdYmdt": "2023-12-31T15:00:00+09:00",
+        "updatedYmdt": "2023-12-31T15:00:00+09:00"
+    }
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 보안 그룹 수정하기
+
+```http
+PUT /v1.0/db-security-groups/{dbSecurityGroupId}
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+| dbSecurityGroupName | Body | String | O | DB 보안 그룹을 식별할 수 있는 이름 |
+| description | Body | String | X | DB 보안 그룹에 대한 추가 정보 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "dbSecurityGroupName": "dbSecurityGroupName-example",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### DB 보안 그룹 규칙 삭제하기
+
+```http
+DELETE /v1.0/db-security-groups/{dbSecurityGroupId}/rules
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+| ruleIds | Query | String | O | DB 보안 그룹 규칙 ID 리스트 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 보안 그룹 규칙 생성하기
+
+```http
+POST /v1.0/db-security-groups/{dbSecurityGroupId}/rules
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+| direction | Body | Enum | O | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
+| etherType | Body | Enum | O | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
+| port | Body | Object | O | 포트 정보 |
+| port.portType | Body | Enum | O | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
+| port.minPort | Body | Number | X | 최소 포트 범위<br/>- 최솟값: `1` |
+| port.maxPort | Body | Number | X | 최대 포트 범위<br/>- 최댓값: `65535` |
+| cidr | Body | String | O | CIDR |
+| description | Body | String | X | DB 보안 그룹 규칙에 대한 추가 정보 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "direction": "INGRESS",
+    "etherType": "IPV4",
+    "port": {
+        "portType": "ALL",
+        "minPort": 1,
+        "maxPort": 1
+    },
+    "cidr": "cidr-example",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 보안 그룹 규칙 수정하기
+
+```http
+PUT /v1.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+| ruleId | URL | UUID | O |  |
+| direction | Body | Enum | O | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
+| etherType | Body | Enum | O | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
+| port | Body | Object | O | 포트 정보 |
+| port.portType | Body | Enum | O | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
+| port.minPort | Body | Number | X | 최소 포트 범위<br/>- 최솟값: `1` |
+| port.maxPort | Body | Number | X | 최대 포트 범위<br/>- 최댓값: `65535` |
+| cidr | Body | String | O | CIDR |
+| description | Body | String | X | DB 보안 그룹 규칙에 대한 추가 정보 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "direction": "INGRESS",
+    "etherType": "IPV4",
+    "port": {
+        "portType": "ALL",
+        "minPort": 1,
+        "maxPort": 1
+    },
+    "cidr": "cidr-example",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+## 파라미터 그룹
+
+### 파라미터 그룹 목록 보기
+
+```http
+GET /v1.0/parameter-groups
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| parameterGroups | Body | Array | 파라미터 그룹 목록 |
+| parameterGroups.parameterGroupId | Body | String | 파라미터 그룹의 식별자 |
+| parameterGroups.parameterGroupName | Body | String | 파라미터 그룹을 식별할 수 있는 이름 |
+| parameterGroups.description | Body | String | 파라미터 그룹에 대한 추가 정보 |
+| parameterGroups.dbVersion | Body | Enum | DB 엔진 버전 |
+| parameterGroups.parameterGroupStatus | Body | Enum | 파라미터 그룹의 현재 상태<br/>- STABLE: `적용 완료`<br/>- NEED_TO_APPLY: `적용 필요`<br/>- DELETED: `삭제됨` |
+| parameterGroups.createdYmdt | Body | DateTime | 생성 일시 |
+| parameterGroups.updatedYmdt | Body | DateTime | 수정 일시 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "parameterGroups": [
+        {
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### 파라미터 그룹 생성하기
+
+```http
+POST /v1.0/parameter-groups
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupName | Body | String | O | 파라미터 그룹을 식별할 수 있는 이름 |
+| description | Body | String | X | 파라미터 그룹에 대한 추가 정보 |
+| dbVersion | Body | Enum | O | DB 엔진 버전 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "parameterGroupName": "parameterGroupName-example",
+    "description": "description-example",
+    "dbVersion": "ENUM_VALUE"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| parameterGroupId | Body | String | 파라미터 그룹의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "parameterGroupId": "parameterGroupId-example"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 파라미터 그룹 삭제하기
+
+```http
+DELETE /v1.0/parameter-groups/{parameterGroupId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O | 파라미터 그룹 ID |
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### 파라미터 그룹 상세 조회
+
+```http
+GET /v1.0/parameter-groups/{parameterGroupId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O | 파라미터 그룹 ID |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| parameterGroupId | Body | String | 파라미터 그룹의 식별자 |
+| parameterGroupName | Body | String | 파라미터 그룹을 식별할 수 있는 이름 |
+| description | Body | String | 파라미터 그룹에 대한 추가 정보 |
+| dbVersion | Body | Enum | DB 엔진 버전 |
+| parameterGroupStatus | Body | Enum | 파라미터 그룹의 현재 상태<br/>- STABLE: `적용 완료`<br/>- NEED_TO_APPLY: `적용 필요`<br/>- DELETED: `삭제됨` |
+| parameters | Body | Array | 파라미터 정보 |
+| parameters.parameterCategory | Body | String | 파라미터 카테고리 |
+| parameters.parameterName | Body | String | 파라미터 이름 |
+| parameters.value | Body | String | 현재 설정된 값 |
+| parameters.valueUnit | Body | String | 값 단위 (바이트: B,kB,MB,GB,TB, 시간: us,ms,s,min,h,d) |
+| parameters.defaultValue | Body | String | 기본값 |
+| parameters.allowedValue | Body | String | 허용된 값 |
+| parameters.valueType | Body | Enum | 값 타입<br/>- BOOLEAN: `불린 타입
+ * ex) on, off, true, false, yes, no, 1, 0`<br/>- STRING: `문자열`<br/>- NUMERIC: `정수 및 부동 소수점`<br/>- NUMERIC_WITH_BYTE_UNIT: `단위가 있는 숫자
+ * ex) 120kB, 100MB
+ * 허용된 바이트 단위: B (bytes), kB (kilobytes), MB (megabytes), GB (gigabytes), and TB (terabytes)`<br/>- NUMERIC_WITH_TIME_UNIT: `단위가 있는 숫자
+ * ex) 120ms, 100s, 1d
+ * 허용된 시간 단위: us (microseconds), ms (milliseconds), s (seconds), min (minutes), h (hours), and d (days)`<br/>- ENUMERATED: `allowed_value에 선언된 값 중 한 개 선택 (콤마(,)로 구분됨)`<br/>- MULTI_ENUMERATED: `allowed_value에 선언된 값 중 여러개 선택 (콤마(,)로 구분됨)` |
+| parameters.updateType | Body | Enum | 수정 타입<br/>- VARIABLE: `동적, 언제든 수정 가능`<br/>- CONSTANT: `수정 불가능` |
+| parameters.applyType | Body | Enum | 적용 타입<br/>- BOTH: `세션, 파일 모두 적용`<br/>- SESSION: `세션에만 적용`<br/>- FILE: `파일에만 적용` |
+| parameters.expressionAvailable | Body | Boolean | 수식 허용 여부 |
+| createdYmdt | Body | DateTime | 생성 일시 |
+| updatedYmdt | Body | DateTime | 수정 일시 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "parameterGroupId": "parameterGroupId-example",
+    "parameterGroupName": "parameterGroupName-example",
+    "description": "description-example",
+    "dbVersion": "ENUM_VALUE",
+    "parameterGroupStatus": "STABLE",
+    "parameters": [
+        {
+            "expressionAvailable": false
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 파라미터 그룹 수정하기
+
+```http
+PUT /v1.0/parameter-groups/{parameterGroupId}
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O | 파라미터 그룹 ID |
+| parameterGroupName | Body | String | X | 파라미터 그룹을 식별할 수 있는 이름 |
+| description | Body | String | X | 파라미터 그룹에 대한 추가 정보 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "parameterGroupName": "parameterGroupName-example",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### 파라미터 그룹 복사하기
+
+```http
+POST /v1.0/parameter-groups/{parameterGroupId}/copy
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O | 파라미터 그룹 ID |
+| parameterGroupName | Body | String | O | 파라미터 그룹을 식별할 수 있는 이름 |
+| description | Body | String | X | 파라미터 그룹에 대한 추가 정보 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "parameterGroupName": "parameterGroupName-example",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| parameterGroupId | Body | String | 파라미터 그룹의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "parameterGroupId": "parameterGroupId-example"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 파라미터 그룹 내 파라미터 수정하기
+
+```http
+PUT /v1.0/parameter-groups/{parameterGroupId}/parameters
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O | 파라미터 그룹 ID |
+| modifiedParameters | Body | Array | O | 변경할 파라미터 목록 |
+| modifiedParameters.parameterName | Body | String | O | 파라미터 이름 |
+| modifiedParameters.value | Body | String | O | 변경할 파라미터 값 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "modifiedParameters": [
+        {
+            "value": "value-example"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### 파라미터 그룹 재설정하기
+
+```http
+PUT /v1.0/parameter-groups/{parameterGroupId}/reset
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O | 파라미터 그룹 ID |
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
 
 ---
 
@@ -4483,84 +4821,28 @@ PUT /v1.0/notification-groups/{notificationGroupId}/watchdogs/{watchdogId}
 
 ---
 
-## 작업 정보
+## 모니터링
 
-### 작업 상태
-
-| 상태명                | 설명                   |
-|--------------------|----------------------|
-| `PREPARING`        | 작업이 준비 중인 경우         |
-| `READY`            | 작업이 준비 완료된 경우        |
-| `RUNNING`          | 작업이 진행 중인 경우         |
-| `COMPLETED`        | 작업이 완료된 경우           |
-| `REGISTERED`       | 작업이 등록된 경우           |
-| `WAIT_TO_REGISTER` | 작업 등록 대기 중인 경우       |
-| `INTERRUPTED`      | 작업 진행 중 인터럽트가 발생한 경우 |
-| `CANCELED`         | 작업이 취소된 경우           |
-| `FAILED`           | 작업이 실패한 경우           |
-| `ERROR`            | 작업 진행 중 오류가 발생한 경우   |
-| `DELETED`          | 작업이 삭제된 경우           |
-| `FAIL_TO_READY`    | 작업 준비에 실패한 경우        |
-
-### 작업 정보 상세 보기
+### 통계 정보 조회
 
 ```http
-GET /v1.0/jobs/{jobId}
+GET /v1.0/metric-statistics
 ```
 
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| jobId | URL | UUID | O |  |
-
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | String | 작업의 식별자 |
-| jobStatus | Body | Enum | 작업의 현재 상태<br/>- DELETED<br/>- CANNOT_PROGRESS<br/>- FAILED<br/>- ERROR<br/>- CANCELED<br/>- INTERRUPTED<br/>- COMPLETED<br/>- COMPLETED_WITH_ERROR<br/>- RUNNING<br/>- PREPARING<br/>- READY<br/>- CREATED<br/>- FAIL_TO_READY<br/>- REGISTERED<br/>- FAIL_TO_REGISTER<br/>- WAIT_TO_REGISTER |
-| resourceRelations | Body | Array | 연관 리소스 목록 |
-| resourceRelations.resourceType | Body | String | 연관 리소스 유형 |
-| resourceRelations.resourceId | Body | String | 연관 리소스의 식별자 |
-| createdYmdt | Body | DateTime | 생성 일시 |
-| updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "jobId-example",
-    "jobStatus": "DELETED",
-    "resourceRelations": [
-        {
-            "resourceId": "resourceId-example"
-        }
-    ],
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
-}
-```
-
-</p>
-</details>
+이 API는 응답 본문을 반환하지 않습니다.
 
 ---
 
-## 파라미터 그룹
-
-### 파라미터 그룹 목록 보기
+### 성능 지표 목록 보기
 
 ```http
-GET /v1.0/parameter-groups
+GET /v1.0/metrics
 ```
 
 #### 요청
@@ -4571,14 +4853,9 @@ GET /v1.0/parameter-groups
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| parameterGroups | Body | Array | 파라미터 그룹 목록 |
-| parameterGroups.parameterGroupId | Body | String | 파라미터 그룹의 식별자 |
-| parameterGroups.parameterGroupName | Body | String | 파라미터 그룹을 식별할 수 있는 이름 |
-| parameterGroups.description | Body | String | 파라미터 그룹에 대한 추가 정보 |
-| parameterGroups.dbVersion | Body | Enum | DB 엔진 버전 |
-| parameterGroups.parameterGroupStatus | Body | Enum | 파라미터 그룹의 현재 상태<br/>- STABLE: `적용 완료`<br/>- NEED_TO_APPLY: `적용 필요`<br/>- DELETED: `삭제됨` |
-| parameterGroups.createdYmdt | Body | DateTime | 생성 일시 |
-| parameterGroups.updatedYmdt | Body | DateTime | 수정 일시 |
+| metrics | Body | Array | Metric 목록 |
+| metrics.metricName | Body | String | 조회 지표 유형 |
+| metrics.unit | Body | String | 측정값 단위 |
 
 <details><summary>예시</summary>
 <p>
@@ -4590,9 +4867,9 @@ GET /v1.0/parameter-groups
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "parameterGroups": [
+    "metrics": [
         {
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
+            "unit": "unit-example"
         }
     ]
 }
@@ -4603,39 +4880,38 @@ GET /v1.0/parameter-groups
 
 ---
 
-### 파라미터 그룹 생성하기
+## 이벤트
+
+### 이벤트 카테고리
+
+이벤트는 카테고리로 분류할 수 있으며 아래와 같습니다.
+
+| 이벤트 카테고리    | 설명      |
+|-------------|---------|
+| ALL         | 전체      |
+| BACKUP      | 백업      |
+| DB_INSTANCE | DB 인스턴스 |
+| JOB         | 작업      |
+| TENANT      | 테넌트     |
+| MONITORING  | 모니터링    |
+
+### 구독 가능한 이벤트 코드 목록 보기
 
 ```http
-POST /v1.0/parameter-groups
+GET /v1.0/event-codes
 ```
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| parameterGroupName | Body | String | O | 파라미터 그룹을 식별할 수 있는 이름 |
-| description | Body | String | X | 파라미터 그룹에 대한 추가 정보 |
-| dbVersion | Body | Enum | O | DB 엔진 버전 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "parameterGroupName": "parameterGroupName-example",
-    "description": "description-example",
-    "dbVersion": "ENUM_VALUE"
-}
-```
-
-</p>
-</details>
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| parameterGroupId | Body | String | 파라미터 그룹의 식별자 |
+| eventCodes | Body | Array | 이벤트 코드 목록 |
+| eventCodes.eventCode | Body | Enum | 이벤트 코드 |
+| eventCodes.eventCategoryType | Body | Enum | 이벤트 카테고리 유형<br/>- ALL: `전체`<br/>- DB_INSTANCE: `DB 인스턴스로 발생한 이벤트`<br/>- DB_SECURITY_GROUP: `DB 보안 그룹으로 발생한 이벤트`<br/>- MONITORING: `모니터링으로 발생한 이벤트`<br/>- JOB: `JOB으로 발생한 이벤트`<br/>- BACKUP: `백업으로 발생한 이벤트`<br/>- TENANT: `테넌트로 발생한 이벤트` |
 
 <details><summary>예시</summary>
 <p>
@@ -4647,284 +4923,9 @@ POST /v1.0/parameter-groups
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "parameterGroupId": "parameterGroupId-example"
-}
-```
-
-</p>
-</details>
-
----
-
-### 파라미터 그룹 삭제하기
-
-```http
-DELETE /v1.0/parameter-groups/{parameterGroupId}
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O | 파라미터 그룹 ID |
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
----
-
-### 파라미터 그룹 상세 조회
-
-```http
-GET /v1.0/parameter-groups/{parameterGroupId}
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O | 파라미터 그룹 ID |
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| parameterGroupId | Body | String | 파라미터 그룹의 식별자 |
-| parameterGroupName | Body | String | 파라미터 그룹을 식별할 수 있는 이름 |
-| description | Body | String | 파라미터 그룹에 대한 추가 정보 |
-| dbVersion | Body | Enum | DB 엔진 버전 |
-| parameterGroupStatus | Body | Enum | 파라미터 그룹의 현재 상태<br/>- STABLE: `적용 완료`<br/>- NEED_TO_APPLY: `적용 필요`<br/>- DELETED: `삭제됨` |
-| parameters | Body | Array | 파라미터 정보 |
-| parameters.parameterCategory | Body | String | 파라미터 카테고리 |
-| parameters.parameterName | Body | String | 파라미터 이름 |
-| parameters.value | Body | String | 현재 설정된 값 |
-| parameters.valueUnit | Body | String | 값 단위 (바이트: B,kB,MB,GB,TB, 시간: us,ms,s,min,h,d) |
-| parameters.defaultValue | Body | String | 기본값 |
-| parameters.allowedValue | Body | String | 허용된 값 |
-| parameters.valueType | Body | Enum | 값 타입<br/>- BOOLEAN: `불린 타입
- * ex) on, off, true, false, yes, no, 1, 0`<br/>- STRING: `문자열`<br/>- NUMERIC: `정수 및 부동 소수점`<br/>- NUMERIC_WITH_BYTE_UNIT: `단위가 있는 숫자
- * ex) 120kB, 100MB
- * 허용된 바이트 단위: B (bytes), kB (kilobytes), MB (megabytes), GB (gigabytes), and TB (terabytes)`<br/>- NUMERIC_WITH_TIME_UNIT: `단위가 있는 숫자
- * ex) 120ms, 100s, 1d
- * 허용된 시간 단위: us (microseconds), ms (milliseconds), s (seconds), min (minutes), h (hours), and d (days)`<br/>- ENUMERATED: `allowed_value에 선언된 값 중 한 개 선택 (콤마(,)로 구분됨)`<br/>- MULTI_ENUMERATED: `allowed_value에 선언된 값 중 여러개 선택 (콤마(,)로 구분됨)` |
-| parameters.updateType | Body | Enum | 수정 타입<br/>- VARIABLE: `동적, 언제든 수정 가능`<br/>- CONSTANT: `수정 불가능` |
-| parameters.applyType | Body | Enum | 적용 타입<br/>- BOTH: `세션, 파일 모두 적용`<br/>- SESSION: `세션에만 적용`<br/>- FILE: `파일에만 적용` |
-| parameters.expressionAvailable | Body | Boolean | 수식 허용 여부 |
-| createdYmdt | Body | DateTime | 생성 일시 |
-| updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroupId": "parameterGroupId-example",
-    "parameterGroupName": "parameterGroupName-example",
-    "description": "description-example",
-    "dbVersion": "ENUM_VALUE",
-    "parameterGroupStatus": "STABLE",
-    "parameters": [
+    "eventCodes": [
         {
-            "expressionAvailable": false
-        }
-    ],
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
-}
-```
-
-</p>
-</details>
-
----
-
-### 파라미터 그룹 수정하기
-
-```http
-PUT /v1.0/parameter-groups/{parameterGroupId}
-```
-
-#### 요청
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O | 파라미터 그룹 ID |
-| parameterGroupName | Body | String | X | 파라미터 그룹을 식별할 수 있는 이름 |
-| description | Body | String | X | 파라미터 그룹에 대한 추가 정보 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "parameterGroupName": "parameterGroupName-example",
-    "description": "description-example"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
----
-
-### 파라미터 그룹 복사하기
-
-```http
-POST /v1.0/parameter-groups/{parameterGroupId}/copy
-```
-
-#### 요청
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O | 파라미터 그룹 ID |
-| parameterGroupName | Body | String | O | 파라미터 그룹을 식별할 수 있는 이름 |
-| description | Body | String | X | 파라미터 그룹에 대한 추가 정보 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "parameterGroupName": "parameterGroupName-example",
-    "description": "description-example"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| parameterGroupId | Body | String | 파라미터 그룹의 식별자 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroupId": "parameterGroupId-example"
-}
-```
-
-</p>
-</details>
-
----
-
-### 파라미터 그룹 내 파라미터 수정하기
-
-```http
-PUT /v1.0/parameter-groups/{parameterGroupId}/parameters
-```
-
-#### 요청
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O | 파라미터 그룹 ID |
-| modifiedParameters | Body | Array | O | 변경할 파라미터 목록 |
-| modifiedParameters.parameterName | Body | String | O | 파라미터 이름 |
-| modifiedParameters.value | Body | String | O | 변경할 파라미터 값 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "modifiedParameters": [
-        {
-            "value": "value-example"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
----
-
-### 파라미터 그룹 재설정하기
-
-```http
-PUT /v1.0/parameter-groups/{parameterGroupId}/reset
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O | 파라미터 그룹 ID |
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
----
-
-## 프로젝트
-
-### 프로젝트의 멤버 목록 조회
-
-```http
-GET /v1.0/project/members
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| projectMembers | Body | Array | 프로젝트 멤버 정보 |
-| projectMembers.memberId | Body | String | 프로젝트 멤버의 식별자 |
-| projectMembers.memberName | Body | String | 프로젝트 멤버의 이름 |
-| projectMembers.emailAddress | Body | String | 프로젝트 멤버의 이메일 주소 |
-| projectMembers.phoneNumber | Body | String | 프로젝트 멤버의 전화번호 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "projectMembers": [
-        {
-            "phoneNumber": "phoneNumber-example"
+            "eventCategoryType": "ALL"
         }
     ]
 }
@@ -4935,10 +4936,10 @@ GET /v1.0/project/members
 
 ---
 
-### 프로젝트의 리전 목록 조회
+### 이벤트 목록 보기
 
 ```http
-GET /v1.0/project/regions
+GET /v1.0/events
 ```
 
 #### 요청
@@ -4949,9 +4950,16 @@ GET /v1.0/project/regions
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| regions | Body | Array | 리전 정보 |
-| regions.regionCode | Body | Enum | 리전 코드<br/>- KR1: `한국(판교)`<br/>- KR2: `한국(평촌)` |
-| regions.isEnabled | Body | Boolean | 리전의 활성화 여부 |
+| totalCounts | Body | Number | 전체 이벤트 목록 수 |
+| events | Body | Array | 이벤트 목록 |
+| events.eventCategoryType | Body | Enum | 이벤트 카테고리 유형<br/>- ALL: `전체`<br/>- DB_INSTANCE: `DB 인스턴스로 발생한 이벤트`<br/>- DB_SECURITY_GROUP: `DB 보안 그룹으로 발생한 이벤트`<br/>- MONITORING: `모니터링으로 발생한 이벤트`<br/>- JOB: `JOB으로 발생한 이벤트`<br/>- BACKUP: `백업으로 발생한 이벤트`<br/>- TENANT: `테넌트로 발생한 이벤트` |
+| events.eventCode | Body | Enum | 발생한 이벤트의 유형 |
+| events.sourceId | Body | String | 이벤트 소스의 식별자 |
+| events.sourceName | Body | String | 이벤트 소스를 식별할 수 있는 이름 |
+| events.messages | Body | Array | 이벤트 메세지 목록 |
+| events.messages.langCode | Body | Enum | 언어 코드<br/>- KO<br/>- EN<br/>- JA<br/>- ZH |
+| events.messages.message | Body | String | 이벤트 메세지 |
+| events.eventYmdt | Body | DateTime | 이벤트 발생 일시 |
 
 <details><summary>예시</summary>
 <p>
@@ -4963,9 +4971,10 @@ GET /v1.0/project/regions
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "regions": [
+    "totalCounts": 1,
+    "events": [
         {
-            "isEnabled": false
+            "eventYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }

--- a/ko/api-guide-v1.0.md
+++ b/ko/api-guide-v1.0.md
@@ -355,7 +355,10 @@ GET /v1.0/storage-types
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "storageTypes": []
+    "storageTypes": [
+        "General SSD",
+        "General HDD"
+    ]
 }
 ```
 
@@ -1268,8 +1271,12 @@ GET /v1.0/db-instances/{dbInstanceId}
     "progressStatus": "progressStatus-example",
     "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
     "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbSecurityGroupIds": [],
-    "notificationGroupIds": [],
+    "dbSecurityGroupIds": [
+        "550e8400-e29b-41d4-a716-446655440000"
+    ],
+    "notificationGroupIds": [
+        "550e8400-e29b-41d4-a716-446655440000"
+    ],
     "useDeletionProtection": false,
     "needToApplyParameterGroup": false,
     "needMigration": false,

--- a/ko/api-guide-v1.0.md
+++ b/ko/api-guide-v1.0.md
@@ -88,6 +88,9 @@ GET /v1.0/db-versions
     },
     "dbVersions": [
         {
+            "dbVersionCode": "MYSQL_V5633",
+            "dbMajorVersionCode": "MYSQL_V56",
+            "name": "PostgreSQL V14.6",
             "canCreate": false
         }
     ]
@@ -133,6 +136,9 @@ GET /v1.0/db-flavors
     },
     "dbFlavors": [
         {
+            "dbFlavorId": "289e34e9-cd8a-4baf-82e3-a3d013c5186b",
+            "dbFlavorName": "r2.c2m4",
+            "ram": 4096,
             "vcpus": 2
         }
     ]
@@ -178,6 +184,9 @@ GET /v1.0/project/members
     },
     "projectMembers": [
         {
+            "memberId": "memberId-example",
+            "memberName": "memberName-example",
+            "emailAddress": "emailAddress-example",
             "phoneNumber": "phoneNumber-example"
         }
     ]
@@ -219,6 +228,7 @@ GET /v1.0/project/regions
     },
     "regions": [
         {
+            "regionCode": "KR1",
             "isEnabled": false
         }
     ]
@@ -247,7 +257,7 @@ GET /v1.0/network/subnets
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
 | subnets | Body | Array | 서브넷 정보 |
-| subnets.subnetId | Body | String | 서브넷의 식별자 |
+| subnets.subnetId | Body | UUID | 서브넷의 식별자 |
 | subnets.subnetName | Body | String | 서브넷을 식별할 수 있는 이름 |
 | subnets.subnetCidr | Body | String | 서브넷의 CIDR |
 | subnets.usingGateway | Body | Boolean | 게이트웨이 사용 여부 |
@@ -265,6 +275,10 @@ GET /v1.0/network/subnets
     },
     "subnets": [
         {
+            "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+            "subnetName": "subnetName-example",
+            "subnetCidr": "subnetCidr-example",
+            "usingGateway": false,
             "availableIpCount": 1
         }
     ]
@@ -372,6 +386,7 @@ GET /v1.0/jobs/{jobId}
     "jobStatus": "DELETED",
     "resourceRelations": [
         {
+            "resourceType": "resourceType-example",
             "resourceId": "resourceId-example"
         }
     ],
@@ -420,6 +435,10 @@ GET /v1.0/db-instance-groups
     },
     "dbInstanceGroups": [
         {
+            "dbInstanceGroupId": "dbInstanceGroupId-example",
+            "dbInstanceGroupStatus": "CREATED",
+            "replicationType": "STANDALONE",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
             "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
@@ -474,6 +493,8 @@ GET /v1.0/db-instance-groups/{dbInstanceGroupId}
     "replicationType": "STANDALONE",
     "dbInstances": [
         {
+            "dbInstanceId": "dbInstanceId-example",
+            "dbInstanceType": "MASTER",
             "dbInstanceStatus": "BEFORE_CREATE"
         }
     ],
@@ -530,9 +551,19 @@ GET /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions
     },
     "extensions": [
         {
-            "databases": {
-                "errorReason": "errorReason-example"
-            }
+            "extensionId": "extensionId-example",
+            "extensionName": "extensionName-example",
+            "extensionStatus": "AVAILABLE",
+            "databases": [
+                {
+                    "dbInstanceGroupExtensionId": "dbInstanceGroupExtensionId-example",
+                    "databaseId": "databaseId-example",
+                    "databaseName": "databaseName-example",
+                    "dbInstanceGroupExtensionStatus": "CREATED",
+                    "reservedAction": "NONE",
+                    "errorReason": "errorReason-example"
+                }
+            ]
         }
     ],
     "isNeedToApply": false
@@ -766,6 +797,16 @@ GET /v1.0/db-instances
     },
     "dbInstances": [
         {
+            "dbInstanceId": "dbInstanceId-example",
+            "dbInstanceGroupId": "dbInstanceGroupId-example",
+            "dbInstanceName": "dbInstanceName-example",
+            "description": "description-example",
+            "dbVersion": "ENUM_VALUE",
+            "dbPort": 1,
+            "dbInstanceType": "MASTER",
+            "dbInstanceStatus": "BEFORE_CREATE",
+            "progressStatus": "progressStatus-example",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
             "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
@@ -854,6 +895,7 @@ POST /v1.0/db-instances
         "backupRetryCount": 0,
         "backupSchedules": [
             {
+                "backupWndBgnTime": "backupWndBgnTime-example",
                 "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
@@ -965,6 +1007,7 @@ POST /v1.0/db-instances/restore-from-obs
         "replicationRegion": "KR1",
         "backupSchedules": [
             {
+                "backupWndBgnTime": "backupWndBgnTime-example",
                 "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
@@ -1273,6 +1316,9 @@ GET /v1.0/db-instances/{dbInstanceId}/available-db-versions
     },
     "availableDbVersions": [
         {
+            "dbVersionCode": "MYSQL_V5633",
+            "dbMajorVersionCode": "MYSQL_V56",
+            "name": "PostgreSQL V14.6",
             "canCreate": false
         }
     ]
@@ -1376,6 +1422,7 @@ GET /v1.0/db-instances/{dbInstanceId}/backup-info
     "backupRetryCount": 1,
     "backupSchedules": [
         {
+            "backupWndBgnTime": "backupWndBgnTime-example",
             "backupWndDuration": "HALF_AN_HOUR"
         }
     ]
@@ -1417,6 +1464,7 @@ PUT /v1.0/db-instances/{dbInstanceId}/backup-info
     "backupRetryCount": 0,
     "backupSchedules": [
         {
+            "backupWndBgnTime": "backupWndBgnTime-example",
             "backupWndDuration": "HALF_AN_HOUR"
         }
     ]
@@ -1548,9 +1596,16 @@ GET /v1.0/db-instances/{dbInstanceId}/databases
     },
     "databases": [
         {
-            "schemas": {
-                "schemaName": "schemaName-example"
-            }
+            "databaseId": "databaseId-example",
+            "databaseName": "databaseName-example",
+            "databaseStatus": "STABLE",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00",
+            "schemas": [
+                {
+                    "schemaName": "schemaName-example"
+                }
+            ]
         }
     ]
 }
@@ -1742,6 +1797,11 @@ GET /v1.0/db-instances/{dbInstanceId}/db-users
     },
     "dbUsers": [
         {
+            "dbUserId": "dbUserId-example",
+            "dbUserName": "dbUserName-example",
+            "authorityType": "CUSTOM",
+            "dbUserStatus": "STABLE",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
             "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
@@ -2007,6 +2067,26 @@ GET /v1.0/db-instances/{dbInstanceId}/hba-rules
     },
     "hbaRules": [
         {
+            "hbaRuleId": "hbaRuleId-example",
+            "hbaRuleStatus": "CREATED",
+            "databaseApplyType": "ENTIRE",
+            "dbUserApplyTypeCode": "ENTIRE",
+            "databases": [
+                {
+                    "databaseId": "databaseId-example",
+                    "databaseName": "databaseName-example"
+                }
+            ],
+            "dbUsers": [
+                {
+                    "dbUserId": "dbUserId-example",
+                    "dbUserName": "dbUserName-example"
+                }
+            ],
+            "address": "address-example",
+            "authMethod": "TRUST",
+            "reservedAction": "NONE",
+            "order": 1,
             "applicable": false
         }
     ],
@@ -2622,6 +2702,8 @@ GET /v1.0/db-instances/{dbInstanceId}/network-info
     },
     "endPoints": [
         {
+            "domain": "domain-example",
+            "ipAddress": "ipAddress-example",
             "endPointType": "endPointType-example"
         }
     ]
@@ -2891,6 +2973,19 @@ GET /v1.0/db-instances/{dbInstanceId}/restoration-info
     "latestRestorableYmdt": "2023-12-31T15:00:00+09:00",
     "restorableBackups": [
         {
+            "backupId": "backupId-example",
+            "backupName": "backupName-example",
+            "backupStatus": "BACKING_UP",
+            "dbInstanceId": "dbInstanceId-example",
+            "dbInstanceName": "dbInstanceName-example",
+            "dbVersion": "ENUM_VALUE",
+            "backupType": "AUTO",
+            "backupSize": 1,
+            "failoverCount": 1,
+            "walFileName": "walFileName-example",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00",
+            "startYmdt": "2023-12-31T15:00:00+09:00",
             "completedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
@@ -2975,6 +3070,7 @@ POST /v1.0/db-instances/{dbInstanceId}/restore
         "replicationRegion": "KR1",
         "backupSchedules": [
             {
+                "backupWndBgnTime": "backupWndBgnTime-example",
                 "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
@@ -3244,6 +3340,16 @@ GET /v1.0/backups
     "totalCounts": 1,
     "backups": [
         {
+            "backupId": "backupId-example",
+            "backupName": "backupName-example",
+            "backupStatus": "BACKING_UP",
+            "dbInstanceId": "dbInstanceId-example",
+            "dbVersion": "ENUM_VALUE",
+            "backupType": "AUTO",
+            "backupSize": 1,
+            "startYmdt": "2023-12-31T15:00:00+09:00",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00",
             "completedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
@@ -3422,6 +3528,7 @@ POST /v1.0/backups/{backupId}/restore
         "backupRetryCount": 0,
         "backupSchedules": [
             {
+                "backupWndBgnTime": "backupWndBgnTime-example",
                 "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
@@ -3503,6 +3610,12 @@ GET /v1.0/db-security-groups
     },
     "dbSecurityGroups": [
         {
+            "dbSecurityGroupId": "dbSecurityGroupId-example",
+            "dbSecurityGroupName": "dbSecurityGroupName-example",
+            "dbSecurityGroupStatus": "CREATED",
+            "description": "description-example",
+            "progressStatus": "NONE",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
             "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
@@ -3545,6 +3658,14 @@ POST /v1.0/db-security-groups
     "description": "description-example",
     "rules": [
         {
+            "direction": "INGRESS",
+            "etherType": "IPV4",
+            "port": {
+                "portType": "ALL",
+                "minPort": 1,
+                "maxPort": 1
+            },
+            "cidr": "cidr-example",
             "description": "description-example"
         }
     ]
@@ -3656,6 +3777,17 @@ GET /v1.0/db-security-groups/{dbSecurityGroupId}
         "progressStatus": "NONE",
         "rules": [
             {
+                "ruleId": "ruleId-example",
+                "description": "description-example",
+                "direction": "INGRESS",
+                "etherType": "IPV4",
+                "port": {
+                    "portType": "ALL",
+                    "minPort": 1,
+                    "maxPort": 1
+                },
+                "cidr": "cidr-example",
+                "createdYmdt": "2023-12-31T15:00:00+09:00",
                 "updatedYmdt": "2023-12-31T15:00:00+09:00"
             }
         ],
@@ -3911,6 +4043,12 @@ GET /v1.0/parameter-groups
     },
     "parameterGroups": [
         {
+            "parameterGroupId": "parameterGroupId-example",
+            "parameterGroupName": "parameterGroupName-example",
+            "description": "description-example",
+            "dbVersion": "ENUM_VALUE",
+            "parameterGroupStatus": "STABLE",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
             "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
@@ -4054,6 +4192,15 @@ GET /v1.0/parameter-groups/{parameterGroupId}
     "parameterGroupStatus": "STABLE",
     "parameters": [
         {
+            "parameterCategory": "parameterCategory-example",
+            "parameterName": "parameterName-example",
+            "value": "value-example",
+            "valueUnit": "valueUnit-example",
+            "defaultValue": "defaultValue-example",
+            "allowedValue": "allowedValue-example",
+            "valueType": "BOOLEAN",
+            "updateType": "VARIABLE",
+            "applyType": "BOTH",
             "expressionAvailable": false
         }
     ],
@@ -4174,6 +4321,7 @@ PUT /v1.0/parameter-groups/{parameterGroupId}/parameters
 {
     "modifiedParameters": [
         {
+            "parameterName": "parameterName-example",
             "value": "value-example"
         }
     ]
@@ -4244,6 +4392,10 @@ GET /v1.0/user-groups
     },
     "userGroups": [
         {
+            "userGroupId": "userGroupId-example",
+            "userGroupName": "userGroupName-example",
+            "userGroupStatus": "CREATED",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
             "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
@@ -4457,6 +4609,13 @@ GET /v1.0/notification-groups
     },
     "notificationGroups": [
         {
+            "notificationGroupId": "notificationGroupId-example",
+            "notificationGroupName": "notificationGroupName-example",
+            "notificationGroupStatus": "CREATED",
+            "notifyEmail": false,
+            "notifySms": false,
+            "isEnabled": false,
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
             "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
@@ -4598,11 +4757,13 @@ GET /v1.0/notification-groups/{notificationGroupId}
     "isEnabled": false,
     "dbInstances": [
         {
+            "dbInstanceId": "dbInstanceId-example",
             "dbInstanceName": "dbInstanceName-example"
         }
     ],
     "userGroups": [
         {
+            "userGroupId": "userGroupId-example",
             "userGroupName": "userGroupName-example"
         }
     ],
@@ -4695,6 +4856,11 @@ GET /v1.0/notification-groups/{notificationGroupId}/watchdogs
     },
     "notificationWatchdogs": [
         {
+            "watchdogId": "watchdogId-example",
+            "metricName": "metricName-example",
+            "comparisonOperator": "LE",
+            "threshold": 1,
+            "duration": 1,
             "createdYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
@@ -4869,6 +5035,7 @@ GET /v1.0/metrics
     },
     "metrics": [
         {
+            "metricName": "metricName-example",
             "unit": "unit-example"
         }
     ]
@@ -4925,6 +5092,7 @@ GET /v1.0/event-codes
     },
     "eventCodes": [
         {
+            "eventCode": "ENUM_VALUE",
             "eventCategoryType": "ALL"
         }
     ]
@@ -4974,6 +5142,16 @@ GET /v1.0/events
     "totalCounts": 1,
     "events": [
         {
+            "eventCategoryType": "ALL",
+            "eventCode": "ENUM_VALUE",
+            "sourceId": "sourceId-example",
+            "sourceName": "sourceName-example",
+            "messages": [
+                {
+                    "langCode": "KO",
+                    "message": "message-example"
+                }
+            ],
             "eventYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]

--- a/ko/api-guide-v1.0.md
+++ b/ko/api-guide-v1.0.md
@@ -1,4 +1,6 @@
-## Database > RDS for PostgreSQL > API v1.0 가이드
+## RDS for PostgreSQL API 가이드
+
+**Database > RDS for PostgreSQL > API v1.0 가이드**
 
 ## RDS for PostgreSQL API 공통 정보
 
@@ -15,10 +17,10 @@
 RDS for PostgreSQL은(는) API 호출 시 인증/인가를 위해 User Access Key 토큰을 사용합니다. User Access Key 토큰은 User Access Key를 기반으로 발급되는 Bearer 타입의 일시적 액세스 토큰입니다. User Access Key 토큰 발급 및 사용에 대한 자세한 내용은 [User Access Key 토큰](/nhncloud/ko/public-api/user-access-key-token)을 참고하세요.
 발급 받은 토큰은 Appkey와 함께 요청 Header에 포함해야 합니다.
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| X-TC-APP-KEY | Header | String | O | RDS for PostgreSQL 서비스의 Appkey 또는 프로젝트 통합 Appkey |
-| X-NHN-AUTHORIZATION | Header | String | O | Public API로 발급 받은 Bearer 유형 토큰 |
+| X-TC-APP-KEY | Header | String | Y | RDS for PostgreSQL 서비스의 Appkey 또는 프로젝트 통합 Appkey |
+| X-NHN-AUTHORIZATION | Header | String | Y | Public API로 발급 받은 Bearer 유형 토큰 |
 
 또한 프로젝트 권한에 따라 호출할 수 있는 API가 제한됩니다. `RDS for PostgreSQL ADMIN`, `RDS for PostgreSQL VIEWER` 역할에는 아래처럼 기본 권한이 부여돼 있고 프로젝트 내 역할 그룹 관리 메뉴에서 필요한 권한만 부여할 수 있습니다.
 
@@ -38,7 +40,9 @@ API 요청 시 인증에 실패하거나 권한이 없을 경우 다음과 같�
 
 모든 API 요청에 '200 OK'로 응답합니다. 자세한 응답 결과는 응답 본문의 헤더를 참고합니다.
 
-#### 응답 본문
+<details>
+  <summary><strong>성공 응답</strong></summary>
+
 ```json
 {
     "header": {
@@ -49,8 +53,24 @@ API 요청 시 인증에 실패하거나 권한이 없을 경우 다음과 같�
 }
 ```
 
-#### 필드
-| 이름 | 형식 | 설명 |
+</details>
+
+<details>
+  <summary><strong>실패 응답</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": -1,
+        "resultMessage": "FAIL",
+        "isSuccessful": false
+    }
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
 |-----|-----|-----|
 | resultCode | Number | 결과 코드<br/>- 성공: `0`<br/>- 실패: `0`이 아닌 값 |
 | resultMessage | String | 결과 메시지 |
@@ -58,10 +78,6 @@ API 요청 시 인증에 실패하거나 권한이 없을 경우 다음과 같�
 ## DB 버전
 
 ### DB 버전 목록 보기
-
-```http
-GET /v1.0/db-versions
-```
 
 #### 필요 권한
 
@@ -71,20 +87,18 @@ GET /v1.0/db-versions
 
 #### 요청
 
+```http
+GET /v1.0/db-versions
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| dbVersions | Body | Array | DB 버전 정보 |
-| dbVersions.dbVersionCode | Body | Enum | DB 버전 코드<br/>- MYSQL_V5633<br/>- MYSQL_V5715<br/>- MYSQL_V5719<br/>- MYSQL_V5726<br/>- MYSQL_V5731<br/>- MYSQL_V5733<br/>- MYSQL_V5737<br/>- MYSQL_V8018<br/>- MYSQL_V8023<br/>- MYSQL_V8028<br/>- MYSQL_V8032<br/>- MYSQL_V8033<br/>- MYSQL_V8034<br/>- MYSQL_V8035<br/>- MYSQL_V8036<br/>- MYSQL_V8040<br/>- MYSQL_V8041<br/>- MYSQL_V8042<br/>- MYSQL_V8043<br/>- MYSQL_V8044<br/>- MYSQL_V8045<br/>- MYSQL_V8405<br/>- MYSQL_V8406<br/>- MYSQL_V8407<br/>- MYSQL_V8408<br/>- MARIADB_V10330<br/>- MARIADB_V10611<br/>- MARIADB_V10612<br/>- MARIADB_V10616<br/>- MARIADB_V10622<br/>- MARIADB_V10625<br/>- MARIADB_V101107<br/>- MARIADB_V101108<br/>- MARIADB_V101113<br/>- MARIADB_V101116<br/>- MARIADB_V11407<br/>- MARIADB_V11410<br/>- MARIADB_V11806<br/>- POSTGRESQL_V14_6<br/>- POSTGRESQL_V14_15<br/>- POSTGRESQL_V14_17<br/>- POSTGRESQL_V14_19<br/>- POSTGRESQL_V17_2<br/>- POSTGRESQL_V17_4<br/>- POSTGRESQL_V17_6 |
-| dbVersions.dbMajorVersionCode | Body | Enum | DB 메이저 버전 코드<br/>- MYSQL_V56<br/>- MYSQL_V57<br/>- MYSQL_V80<br/>- MYSQL_V84<br/>- MARIADB_V103<br/>- MARIADB_V106<br/>- MARIADB_V1011<br/>- MARIADB_V114<br/>- MARIADB_V118<br/>- POSTGRES_V14<br/>- POSTGRES_V17 |
-| dbVersions.name | Body | String | DB 버전명 |
-| dbVersions.canCreate | Body | Boolean | 신규 생성 가능 여부 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -95,8 +109,8 @@ GET /v1.0/db-versions
     },
     "dbVersions": [
         {
-            "dbVersionCode": "MYSQL_V5633",
-            "dbMajorVersionCode": "MYSQL_V56",
+            "dbVersionCode": "dbVersionCode-example",
+            "dbMajorVersionCode": "dbMajorVersionCode-example",
             "name": "PostgreSQL V14.6",
             "canCreate": false
         }
@@ -104,18 +118,21 @@ GET /v1.0/db-versions
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbVersions | Array | DB 버전 정보 |
+| dbVersions.dbVersionCode | String | DB 버전 코드 |
+| dbVersions.dbMajorVersionCode | String | DB 메이저 버전 코드 |
+| dbVersions.name | String | DB 버전명 |
+| dbVersions.canCreate | Boolean | 신규 생성 가능 여부 |
 
 ---
 
 ## DB 인스턴스 사양
 
 ### DB 인스턴스 유형 목록 보기
-
-```http
-GET /v1.0/db-flavors
-```
 
 #### 필요 권한
 
@@ -125,20 +142,18 @@ GET /v1.0/db-flavors
 
 #### 요청
 
+```http
+GET /v1.0/db-flavors
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| dbFlavors | Body | Array | DB 인스턴스 사양 정보 |
-| dbFlavors.dbFlavorId | Body | UUID | DB 인스턴스 사양의 식별자 |
-| dbFlavors.dbFlavorName | Body | String | DB 인스턴스 사양명 |
-| dbFlavors.ram | Body | Number | 메모리 용량(MB) |
-| dbFlavors.vcpus | Body | Number | CPU 코어 수 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -158,18 +173,21 @@ GET /v1.0/db-flavors
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbFlavors | Array | DB 인스턴스 사양 정보 |
+| dbFlavors.dbFlavorId | UUID | DB 인스턴스 사양의 식별자 |
+| dbFlavors.dbFlavorName | String | DB 인스턴스 사양명 |
+| dbFlavors.ram | Number | 메모리 용량(MB) |
+| dbFlavors.vcpus | Number | CPU 코어 수 |
 
 ---
 
 ## 프로젝트 정보
 
 ### 프로젝트의 멤버 목록 조회
-
-```http
-GET /v1.0/project/members
-```
 
 #### 필요 권한
 
@@ -179,20 +197,18 @@ GET /v1.0/project/members
 
 #### 요청
 
+```http
+GET /v1.0/project/members
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| projectMembers | Body | Array | 프로젝트 멤버 정보 |
-| projectMembers.memberId | Body | UUID | 프로젝트 멤버의 식별자 |
-| projectMembers.memberName | Body | String | 프로젝트 멤버의 이름 |
-| projectMembers.emailAddress | Body | String | 프로젝트 멤버의 이메일 주소 |
-| projectMembers.phoneNumber | Body | String | 프로젝트 멤버의 전화번호 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -212,16 +228,19 @@ GET /v1.0/project/members
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| projectMembers | Array | 프로젝트 멤버 정보 |
+| projectMembers.memberId | UUID | 프로젝트 멤버의 식별자 |
+| projectMembers.memberName | String | 프로젝트 멤버의 이름 |
+| projectMembers.emailAddress | String | 프로젝트 멤버의 이메일 주소 |
+| projectMembers.phoneNumber | String | 프로젝트 멤버의 전화번호 |
 
 ---
 
 ### 프로젝트의 리전 목록 조회
-
-```http
-GET /v1.0/project/regions
-```
 
 #### 필요 권한
 
@@ -231,18 +250,18 @@ GET /v1.0/project/regions
 
 #### 요청
 
+```http
+GET /v1.0/project/regions
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| regions | Body | Array | 리전 정보 |
-| regions.regionCode | Body | Enum | 리전 코드<br/>- KR1: `한국(판교)`<br/>- KR2: `한국(평촌)` |
-| regions.isEnabled | Body | Boolean | 리전의 활성화 여부 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -260,18 +279,19 @@ GET /v1.0/project/regions
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| regions | Array | 리전 정보 |
+| regions.regionCode | Enum | 리전 코드<br/>- KR1: `한국(판교)`<br/>- KR2: `한국(평촌)` |
+| regions.isEnabled | Boolean | 리전의 활성화 여부 |
 
 ---
 
 ## 네트워크
 
 ### 서브넷 목록 보기
-
-```http
-GET /v1.0/network/subnets
-```
 
 #### 필요 권한
 
@@ -281,21 +301,18 @@ GET /v1.0/network/subnets
 
 #### 요청
 
+```http
+GET /v1.0/network/subnets
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| subnets | Body | Array | 서브넷 정보 |
-| subnets.subnetId | Body | UUID | 서브넷의 식별자 |
-| subnets.subnetName | Body | String | 서브넷을 식별할 수 있는 이름 |
-| subnets.subnetCidr | Body | String | 서브넷의 CIDR |
-| subnets.usingGateway | Body | Boolean | 게이트웨이 사용 여부 |
-| subnets.availableIpCount | Body | Number | 사용 가능한 IP 수 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -316,18 +333,22 @@ GET /v1.0/network/subnets
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| subnets | Array | 서브넷 정보 |
+| subnets.subnetId | UUID | 서브넷의 식별자 |
+| subnets.subnetName | String | 서브넷을 식별할 수 있는 이름 |
+| subnets.subnetCidr | String | 서브넷의 CIDR |
+| subnets.usingGateway | Boolean | 게이트웨이 사용 여부 |
+| subnets.availableIpCount | Number | 사용 가능한 IP 수 |
 
 ---
 
 ## 스토리지
 
 ### 스토리지 유형 목록 보기
-
-```http
-GET /v1.0/storage-types
-```
 
 #### 필요 권한
 
@@ -337,16 +358,18 @@ GET /v1.0/storage-types
 
 #### 요청
 
+```http
+GET /v1.0/storage-types
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| storageTypes | Body | Array | 스토리지 유형 정보 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -362,8 +385,11 @@ GET /v1.0/storage-types
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| storageTypes | Array | 스토리지 유형 정보 |
 
 ---
 
@@ -388,10 +414,6 @@ GET /v1.0/storage-types
 
 ### 작업 정보 상세 보기
 
-```http
-GET /v1.0/jobs/{jobId}
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -400,26 +422,24 @@ GET /v1.0/jobs/{jobId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v1.0/jobs/{jobId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| jobId | URL | UUID | O |  |
+| jobId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 작업의 식별자 |
-| jobStatus | Body | Enum | 작업의 현재 상태<br/>- DELETED<br/>- CANNOT_PROGRESS<br/>- FAILED<br/>- ERROR<br/>- CANCELED<br/>- INTERRUPTED<br/>- COMPLETED<br/>- COMPLETED_WITH_ERROR<br/>- RUNNING<br/>- PREPARING<br/>- READY<br/>- CREATED<br/>- FAIL_TO_READY<br/>- REGISTERED<br/>- FAIL_TO_REGISTER<br/>- WAIT_TO_REGISTER |
-| resourceRelations | Body | Array | 연관 리소스 목록 |
-| resourceRelations.resourceType | Body | String | 연관 리소스 유형 |
-| resourceRelations.resourceId | Body | String | 연관 리소스의 식별자 |
-| createdYmdt | Body | DateTime | 생성 일시 |
-| updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -441,18 +461,23 @@ GET /v1.0/jobs/{jobId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
+| jobStatus | Enum | 작업의 현재 상태<br/>- DELETED<br/>- CANNOT_PROGRESS<br/>- FAILED<br/>- ERROR<br/>- CANCELED<br/>- INTERRUPTED<br/>- COMPLETED<br/>- COMPLETED_WITH_ERROR<br/>- RUNNING<br/>- PREPARING<br/>- READY<br/>- CREATED<br/>- FAIL_TO_READY<br/>- REGISTERED<br/>- FAIL_TO_REGISTER<br/>- WAIT_TO_REGISTER |
+| resourceRelations | Array | 연관 리소스 목록 |
+| resourceRelations.resourceType | String | 연관 리소스 유형 |
+| resourceRelations.resourceId | String | 연관 리소스의 식별자 |
+| createdYmdt | DateTime | 생성 일시 |
+| updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
 ## DB 인스턴스 그룹
 
 ### DB 인스턴스 그룹 목록 보기
-
-```http
-GET /v1.0/db-instance-groups
-```
 
 #### 필요 권한
 
@@ -462,21 +487,18 @@ GET /v1.0/db-instance-groups
 
 #### 요청
 
+```http
+GET /v1.0/db-instance-groups
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| dbInstanceGroups | Body | Array | DB 인스턴스 그룹 정보 |
-| dbInstanceGroups.dbInstanceGroupId | Body | UUID | DB 인스턴스 그룹의 식별자 |
-| dbInstanceGroups.dbInstanceGroupStatus | Body | Enum | DB 인스턴스 그룹의 현재 형태<br/>- CREATED: `생성됨`<br/>- DELETED: `삭제됨` |
-| dbInstanceGroups.replicationType | Body | Enum | DB 인스턴스 그룹의 복제 형태<br/>- STANDALONE: `고가용성 사용 안함`<br/>- HIGH_AVAILABILITY: `고가용성 사용` |
-| dbInstanceGroups.createdYmdt | Body | DateTime | 생성 일시 |
-| dbInstanceGroups.updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -497,16 +519,20 @@ GET /v1.0/db-instance-groups
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbInstanceGroups | Array | DB 인스턴스 그룹 정보 |
+| dbInstanceGroups.dbInstanceGroupId | UUID | DB 인스턴스 그룹의 식별자 |
+| dbInstanceGroups.dbInstanceGroupStatus | Enum | DB 인스턴스 그룹의 현재 형태<br/>- CREATED: `생성됨`<br/>- DELETED: `삭제됨` |
+| dbInstanceGroups.replicationType | Enum | DB 인스턴스 그룹의 복제 형태<br/>- STANDALONE: `고가용성 사용 안함`<br/>- HIGH_AVAILABILITY: `고가용성 사용` |
+| dbInstanceGroups.createdYmdt | DateTime | 생성 일시 |
+| dbInstanceGroups.updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
 ### DB 인스턴스 그룹 상세 보기
-
-```http
-GET /v1.0/db-instance-groups/{dbInstanceGroupId}
-```
 
 #### 필요 권한
 
@@ -516,28 +542,24 @@ GET /v1.0/db-instance-groups/{dbInstanceGroupId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v1.0/db-instance-groups/{dbInstanceGroupId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceGroupId | URL | UUID | O |  |
+| dbInstanceGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| dbInstanceGroupId | Body | UUID | DB 인스턴스 그룹의 식별자 |
-| dbInstanceGroupStatus | Body | Enum | DB 인스턴스 그룹의 현재 상태<br/>- CREATED: `생성됨`<br/>- DELETED: `삭제됨` |
-| replicationType | Body | Enum | DB 인스턴스 그룹의 복제 형태<br/>- STANDALONE: `고가용성 사용 안함`<br/>- HIGH_AVAILABILITY: `고가용성 사용` |
-| dbInstances | Body | Array | DB 인스턴스 그룹에 속한 DB 인스턴스 목록 |
-| dbInstances.dbInstanceId | Body | UUID | DB 인스턴스의 식별자 |
-| dbInstances.dbInstanceType | Body | Enum | DB 인스턴스의 역할 타입<br/>- MASTER: `마스터`<br/>- FAILED_MASTER: `장애 마스터`<br/>- CANDIDATE_MASTER: `예비 마스터`<br/>- READ_ONLY_SLAVE: `읽기 복제본` |
-| dbInstances.dbInstanceStatus | Body | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전 (회색)`<br/>- AVAILABLE: `사용 가능 (녹색)`<br/>- STORAGE_FULL: `용량 부족 (적색)`<br/>- FAIL_TO_CREATE: `생성 실패 (적색)`<br/>- FAIL_TO_CONNECT: `연결 실패 (적색)`<br/>- REPLICATION_STOP: `복제 중단 (적색)`<br/>- REPLICATION_DELAY: `복제 지연 (황색)`<br/>- FAILOVER: `장애 조치 완료 (적색)`<br/>- SHUTDOWN: `중지 됨 (회색)`<br/>- DELETED: `삭제됨 (회색)` |
-| createdYmdt | Body | DateTime | 생성 일시 |
-| updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -561,16 +583,23 @@ GET /v1.0/db-instance-groups/{dbInstanceGroupId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbInstanceGroupId | UUID | DB 인스턴스 그룹의 식별자 |
+| dbInstanceGroupStatus | Enum | DB 인스턴스 그룹의 현재 상태<br/>- CREATED: `생성됨`<br/>- DELETED: `삭제됨` |
+| replicationType | Enum | DB 인스턴스 그룹의 복제 형태<br/>- STANDALONE: `고가용성 사용 안함`<br/>- HIGH_AVAILABILITY: `고가용성 사용` |
+| dbInstances | Array | DB 인스턴스 그룹에 속한 DB 인스턴스 목록 |
+| dbInstances.dbInstanceId | UUID | DB 인스턴스의 식별자 |
+| dbInstances.dbInstanceType | Enum | DB 인스턴스의 역할 타입<br/>- MASTER: `마스터`<br/>- FAILED_MASTER: `장애 마스터`<br/>- CANDIDATE_MASTER: `예비 마스터`<br/>- READ_ONLY_SLAVE: `읽기 복제본` |
+| dbInstances.dbInstanceStatus | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전 (회색)`<br/>- AVAILABLE: `사용 가능 (녹색)`<br/>- STORAGE_FULL: `용량 부족 (적색)`<br/>- FAIL_TO_CREATE: `생성 실패 (적색)`<br/>- FAIL_TO_CONNECT: `연결 실패 (적색)`<br/>- REPLICATION_STOP: `복제 중단 (적색)`<br/>- REPLICATION_DELAY: `복제 지연 (황색)`<br/>- FAILOVER: `장애 조치 완료 (적색)`<br/>- SHUTDOWN: `중지 됨 (회색)`<br/>- DELETED: `삭제됨 (회색)` |
+| createdYmdt | DateTime | 생성 일시 |
+| updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
 ### 확장 리스트 조회
-
-```http
-GET /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions
-```
 
 #### 필요 권한
 
@@ -580,31 +609,24 @@ GET /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceGroupId | URL | UUID | O | DB 인스턴스 그룹 ID |
+| dbInstanceGroupId | URL | UUID | Y | DB 인스턴스 그룹 ID |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| extensions | Body | Array | 확장 정보 |
-| extensions.extensionId | Body | UUID | 확장 ID |
-| extensions.extensionName | Body | String | 확장 이름 |
-| extensions.extensionStatus | Body | Enum | 확장 상태<br/>- AVAILABLE: `사용 가능`<br/>- NEED_TO_APPLY: `적용 필요`<br/>- APPLYING: `적용 중` |
-| extensions.databases | Body | Array | 데이터베이스 정보 |
-| extensions.databases.dbInstanceGroupExtensionId | Body | UUID | DB 인스턴스 그룹 확장 ID |
-| extensions.databases.databaseId | Body | UUID | 데이터베이스 ID |
-| extensions.databases.databaseName | Body | String | 데이터베이스 이름 |
-| extensions.databases.dbInstanceGroupExtensionStatus | Body | Enum | 데이터베이스 확장 설치 상태<br/>- CREATED: `생성 됨`<br/>- INSTALLED: `설치 됨`<br/>- INSTALLING: `설치 중`<br/>- INSTALL_ERROR: `설치 에러`<br/>- DELETED: `삭제 됨`<br/>- DELETING: `삭제 중`<br/>- DELETE_ERROR: `삭제 에러` |
-| extensions.databases.reservedAction | Body | Enum | 예약 작업<br/>- NONE: `없음`<br/>- INSTALL: `설치 예약 (적용 필요)`<br/>- INSTALL_WITH_CASCADE: `강제 설치 예약 (적용 필요)`<br/>- DELETE: `삭제 예약 (적용 필요)`<br/>- DELETE_WITH_CASCADE: `강제 삭제 예약 (적용 필요)` |
-| extensions.databases.errorReason | Body | String | 에러 원인 |
-| isNeedToApply | Body | Boolean | 적용 필요 여부 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -634,16 +656,26 @@ GET /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| extensions | Array | 확장 정보 |
+| extensions.extensionId | UUID | 확장 ID |
+| extensions.extensionName | String | 확장 이름 |
+| extensions.extensionStatus | Enum | 확장 상태<br/>- AVAILABLE: `사용 가능`<br/>- NEED_TO_APPLY: `적용 필요`<br/>- APPLYING: `적용 중` |
+| extensions.databases | Array | 데이터베이스 정보 |
+| extensions.databases.dbInstanceGroupExtensionId | UUID | DB 인스턴스 그룹 확장 ID |
+| extensions.databases.databaseId | UUID | 데이터베이스 ID |
+| extensions.databases.databaseName | String | 데이터베이스 이름 |
+| extensions.databases.dbInstanceGroupExtensionStatus | Enum | 데이터베이스 확장 설치 상태<br/>- CREATED: `생성 됨`<br/>- INSTALLED: `설치 됨`<br/>- INSTALLING: `설치 중`<br/>- INSTALL_ERROR: `설치 에러`<br/>- DELETED: `삭제 됨`<br/>- DELETING: `삭제 중`<br/>- DELETE_ERROR: `삭제 에러` |
+| extensions.databases.reservedAction | Enum | 예약 작업<br/>- NONE: `없음`<br/>- INSTALL: `설치 예약 (적용 필요)`<br/>- INSTALL_WITH_CASCADE: `강제 설치 예약 (적용 필요)`<br/>- DELETE: `삭제 예약 (적용 필요)`<br/>- DELETE_WITH_CASCADE: `강제 삭제 예약 (적용 필요)` |
+| extensions.databases.errorReason | String | 에러 원인 |
+| isNeedToApply | Boolean | 적용 필요 여부 |
 
 ---
 
 ### 확장 변경사항 적용
-
-```http
-POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/apply
-```
 
 #### 필요 권한
 
@@ -653,20 +685,24 @@ POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/apply
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/apply
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceGroupId | URL | UUID | O | DB 인스턴스 그룹 ID |
+| dbInstanceGroupId | URL | UUID | Y | DB 인스턴스 그룹 ID |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -679,16 +715,15 @@ POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/apply
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### 확장 동기화
-
-```http
-POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/sync
-```
 
 #### 필요 권한
 
@@ -698,20 +733,24 @@ POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/sync
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/sync
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceGroupId | URL | UUID | O | DB 인스턴스 그룹 ID |
+| dbInstanceGroupId | URL | UUID | Y | DB 인스턴스 그룹 ID |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -724,16 +763,15 @@ POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/sync
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### 확장 삭제(취소)
-
-```http
-DELETE /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{dbInstanceGroupExtensionId}
-```
 
 #### 필요 권한
 
@@ -743,13 +781,21 @@ DELETE /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{dbInstanceGroupE
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+DELETE /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{dbInstanceGroupExtensionId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceGroupId | URL | UUID | O | DB 인스턴스 그룹 ID |
-| dbInstanceGroupExtensionId | URL | UUID | O | DB 인스턴스 그룹 확장 ID |
-| withCascade | Query | Boolean | O | 강제 삭제 여부 |
+| dbInstanceGroupId | URL | UUID | Y | DB 인스턴스 그룹 ID |
+| dbInstanceGroupExtensionId | URL | UUID | Y | DB 인스턴스 그룹 확장 ID |
+| withCascade | Query | Boolean | Y | 강제 삭제 여부 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
@@ -759,10 +805,6 @@ DELETE /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{dbInstanceGroupE
 
 ### 확장 설치
 
-```http
-POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{extensionId}
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -771,16 +813,21 @@ POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{extensionId}
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceGroupId | URL | UUID | O | DB 인스턴스 그룹 ID |
-| extensionId | URL | UUID | O | 확장 ID |
-| databaseId | Body | UUID | O | 데이터베이스 ID |
-| schemaName | Body | String | O | 스키마 이름 |
-| withCascade | Body | Boolean | X | 연관 정보 자동 설치 여부<br/>- 기본값: `false` |
+```http
+POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{extensionId}
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | Y | DB 인스턴스 그룹 ID |
+| extensionId | URL | UUID | Y | 확장 ID |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -790,8 +837,13 @@ POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{extensionId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| databaseId | UUID | Y | 데이터베이스 ID |
+| schemaName | String | Y | 스키마 이름 |
+| withCascade | Boolean | N | 연관 정보 자동 설치 여부<br/>- 기본값: `false` |
 
 #### 응답
 
@@ -848,10 +900,6 @@ POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{extensionId}
 
 ### DB 인스턴스 목록 보기
 
-```http
-GET /v1.0/db-instances
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -860,27 +908,18 @@ GET /v1.0/db-instances
 
 #### 요청
 
+```http
+GET /v1.0/db-instances
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| dbInstances | Body | Array | DB 인스턴스 정보 |
-| dbInstances.dbInstanceId | Body | UUID | DB 인스턴스의 식별자 |
-| dbInstances.dbInstanceGroupId | Body | UUID | DB 인스턴스 그룹의 식별자 |
-| dbInstances.dbInstanceName | Body | String | DB 인스턴스를 식별할 수 있는 이름 |
-| dbInstances.description | Body | String | DB 인스턴스에 대한 추가 정보 |
-| dbInstances.dbVersion | Body | Enum | DB 엔진 유형 |
-| dbInstances.dbPort | Body | Number | DB 포트 |
-| dbInstances.dbInstanceType | Body | Enum | DB 인스턴스 역할 타입<br/>- MASTER: `마스터`<br/>- FAILED_MASTER: `장애 마스터`<br/>- CANDIDATE_MASTER: `예비 마스터`<br/>- READ_ONLY_SLAVE: `읽기 복제본` |
-| dbInstances.dbInstanceStatus | Body | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전 (회색)`<br/>- AVAILABLE: `사용 가능 (녹색)`<br/>- STORAGE_FULL: `용량 부족 (적색)`<br/>- FAIL_TO_CREATE: `생성 실패 (적색)`<br/>- FAIL_TO_CONNECT: `연결 실패 (적색)`<br/>- REPLICATION_STOP: `복제 중단 (적색)`<br/>- REPLICATION_DELAY: `복제 지연 (황색)`<br/>- FAILOVER: `장애 조치 완료 (적색)`<br/>- SHUTDOWN: `중지 됨 (회색)`<br/>- DELETED: `삭제됨 (회색)` |
-| dbInstances.progressStatus | Body | String | DB 인스턴스의 현재 진행 상태 |
-| dbInstances.createdYmdt | Body | DateTime | 생성 일시 |
-| dbInstances.updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -907,16 +946,26 @@ GET /v1.0/db-instances
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbInstances | Array | DB 인스턴스 정보 |
+| dbInstances.dbInstanceId | UUID | DB 인스턴스의 식별자 |
+| dbInstances.dbInstanceGroupId | UUID | DB 인스턴스 그룹의 식별자 |
+| dbInstances.dbInstanceName | String | DB 인스턴스를 식별할 수 있는 이름 |
+| dbInstances.description | String | DB 인스턴스에 대한 추가 정보 |
+| dbInstances.dbVersion | String | DB 엔진 유형 |
+| dbInstances.dbPort | Number | DB 포트 |
+| dbInstances.dbInstanceType | Enum | DB 인스턴스 역할 타입<br/>- MASTER: `마스터`<br/>- FAILED_MASTER: `장애 마스터`<br/>- CANDIDATE_MASTER: `예비 마스터`<br/>- READ_ONLY_SLAVE: `읽기 복제본` |
+| dbInstances.dbInstanceStatus | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전 (회색)`<br/>- AVAILABLE: `사용 가능 (녹색)`<br/>- STORAGE_FULL: `용량 부족 (적색)`<br/>- FAIL_TO_CREATE: `생성 실패 (적색)`<br/>- FAIL_TO_CONNECT: `연결 실패 (적색)`<br/>- REPLICATION_STOP: `복제 중단 (적색)`<br/>- REPLICATION_DELAY: `복제 지연 (황색)`<br/>- FAILOVER: `장애 조치 완료 (적색)`<br/>- SHUTDOWN: `중지 됨 (회색)`<br/>- DELETED: `삭제됨 (회색)` |
+| dbInstances.progressStatus | String | DB 인스턴스의 현재 진행 상태 |
+| dbInstances.createdYmdt | DateTime | 생성 일시 |
+| dbInstances.updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
 ### DB 인스턴스 생성하기
-
-```http
-POST /v1.0/db-instances
-```
 
 #### 필요 권한
 
@@ -926,41 +975,14 @@ POST /v1.0/db-instances
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceName | Body | String | O | DB 인스턴스를 식별할 수 있는 이름 |
-| dbInstanceCandidateName | Body | String | X | DB 인스턴스를 식별할 수 있는 예비 마스터 이름 |
-| description | Body | String | X | DB 인스턴스에 대한 추가 정보 |
-| dbFlavorId | Body | UUID | O | DB 인스턴스 사양의 식별자 |
-| dbVersion | Body | Enum | O | DB 엔진 유형 |
-| dbPort | Body | Number | O | DB 포트<br/>- 최솟값: 5432, 최댓값: 45432 |
-| databaseName | Body | String | O | 데이터베이스명 |
-| dbUserName | Body | String | O | DB 사용자 계정명 |
-| dbPassword | Body | String | O | DB 사용자 계정 암호 |
-| parameterGroupId | Body | UUID | O | 파라미터 그룹의 식별자 |
-| dbSecurityGroupIds | Body | Array | X | DB 보안 그룹의 식별자 목록 |
-| userGroupIds | Body | Array | X | 사용자 그룹의 식별자 목록 |
-| useHighAvailability | Body | Boolean | X | 고가용성 사용 여부<br/>- 기본값: `false` |
-| useDefaultNotification | Body | Boolean | X | 기본 알림 사용 여부<br/>- 기본값: `false` |
-| useDeletionProtection | Body | Boolean | X | 삭제 보호 여부<br/>- 기본값: `false` |
-| pingInterval | Body | Number | X | Ping 간격(초)<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
-| failoverReplWaitingTime | Body | Number | X | 장애조치 복제 지연 대기 시간(초)<br/>- 최솟값: `-1` |
-| network | Body | Object | O | 네트워크 정보 |
-| network.subnetId | Body | UUID | O | 서브넷의 식별자 |
-| network.usePublicAccess | Body | Boolean | X | 외부 접속 가능 여부<br/>- 기본값: `false` |
-| network.availabilityZone | Body | Enum | X | DB 인스턴스를 생성할 가용성 영역 |
-| storage | Body | Object | O | 스토리지 정보 |
-| storage.storageType | Body | Enum | O | 스토리지 타입 |
-| storage.storageSize | Body | Number | O | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20` |
-| backup | Body | Object | O | 백업 정보 |
-| backup.backupPeriod | Body | Number | O | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
-| backup.backupRetryCount | Body | Number | X | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
-| backup.backupSchedules | Body | Array | O | 백업 스케쥴 정보 |
-| backup.backupSchedules.backupWndBgnTime | Body | Time | O | 백업 시작 시각 |
-| backup.backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
+```http
+POST /v1.0/db-instances
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1003,17 +1025,45 @@ POST /v1.0/db-instances
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | DB 인스턴스를 식별할 수 있는 이름 |
+| dbInstanceCandidateName | String | N | DB 인스턴스를 식별할 수 있는 예비 마스터 이름 |
+| description | String | N | DB 인스턴스에 대한 추가 정보 |
+| dbFlavorId | UUID | Y | DB 인스턴스 사양의 식별자 |
+| dbVersion | String | Y | DB 엔진 유형 |
+| dbPort | Number | Y | DB 포트<br/>- 최솟값: 5432, 최댓값: 45432 |
+| databaseName | String | Y | 데이터베이스명 |
+| dbUserName | String | Y | DB 사용자 계정명 |
+| dbPassword | String | Y | DB 사용자 계정 암호 |
+| parameterGroupId | UUID | Y | 파라미터 그룹의 식별자 |
+| dbSecurityGroupIds | Array | N | DB 보안 그룹의 식별자 목록 |
+| userGroupIds | Array | N | 사용자 그룹의 식별자 목록 |
+| useHighAvailability | Boolean | N | 고가용성 사용 여부<br/>- 기본값: `false` |
+| useDefaultNotification | Boolean | N | 기본 알림 사용 여부<br/>- 기본값: `false` |
+| useDeletionProtection | Boolean | N | 삭제 보호 여부<br/>- 기본값: `false` |
+| pingInterval | Number | N | Ping 간격(초)<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
+| failoverReplWaitingTime | Number | N | 장애조치 복제 지연 대기 시간(초)<br/>- 최솟값: `-1` |
+| network | Object | Y | 네트워크 정보 |
+| network.subnetId | UUID | Y | 서브넷의 식별자 |
+| network.usePublicAccess | Boolean | N | 외부 접속 가능 여부<br/>- 기본값: `false` |
+| network.availabilityZone | Enum | N | DB 인스턴스를 생성할 가용성 영역 |
+| storage | Object | Y | 스토리지 정보 |
+| storage.storageType | Enum | Y | 스토리지 타입 |
+| storage.storageSize | Number | Y | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20` |
+| backup | Object | Y | 백업 정보 |
+| backup.backupPeriod | Number | Y | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
+| backup.backupRetryCount | Number | N | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
+| backup.backupSchedules | Array | Y | 백업 스케쥴 정보 |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | 백업 시작 시각 |
+| backup.backupSchedules.backupWndDuration | Enum | Y | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1026,16 +1076,15 @@ POST /v1.0/db-instances
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 인스턴스 오브젝트 스토리지에 있는 백업으로 복원
-
-```http
-POST /v1.0/db-instances/restore-from-obs
-```
 
 #### 필요 권한
 
@@ -1045,46 +1094,14 @@ POST /v1.0/db-instances/restore-from-obs
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceName | Body | String | X | DB 인스턴스를 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-| dbInstanceCandidateName | Body | String | X | DB 인스턴스를 식별할 수 있는 예비 마스터 이름 |
-| description | Body | String | X | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
-| dbFlavorId | Body | UUID | O | DB 인스턴스 사양의 식별자 |
-| dbPort | Body | Number | X | DB 포트<br/>- 최솟값: 5432, 최댓값: 45432 |
-| dbVersion | Body | Enum | O | DB 엔진 유형 |
-| useHighAvailability | Body | Boolean | X | 고가용성 사용 여부<br/>- 기본값: `false` |
-| imageId | Body | UUID | X | 이미지의 식별자 |
-| pingInterval | Body | Number | X | 고가용성 사용 시 Ping 간격(초)<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
-| failoverReplWaitingTime | Body | Number | X | 장애조치 복제 지연 대기 시간(초)<br/>- 최솟값: `-1` |
-| storage | Body | Object | O | 스토리지 정보 객체 |
-| storage.storageType | Body | Enum | O | 스토리지 타입 |
-| storage.storageSize | Body | Number | O | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20` |
-| network | Body | Object | O | 네트워크 정보 객체 |
-| network.subnetId | Body | UUID | O | 서브넷의 식별자 |
-| network.usePublicAccess | Body | Boolean | X | 외부 접속 가능 여부<br/>- 기본값: `false` |
-| network.availabilityZone | Body | Enum | X | DB 인스턴스를 생성할 가용성 영역 |
-| backup | Body | Object | O | 백업 정보 객체 |
-| backup.backupPeriod | Body | Number | O | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
-| backup.backupRetryCount | Body | Number | X | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
-| backup.replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)`<br/>- KR2: `한국(평촌)` |
-| backup.backupSchedules | Body | Array | O | 백업 스케쥴 목록 |
-| backup.backupSchedules.backupWndBgnTime | Body | Time | O | 백업 시작 시각 |
-| backup.backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
-| restore | Body | Object | O | 복원 정보 객체 |
-| restore.tenantId | Body | String | O | 백업이 저장된 오브젝트 스토리지의 테넌트 ID |
-| restore.username | Body | String | O | NHN Cloud 계정 혹은 IAM 멤버 ID |
-| restore.password | Body | String | O | 백업이 저장된 오브젝트 스토리지의 API 비밀번호 |
-| restore.targetContainer | Body | String | O | 백업이 저장된 오브젝트 스토리지의 컨테이너 |
-| restore.objectPath | Body | String | O | 컨테이너에 저장된 백업의 경로 |
-| useDefaultNotification | Body | Boolean | X | 기본 알림 사용 여부<br/>- 기본값: `false` |
-| parameterGroupId | Body | UUID | O | 파라미터 그룹의 식별자 |
-| dbSecurityGroupIds | Body | Array | X | DB 보안 그룹의 식별자 목록 |
-| userGroupIds | Body | Array | X | 사용자 그룹의 식별자 목록 |
-| useDeletionProtection | Body | Boolean | X | 삭제 보호 여부<br/>- 기본값: `false` |
+```http
+POST /v1.0/db-instances/restore-from-obs
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1133,17 +1150,50 @@ POST /v1.0/db-instances/restore-from-obs
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | N | DB 인스턴스를 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| dbInstanceCandidateName | String | N | DB 인스턴스를 식별할 수 있는 예비 마스터 이름 |
+| description | String | N | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbFlavorId | UUID | Y | DB 인스턴스 사양의 식별자 |
+| dbPort | Number | N | DB 포트<br/>- 최솟값: 5432, 최댓값: 45432 |
+| dbVersion | String | Y | DB 엔진 유형 |
+| useHighAvailability | Boolean | N | 고가용성 사용 여부<br/>- 기본값: `false` |
+| imageId | UUID | N | 이미지의 식별자 |
+| pingInterval | Number | N | 고가용성 사용 시 Ping 간격(초)<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
+| failoverReplWaitingTime | Number | N | 장애조치 복제 지연 대기 시간(초)<br/>- 최솟값: `-1` |
+| storage | Object | Y | 스토리지 정보 객체 |
+| storage.storageType | Enum | Y | 스토리지 타입 |
+| storage.storageSize | Number | Y | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20` |
+| network | Object | Y | 네트워크 정보 객체 |
+| network.subnetId | UUID | Y | 서브넷의 식별자 |
+| network.usePublicAccess | Boolean | N | 외부 접속 가능 여부<br/>- 기본값: `false` |
+| network.availabilityZone | Enum | N | DB 인스턴스를 생성할 가용성 영역 |
+| backup | Object | Y | 백업 정보 객체 |
+| backup.backupPeriod | Number | Y | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
+| backup.backupRetryCount | Number | N | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
+| backup.replicationRegion | Enum | N | 백업 복제 리전<br/>- KR1: `한국(판교)`<br/>- KR2: `한국(평촌)` |
+| backup.backupSchedules | Array | Y | 백업 스케쥴 목록 |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | 백업 시작 시각 |
+| backup.backupSchedules.backupWndDuration | Enum | Y | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
+| restore | Object | Y | 복원 정보 객체 |
+| restore.tenantId | String | Y | 백업이 저장된 오브젝트 스토리지의 테넌트 ID |
+| restore.username | String | Y | NHN Cloud 계정 혹은 IAM 멤버 ID |
+| restore.password | String | Y | 백업이 저장된 오브젝트 스토리지의 API 비밀번호 |
+| restore.targetContainer | String | Y | 백업이 저장된 오브젝트 스토리지의 컨테이너 |
+| restore.objectPath | String | Y | 컨테이너에 저장된 백업의 경로 |
+| useDefaultNotification | Boolean | N | 기본 알림 사용 여부<br/>- 기본값: `false` |
+| parameterGroupId | UUID | Y | 파라미터 그룹의 식별자 |
+| dbSecurityGroupIds | Array | N | DB 보안 그룹의 식별자 목록 |
+| userGroupIds | Array | N | 사용자 그룹의 식별자 목록 |
+| useDeletionProtection | Boolean | N | 삭제 보호 여부<br/>- 기본값: `false` |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1156,16 +1206,15 @@ POST /v1.0/db-instances/restore-from-obs
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 인스턴스 삭제하기
-
-```http
-DELETE /v1.0/db-instances/{dbInstanceId}
-```
 
 #### 필요 권한
 
@@ -1175,20 +1224,24 @@ DELETE /v1.0/db-instances/{dbInstanceId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+DELETE /v1.0/db-instances/{dbInstanceId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1201,16 +1254,15 @@ DELETE /v1.0/db-instances/{dbInstanceId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 인스턴스 상세 보기
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}
-```
 
 #### 필요 권한
 
@@ -1220,38 +1272,24 @@ GET /v1.0/db-instances/{dbInstanceId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v1.0/db-instances/{dbInstanceId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| dbInstanceId | Body | UUID | DB 인스턴스의 식별자 |
-| dbInstanceGroupId | Body | UUID | DB 인스턴스 그룹의 식별자 |
-| dbInstanceName | Body | String | DB 인스턴스를 식별할 수 있는 이름 |
-| description | Body | String | DB 인스턴스에 대한 추가 정보 |
-| dbVersion | Body | Enum | DB 엔진 유형 |
-| dbPort | Body | Number | DB 포트 |
-| dbInstanceType | Body | Enum | DB 인스턴스 역할 타입<br/>- MASTER: `마스터`<br/>- FAILED_MASTER: `장애 마스터`<br/>- CANDIDATE_MASTER: `예비 마스터`<br/>- READ_ONLY_SLAVE: `읽기 복제본` |
-| dbInstanceStatus | Body | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전 (회색)`<br/>- AVAILABLE: `사용 가능 (녹색)`<br/>- STORAGE_FULL: `용량 부족 (적색)`<br/>- FAIL_TO_CREATE: `생성 실패 (적색)`<br/>- FAIL_TO_CONNECT: `연결 실패 (적색)`<br/>- REPLICATION_STOP: `복제 중단 (적색)`<br/>- REPLICATION_DELAY: `복제 지연 (황색)`<br/>- FAILOVER: `장애 조치 완료 (적색)`<br/>- SHUTDOWN: `중지 됨 (회색)`<br/>- DELETED: `삭제됨 (회색)` |
-| progressStatus | Body | String | DB 인스턴스의 현재 진행 상태 |
-| dbFlavorId | Body | UUID | DB 인스턴스 사양의 식별자 |
-| parameterGroupId | Body | UUID | DB 인스턴스에 적용된 파라미터 그룹의 식별자 |
-| dbSecurityGroupIds | Body | Array | DB 인스턴스에 적용된 DB 보안 그룹의 식별자 목록 |
-| notificationGroupIds | Body | Array | DB 인스턴스에 적용된 알림 그룹의 식별자 목록 |
-| useDeletionProtection | Body | Boolean | DB 인스턴스 삭제 보호 여부 |
-| needToApplyParameterGroup | Body | Boolean | 최신 파라미터 그룹 적용 필요 여부 |
-| needMigration | Body | Boolean | 마이그레이션 필요 여부 |
-| osVersion | Body | String | 운영체제 버전 |
-| createdYmdt | Body | DateTime | 생성 일시 |
-| updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1286,16 +1324,33 @@ GET /v1.0/db-instances/{dbInstanceId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbInstanceId | UUID | DB 인스턴스의 식별자 |
+| dbInstanceGroupId | UUID | DB 인스턴스 그룹의 식별자 |
+| dbInstanceName | String | DB 인스턴스를 식별할 수 있는 이름 |
+| description | String | DB 인스턴스에 대한 추가 정보 |
+| dbVersion | String | DB 엔진 유형 |
+| dbPort | Number | DB 포트 |
+| dbInstanceType | Enum | DB 인스턴스 역할 타입<br/>- MASTER: `마스터`<br/>- FAILED_MASTER: `장애 마스터`<br/>- CANDIDATE_MASTER: `예비 마스터`<br/>- READ_ONLY_SLAVE: `읽기 복제본` |
+| dbInstanceStatus | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전 (회색)`<br/>- AVAILABLE: `사용 가능 (녹색)`<br/>- STORAGE_FULL: `용량 부족 (적색)`<br/>- FAIL_TO_CREATE: `생성 실패 (적색)`<br/>- FAIL_TO_CONNECT: `연결 실패 (적색)`<br/>- REPLICATION_STOP: `복제 중단 (적색)`<br/>- REPLICATION_DELAY: `복제 지연 (황색)`<br/>- FAILOVER: `장애 조치 완료 (적색)`<br/>- SHUTDOWN: `중지 됨 (회색)`<br/>- DELETED: `삭제됨 (회색)` |
+| progressStatus | String | DB 인스턴스의 현재 진행 상태 |
+| dbFlavorId | UUID | DB 인스턴스 사양의 식별자 |
+| parameterGroupId | UUID | DB 인스턴스에 적용된 파라미터 그룹의 식별자 |
+| dbSecurityGroupIds | Array | DB 인스턴스에 적용된 DB 보안 그룹의 식별자 목록 |
+| notificationGroupIds | Array | DB 인스턴스에 적용된 알림 그룹의 식별자 목록 |
+| useDeletionProtection | Boolean | DB 인스턴스 삭제 보호 여부 |
+| needToApplyParameterGroup | Boolean | 최신 파라미터 그룹 적용 필요 여부 |
+| needMigration | Boolean | 마이그레이션 필요 여부 |
+| osVersion | String | 운영체제 버전 |
+| createdYmdt | DateTime | 생성 일시 |
+| updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
 ### DB 인스턴스 수정하기
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}
-```
 
 #### 필요 권한
 
@@ -1305,24 +1360,20 @@ PUT /v1.0/db-instances/{dbInstanceId}
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| dbInstanceName | Body | String | X | DB 인스턴스를 식별할 수 있는 이름 |
-| dbInstanceCandidateName | Body | String | X | DB 인스턴스를 식별할 수 있는 예비 마스터 이름 |
-| description | Body | String | X | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
-| dbPort | Body | Number | X | DB 포트<br/>- 최솟값: 5432, 최댓값: 45432 |
-| dbFlavorId | Body | UUID | X | DB 인스턴스 사양의 식별자 |
-| parameterGroupId | Body | UUID | X | 파라미터 그룹의 식별자 |
-| dbVersion | Body | Enum | X | DB 엔진 버전 코드 |
-| dbSecurityGroupIds | Body | Array | X | DB 보안 그룹의 식별자 목록 |
-| executeBackup | Body | Boolean | X | 현재 시점 백업 진행 여부<br/>- 기본값: `false` |
-| useOnlineFailover | Body | Boolean | X | 장애 조치를 이용한 재시작 여부<br/>- 기본값: `false` |
-| waitReplicationDelay | Body | Boolean | X | 복제 지연 해소 대기<br/>- 기본값: `false` |
-| useReadOnly | Body | Boolean | X | 쓰기 부하 차단<br/>- 기본값: `false` |
+```http
+PUT /v1.0/db-instances/{dbInstanceId}
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1341,17 +1392,27 @@ PUT /v1.0/db-instances/{dbInstanceId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | N | DB 인스턴스를 식별할 수 있는 이름 |
+| dbInstanceCandidateName | String | N | DB 인스턴스를 식별할 수 있는 예비 마스터 이름 |
+| description | String | N | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbPort | Number | N | DB 포트<br/>- 최솟값: 5432, 최댓값: 45432 |
+| dbFlavorId | UUID | N | DB 인스턴스 사양의 식별자 |
+| parameterGroupId | UUID | N | 파라미터 그룹의 식별자 |
+| dbVersion | String | N | DB 엔진 버전 코드 |
+| dbSecurityGroupIds | Array | N | DB 보안 그룹의 식별자 목록 |
+| executeBackup | Boolean | N | 현재 시점 백업 진행 여부<br/>- 기본값: `false` |
+| useOnlineFailover | Boolean | N | 장애 조치를 이용한 재시작 여부<br/>- 기본값: `false` |
+| waitReplicationDelay | Boolean | N | 복제 지연 해소 대기<br/>- 기본값: `false` |
+| useReadOnly | Boolean | N | 쓰기 부하 차단<br/>- 기본값: `false` |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1364,16 +1425,15 @@ PUT /v1.0/db-instances/{dbInstanceId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 인스턴스 최신 파라미터 그룹 적용하기
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/apply-recent-parameter-group
-```
 
 #### 필요 권한
 
@@ -1383,20 +1443,24 @@ POST /v1.0/db-instances/{dbInstanceId}/apply-recent-parameter-group
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+POST /v1.0/db-instances/{dbInstanceId}/apply-recent-parameter-group
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1409,16 +1473,15 @@ POST /v1.0/db-instances/{dbInstanceId}/apply-recent-parameter-group
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### 현 DB 인스턴스에서 선택 가능한 DB 버전 조회
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}/available-db-versions
-```
 
 #### 필요 권한
 
@@ -1428,24 +1491,24 @@ GET /v1.0/db-instances/{dbInstanceId}/available-db-versions
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v1.0/db-instances/{dbInstanceId}/available-db-versions
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| availableDbVersions | Body | Array | DB 버전 정보 |
-| availableDbVersions.dbVersionCode | Body | Enum | DB 버전 코드<br/>- MYSQL_V5633<br/>- MYSQL_V5715<br/>- MYSQL_V5719<br/>- MYSQL_V5726<br/>- MYSQL_V5731<br/>- MYSQL_V5733<br/>- MYSQL_V5737<br/>- MYSQL_V8018<br/>- MYSQL_V8023<br/>- MYSQL_V8028<br/>- MYSQL_V8032<br/>- MYSQL_V8033<br/>- MYSQL_V8034<br/>- MYSQL_V8035<br/>- MYSQL_V8036<br/>- MYSQL_V8040<br/>- MYSQL_V8041<br/>- MYSQL_V8042<br/>- MYSQL_V8043<br/>- MYSQL_V8044<br/>- MYSQL_V8045<br/>- MYSQL_V8405<br/>- MYSQL_V8406<br/>- MYSQL_V8407<br/>- MYSQL_V8408<br/>- MARIADB_V10330<br/>- MARIADB_V10611<br/>- MARIADB_V10612<br/>- MARIADB_V10616<br/>- MARIADB_V10622<br/>- MARIADB_V10625<br/>- MARIADB_V101107<br/>- MARIADB_V101108<br/>- MARIADB_V101113<br/>- MARIADB_V101116<br/>- MARIADB_V11407<br/>- MARIADB_V11410<br/>- MARIADB_V11806<br/>- POSTGRESQL_V14_6<br/>- POSTGRESQL_V14_15<br/>- POSTGRESQL_V14_17<br/>- POSTGRESQL_V14_19<br/>- POSTGRESQL_V17_2<br/>- POSTGRESQL_V17_4<br/>- POSTGRESQL_V17_6 |
-| availableDbVersions.dbMajorVersionCode | Body | Enum | DB 메이저 버전 코드<br/>- MYSQL_V56<br/>- MYSQL_V57<br/>- MYSQL_V80<br/>- MYSQL_V84<br/>- MARIADB_V103<br/>- MARIADB_V106<br/>- MARIADB_V1011<br/>- MARIADB_V114<br/>- MARIADB_V118<br/>- POSTGRES_V14<br/>- POSTGRES_V17 |
-| availableDbVersions.name | Body | String | DB 버전명 |
-| availableDbVersions.canCreate | Body | Boolean | 신규 생성 가능 여부 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1456,8 +1519,8 @@ GET /v1.0/db-instances/{dbInstanceId}/available-db-versions
     },
     "availableDbVersions": [
         {
-            "dbVersionCode": "MYSQL_V5633",
-            "dbMajorVersionCode": "MYSQL_V56",
+            "dbVersionCode": "dbVersionCode-example",
+            "dbMajorVersionCode": "dbMajorVersionCode-example",
             "name": "PostgreSQL V14.6",
             "canCreate": false
         }
@@ -1465,16 +1528,19 @@ GET /v1.0/db-instances/{dbInstanceId}/available-db-versions
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| availableDbVersions | Array | DB 버전 정보 |
+| availableDbVersions.dbVersionCode | String | DB 버전 코드 |
+| availableDbVersions.dbMajorVersionCode | String | DB 메이저 버전 코드 |
+| availableDbVersions.name | String | DB 버전명 |
+| availableDbVersions.canCreate | Boolean | 신규 생성 가능 여부 |
 
 ---
 
 ### DB 인스턴스 백업하기
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/backup
-```
 
 #### 필요 권한
 
@@ -1484,13 +1550,20 @@ POST /v1.0/db-instances/{dbInstanceId}/backup
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| backupName | Body | String | O | 백업을 식별할 수 있는 이름 |
+```http
+POST /v1.0/db-instances/{dbInstanceId}/backup
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1498,17 +1571,16 @@ POST /v1.0/db-instances/{dbInstanceId}/backup
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| backupName | String | Y | 백업을 식별할 수 있는 이름 |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1521,16 +1593,15 @@ POST /v1.0/db-instances/{dbInstanceId}/backup
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 인스턴스 백업 정보 조회
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}/backup-info
-```
 
 #### 필요 권한
 
@@ -1540,26 +1611,24 @@ GET /v1.0/db-instances/{dbInstanceId}/backup-info
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v1.0/db-instances/{dbInstanceId}/backup-info
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| allowAutoBackup | Body | Boolean | 자동 백업 허용 여부 |
-| usePeriodicAutoBackup | Body | Boolean | 예정된 자동 백업 사용 여부 |
-| backupPeriod | Body | Number | 백업 보관 기간(일) |
-| backupRetryCount | Body | Number | 백업 재시도 횟수 |
-| backupSchedules | Body | Array | 백업 스케쥴 목록 |
-| backupSchedules.backupWndBgnTime | Body | Time | 백업 시작 시각 |
-| backupSchedules.backupWndDuration | Body | Enum | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1581,16 +1650,21 @@ GET /v1.0/db-instances/{dbInstanceId}/backup-info
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| allowAutoBackup | Boolean | 자동 백업 허용 여부 |
+| usePeriodicAutoBackup | Boolean | 예정된 자동 백업 사용 여부 |
+| backupPeriod | Number | 백업 보관 기간(일) |
+| backupRetryCount | Number | 백업 재시도 횟수 |
+| backupSchedules | Array | 백업 스케쥴 목록 |
+| backupSchedules.backupWndBgnTime | Time | 백업 시작 시각 |
+| backupSchedules.backupWndDuration | Enum | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 
 ---
 
 ### DB 인스턴스 백업 정보 수정하기
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/backup-info
-```
 
 #### 필요 권한
 
@@ -1600,19 +1674,20 @@ PUT /v1.0/db-instances/{dbInstanceId}/backup-info
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| allowAutoBackup | Body | Boolean | X | 자동 백업 허용 여부 |
-| usePeriodicAutoBackup | Body | Boolean | X | 예정된 자동 백업 사용 여부 |
-| backupPeriod | Body | Number | X | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
-| backupRetryCount | Body | Number | X | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
-| backupSchedules | Body | Array | X | 백업 스케쥴 목록 |
-| backupSchedules.backupWndBgnTime | Body | Time | O | 백업 시작 시각 |
-| backupSchedules.backupWndDuration | Body | Enum | O | 백업 윈도우<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/backup-info
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1629,17 +1704,22 @@ PUT /v1.0/db-instances/{dbInstanceId}/backup-info
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| allowAutoBackup | Boolean | N | 자동 백업 허용 여부 |
+| usePeriodicAutoBackup | Boolean | N | 예정된 자동 백업 사용 여부 |
+| backupPeriod | Number | N | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
+| backupRetryCount | Number | N | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
+| backupSchedules | Array | N | 백업 스케쥴 목록 |
+| backupSchedules.backupWndBgnTime | Time | Y | 백업 시작 시각 |
+| backupSchedules.backupWndDuration | Enum | Y | 백업 윈도우<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1652,16 +1732,15 @@ PUT /v1.0/db-instances/{dbInstanceId}/backup-info
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 인스턴스 오브젝트 스토리지로 백업
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/backup-to-object-storage
-```
 
 #### 필요 권한
 
@@ -1671,17 +1750,20 @@ POST /v1.0/db-instances/{dbInstanceId}/backup-to-object-storage
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| tenantId | Body | String | O | 백업이 저장될 오브젝트 스토리지의 테넌트 ID<br/>- 최소 길이: `32`<br/>- 최대 길이: `32` |
-| username | Body | String | O | NHN Cloud 계정 혹은 IAM 회원 ID |
-| password | Body | String | O | 백업이 저장될 오브젝트 스토리지의 API 비밀번호 |
-| targetContainer | Body | String | O | 백업이 저장될 오브젝트 스토리지의 컨테이너 |
-| objectPath | Body | String | O | 컨테이너에 저장될 백업의 경로 |
+```http
+POST /v1.0/db-instances/{dbInstanceId}/backup-to-object-storage
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1693,17 +1775,20 @@ POST /v1.0/db-instances/{dbInstanceId}/backup-to-object-storage
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| tenantId | String | Y | 백업이 저장될 오브젝트 스토리지의 테넌트 ID<br/>- 최소 길이: `32`<br/>- 최대 길이: `32` |
+| username | String | Y | NHN Cloud 계정 혹은 IAM 회원 ID |
+| password | String | Y | 백업이 저장될 오브젝트 스토리지의 API 비밀번호 |
+| targetContainer | String | Y | 백업이 저장될 오브젝트 스토리지의 컨테이너 |
+| objectPath | String | Y | 컨테이너에 저장될 백업의 경로 |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1716,16 +1801,15 @@ POST /v1.0/db-instances/{dbInstanceId}/backup-to-object-storage
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### 데이터베이스 목록 보기
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}/databases
-```
 
 #### 필요 권한
 
@@ -1735,27 +1819,24 @@ GET /v1.0/db-instances/{dbInstanceId}/databases
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v1.0/db-instances/{dbInstanceId}/databases
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| databases | Body | Array | 데이터베이스 정보 |
-| databases.databaseId | Body | UUID | 데이터베이스의 식별자 |
-| databases.databaseName | Body | String | 데이터베이스 이름 |
-| databases.databaseStatus | Body | Enum | 데이터베이스의 현재 상태<br/>- STABLE: `사용 가능`<br/>- CREATING: `생성 중`<br/>- MODIFYING: `수정 중`<br/>- DELETING: `삭제 중`<br/>- DELETED: `삭제됨`<br/>- SYNCING: `동기화 중` |
-| databases.createdYmdt | Body | DateTime | 생성 일시 |
-| databases.updatedYmdt | Body | DateTime | 수정 일시 |
-| databases.schemas | Body | Array | 스키마 정보 |
-| databases.schemas.schemaName | Body | String | 스키마 이름 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1775,22 +1856,30 @@ GET /v1.0/db-instances/{dbInstanceId}/databases
                 {
                     "schemaName": "schemaName-example"
                 }
-            ]
+            ],
+            "errorReason": "errorReason-example"
         }
     ]
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| databases | Array | 데이터베이스 정보 |
+| databases.databaseId | UUID | 데이터베이스의 식별자 |
+| databases.databaseName | String | 데이터베이스 이름 |
+| databases.databaseStatus | Enum | 데이터베이스의 현재 상태<br/>- STABLE: `사용 가능`<br/>- CREATING: `생성 중`<br/>- MODIFYING: `수정 중`<br/>- DELETING: `삭제 중`<br/>- DELETED: `삭제됨`<br/>- SYNCING: `동기화 중`<br/>- DELETE_ERROR: `삭제 실패` |
+| databases.createdYmdt | DateTime | 생성 일시 |
+| databases.updatedYmdt | DateTime | 수정 일시 |
+| databases.schemas | Array | 스키마 정보 |
+| databases.schemas.schemaName | String | 스키마 이름 |
+| databases.errorReason | String | 삭제 실패 원인 |
 
 ---
 
 ### 데이터베이스 생성하기
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/databases
-```
 
 #### 필요 권한
 
@@ -1800,13 +1889,20 @@ POST /v1.0/db-instances/{dbInstanceId}/databases
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| databaseName | Body | String | O | 데이터베이스 이름 |
+```http
+POST /v1.0/db-instances/{dbInstanceId}/databases
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1814,17 +1910,16 @@ POST /v1.0/db-instances/{dbInstanceId}/databases
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| databaseName | String | Y | 데이터베이스 이름 |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1837,16 +1932,15 @@ POST /v1.0/db-instances/{dbInstanceId}/databases
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### 데이터베이스 삭제하기
-
-```http
-DELETE /v1.0/db-instances/{dbInstanceId}/databases/{databaseId}
-```
 
 #### 필요 권한
 
@@ -1856,21 +1950,25 @@ DELETE /v1.0/db-instances/{dbInstanceId}/databases/{databaseId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+DELETE /v1.0/db-instances/{dbInstanceId}/databases/{databaseId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| databaseId | URL | UUID | O | 데이터베이스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+| databaseId | URL | UUID | Y | 데이터베이스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1883,16 +1981,15 @@ DELETE /v1.0/db-instances/{dbInstanceId}/databases/{databaseId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### 데이터베이스 수정하기
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/databases/{databaseId}
-```
 
 #### 필요 권한
 
@@ -1902,15 +1999,21 @@ PUT /v1.0/db-instances/{dbInstanceId}/databases/{databaseId}
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| databaseId | URL | UUID | O | 데이터베이스의 식별자 |
-| applyHbaRulesImmediately | Body | Boolean | X | 연관된 접근 제어 규칙 즉시 적용 여부<br/>- 기본값: `false` |
-| databaseName | Body | String | O | 데이터베이스 이름 |
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/databases/{databaseId}
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+| databaseId | URL | UUID | Y | 데이터베이스의 식별자 |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1919,17 +2022,17 @@ PUT /v1.0/db-instances/{dbInstanceId}/databases/{databaseId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| applyHbaRulesImmediately | Boolean | N | 연관된 접근 제어 규칙 즉시 적용 여부<br/>- 기본값: `false` |
+| databaseName | String | Y | 데이터베이스 이름 |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1942,16 +2045,15 @@ PUT /v1.0/db-instances/{dbInstanceId}/databases/{databaseId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### 사용자 목록 보기
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}/db-users
-```
 
 #### 필요 권한
 
@@ -1961,26 +2063,24 @@ GET /v1.0/db-instances/{dbInstanceId}/db-users
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v1.0/db-instances/{dbInstanceId}/db-users
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| dbUsers | Body | Array | DB 사용자 목록 |
-| dbUsers.dbUserId | Body | UUID | DB 사용자의 식별자 |
-| dbUsers.dbUserName | Body | String | DB 사용자 계정 이름 |
-| dbUsers.authorityType | Body | Enum | DB 사용자 권한 타입<br/>- CUSTOM: `커스텀 권한 권한`<br/>- READ: `READ 권한 (읽기 전용 권한)`<br/>- CRUD: `CRUD 권한 (읽기 권한 포함)`<br/>- DDL: `DDL 권한 (CRUD 권한 포함)` |
-| dbUsers.dbUserStatus | Body | Enum | DB 사용자의 현재 상태<br/>- STABLE: `사용 가능`<br/>- CREATING: `생성 중`<br/>- MODIFYING: `수정 중`<br/>- DELETING: `삭제 중`<br/>- DELETED: `삭제됨`<br/>- SYNCING: `동기화 중` |
-| dbUsers.createdYmdt | Body | DateTime | 생성 일시 |
-| dbUsers.updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2002,16 +2102,21 @@ GET /v1.0/db-instances/{dbInstanceId}/db-users
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbUsers | Array | DB 사용자 목록 |
+| dbUsers.dbUserId | UUID | DB 사용자의 식별자 |
+| dbUsers.dbUserName | String | DB 사용자 계정 이름 |
+| dbUsers.authorityType | Enum | DB 사용자 권한 타입<br/>- CUSTOM: `커스텀 권한 권한`<br/>- READ: `READ 권한 (읽기 전용 권한)`<br/>- CRUD: `CRUD 권한 (읽기 권한 포함)`<br/>- DDL: `DDL 권한 (CRUD 권한 포함)` |
+| dbUsers.dbUserStatus | Enum | DB 사용자의 현재 상태<br/>- STABLE: `사용 가능`<br/>- CREATING: `생성 중`<br/>- MODIFYING: `수정 중`<br/>- DELETING: `삭제 중`<br/>- DELETED: `삭제됨`<br/>- SYNCING: `동기화 중`<br/>- DELETE_ERROR: `삭제 실패` |
+| dbUsers.createdYmdt | DateTime | 생성 일시 |
+| dbUsers.updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
 ### 사용자 생성하기
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/db-users
-```
 
 #### 필요 권한
 
@@ -2021,17 +2126,20 @@ POST /v1.0/db-instances/{dbInstanceId}/db-users
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| dbUserName | Body | String | O | DB 사용자 계정 이름 |
-| dbPassword | Body | String | O | DB 사용자 계정 암호 |
-| authorityType | Body | Enum | O | DB 사용자 권한 타입<br/>- CUSTOM: `사용자 정의 권한`<br/>- READ: `읽기 권한`<br/>- CRUD: `CRUD 권한`<br/>- DDL: `DDL 권한` |
-| createDefaultHbaRules | Body | Boolean | X | 기본 접근 제어 규칙 생성 여부<br/>- 기본값: `false` |
-| address | Body | String | X | 접속 주소 |
+```http
+POST /v1.0/db-instances/{dbInstanceId}/db-users
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2043,17 +2151,20 @@ POST /v1.0/db-instances/{dbInstanceId}/db-users
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbUserName | String | Y | DB 사용자 계정 이름 |
+| dbPassword | String | Y | DB 사용자 계정 암호 |
+| authorityType | Enum | Y | DB 사용자 권한 타입<br/>- CUSTOM: `사용자 정의 권한`<br/>- READ: `읽기 권한`<br/>- CRUD: `CRUD 권한`<br/>- DDL: `DDL 권한` |
+| createDefaultHbaRules | Boolean | N | 기본 접근 제어 규칙 생성 여부<br/>- 기본값: `false` |
+| address | String | N | 접속 주소 |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2066,16 +2177,15 @@ POST /v1.0/db-instances/{dbInstanceId}/db-users
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### 사용자 삭제하기
-
-```http
-DELETE /v1.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
-```
 
 #### 필요 권한
 
@@ -2085,21 +2195,25 @@ DELETE /v1.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+DELETE /v1.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| dbUserId | URL | UUID | O | 사용자의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+| dbUserId | URL | UUID | Y | 사용자의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2112,16 +2226,15 @@ DELETE /v1.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### 사용자 수정하기
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
-```
 
 #### 필요 권한
 
@@ -2131,17 +2244,21 @@ PUT /v1.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| dbUserId | URL | UUID | O | 사용자의 식별자 |
-| dbUserName | Body | String | X | DB 사용자 계정 이름 |
-| dbPassword | Body | String | X | DB 사용자 계정 암호 |
-| authorityType | Body | Enum | X | DB 사용자 권한<br/>- CUSTOM: `사용자 정의 권한`<br/>- READ: `읽기 권한`<br/>- CRUD: `CRUD 권한`<br/>- DDL: `DDL 권한` |
-| applyHbaRulesImmediately | Body | Boolean | X | 접근 제어 변경 사항 즉시 적용 여부<br/>- 기본값: `false` |
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+| dbUserId | URL | UUID | Y | 사용자의 식별자 |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2152,17 +2269,19 @@ PUT /v1.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbUserName | String | N | DB 사용자 계정 이름 |
+| dbPassword | String | N | DB 사용자 계정 암호 |
+| authorityType | Enum | N | DB 사용자 권한<br/>- CUSTOM: `사용자 정의 권한`<br/>- READ: `읽기 권한`<br/>- CRUD: `CRUD 권한`<br/>- DDL: `DDL 권한` |
+| applyHbaRulesImmediately | Boolean | N | 접근 제어 변경 사항 즉시 적용 여부<br/>- 기본값: `false` |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2175,16 +2294,15 @@ PUT /v1.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 인스턴스 삭제 보호 설정 변경하기
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/deletion-protection
-```
 
 #### 필요 권한
 
@@ -2194,13 +2312,20 @@ PUT /v1.0/db-instances/{dbInstanceId}/deletion-protection
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| useDeletionProtection | Body | Boolean | O | 삭제 보호 여부 |
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/deletion-protection
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2208,8 +2333,11 @@ PUT /v1.0/db-instances/{dbInstanceId}/deletion-protection
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| useDeletionProtection | Boolean | Y | 삭제 보호 여부 |
 
 #### 응답
 
@@ -2219,10 +2347,6 @@ PUT /v1.0/db-instances/{dbInstanceId}/deletion-protection
 
 ### DB 인스턴스 강제 재시작하기
 
-```http
-POST /v1.0/db-instances/{dbInstanceId}/force-restart
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -2231,11 +2355,19 @@ POST /v1.0/db-instances/{dbInstanceId}/force-restart
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+POST /v1.0/db-instances/{dbInstanceId}/force-restart
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
@@ -2245,10 +2377,6 @@ POST /v1.0/db-instances/{dbInstanceId}/force-restart
 
 ### 접근 제어 규칙 목록 보기
 
-```http
-GET /v1.0/db-instances/{dbInstanceId}/hba-rules
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -2257,36 +2385,24 @@ GET /v1.0/db-instances/{dbInstanceId}/hba-rules
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v1.0/db-instances/{dbInstanceId}/hba-rules
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| hbaRules | Body | Array | 접근 제어 규칙 정보 |
-| hbaRules.hbaRuleId | Body | UUID | 접근 제어 규칙의 식별자 |
-| hbaRules.hbaRuleStatus | Body | Enum | 접근 제어 규칙의 현재 상태<br/>- CREATED: `생성됨`<br/>- APPLIED: `적용됨`<br/>- CREATING: `생성 중`<br/>- MODIFYING: `수정 중`<br/>- DELETING: `삭제 중`<br/>- DELETED: `삭제됨` |
-| hbaRules.databaseApplyType | Body | Enum | DB 데이터베이스 적용 타입<br/>- ENTIRE: `전체`<br/>- USER_CUSTOM: `사용자 지정` |
-| hbaRules.dbUserApplyTypeCode | Body | Enum | DB 사용자 적용 타입<br/>- ENTIRE: `전체`<br/>- USER_CUSTOM: `사용자 지정` |
-| hbaRules.databases | Body | Array | 사용자 지정 데이터베이스 리스트 |
-| hbaRules.databases.databaseId | Body | UUID | 데이터베이스 ID |
-| hbaRules.databases.databaseName | Body | String | 데이터베이스 이름 |
-| hbaRules.dbUsers | Body | Array | 사용자 지정 DB 사용자 리스트 |
-| hbaRules.dbUsers.dbUserId | Body | UUID | DB 사용자 ID |
-| hbaRules.dbUsers.dbUserName | Body | String | DB 사용자 이름 |
-| hbaRules.address | Body | String | 접속 주소 |
-| hbaRules.authMethod | Body | Enum | 인증 방식<br/>- TRUST: `트러스트 (패스워드 불필요)`<br/>- REJECT: `접속 차단`<br/>- SCRAM_SHA_256: `패스워드 (SCRAM-SHA-256)` |
-| hbaRules.reservedAction | Body | Enum | 예약된 작업 내용<br/>- NONE: `없음`<br/>- CREATE: `생성 예약 (적용 필요)`<br/>- MODIFY: `수정 예약 (적용 필요)`<br/>- DELETE: `삭제 예약 (적용 필요)` |
-| hbaRules.order | Body | Number | 규칙 적용 순서 |
-| hbaRules.applicable | Body | Boolean | 적용 가능 여부 |
-| needToApply | Body | Boolean | 변경사항 적용 필요 여부 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2324,16 +2440,31 @@ GET /v1.0/db-instances/{dbInstanceId}/hba-rules
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| hbaRules | Array | 접근 제어 규칙 정보 |
+| hbaRules.hbaRuleId | UUID | 접근 제어 규칙의 식별자 |
+| hbaRules.hbaRuleStatus | Enum | 접근 제어 규칙의 현재 상태<br/>- CREATED: `생성됨`<br/>- APPLIED: `적용됨`<br/>- CREATING: `생성 중`<br/>- MODIFYING: `수정 중`<br/>- DELETING: `삭제 중`<br/>- DELETED: `삭제됨` |
+| hbaRules.databaseApplyType | Enum | DB 데이터베이스 적용 타입<br/>- ENTIRE: `전체`<br/>- USER_CUSTOM: `사용자 지정` |
+| hbaRules.dbUserApplyTypeCode | Enum | DB 사용자 적용 타입<br/>- ENTIRE: `전체`<br/>- USER_CUSTOM: `사용자 지정` |
+| hbaRules.databases | Array | 사용자 지정 데이터베이스 리스트 |
+| hbaRules.databases.databaseId | UUID | 데이터베이스 ID |
+| hbaRules.databases.databaseName | String | 데이터베이스 이름 |
+| hbaRules.dbUsers | Array | 사용자 지정 DB 사용자 리스트 |
+| hbaRules.dbUsers.dbUserId | UUID | DB 사용자 ID |
+| hbaRules.dbUsers.dbUserName | String | DB 사용자 이름 |
+| hbaRules.address | String | 접속 주소 |
+| hbaRules.authMethod | Enum | 인증 방식<br/>- TRUST: `트러스트 (패스워드 불필요)`<br/>- REJECT: `접속 차단`<br/>- SCRAM_SHA_256: `패스워드 (SCRAM-SHA-256)` |
+| hbaRules.reservedAction | Enum | 예약된 작업 내용<br/>- NONE: `없음`<br/>- CREATE: `생성 예약 (적용 필요)`<br/>- MODIFY: `수정 예약 (적용 필요)`<br/>- DELETE: `삭제 예약 (적용 필요)` |
+| hbaRules.order | Number | 규칙 적용 순서 |
+| hbaRules.applicable | Boolean | 적용 가능 여부 |
+| needToApply | Boolean | 변경사항 적용 필요 여부 |
 
 ---
 
 ### DB 인스턴스 접근제어 규칙 추가
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/hba-rules
-```
 
 #### 필요 권한
 
@@ -2343,19 +2474,20 @@ POST /v1.0/db-instances/{dbInstanceId}/hba-rules
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| connectionTypeCode | Body | Enum | X | 접근 제어 레코드 타입<br/>- HOST: `TCP/IP로 접속 시 유효`<br/>- HOST_NO_SSL: `SSL 암호화를 사용하지 않는 접속 시에만 유효` |
-| databaseApplyType | Body | Enum | O | Database 적용 타입<br/>- ENTIRE: `전체`<br/>- USER_CUSTOM: `사용자 지정` |
-| dbUserApplyType | Body | Enum | O | DB 사용자 적용 타입<br/>- ENTIRE: `전체`<br/>- USER_CUSTOM: `사용자 지정` |
-| databaseIds | Body | Array | X | 데이터베이스의 식별자 목록 |
-| dbUserIds | Body | Array | X | DB 사용자의 식별자 목록 |
-| address | Body | String | O | 접속 주소 |
-| authMethod | Body | Enum | O | 인증 방식<br/>- TRUST: `트러스트 (패스워드 불필요)`<br/>- REJECT: `접속 차단`<br/>- SCRAM_SHA_256: `패스워드 (SCRAM-SHA-256)` |
+```http
+POST /v1.0/db-instances/{dbInstanceId}/hba-rules
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2369,17 +2501,22 @@ POST /v1.0/db-instances/{dbInstanceId}/hba-rules
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| connectionTypeCode | Enum | N | 접근 제어 레코드 타입<br/>- HOST: `TCP/IP로 접속 시 유효`<br/>- HOST_NO_SSL: `SSL 암호화를 사용하지 않는 접속 시에만 유효` |
+| databaseApplyType | Enum | Y | Database 적용 타입<br/>- ENTIRE: `전체`<br/>- USER_CUSTOM: `사용자 지정` |
+| dbUserApplyType | Enum | Y | DB 사용자 적용 타입<br/>- ENTIRE: `전체`<br/>- USER_CUSTOM: `사용자 지정` |
+| databaseIds | Array | N | 데이터베이스의 식별자 목록 |
+| dbUserIds | Array | N | DB 사용자의 식별자 목록 |
+| address | String | Y | 접속 주소 |
+| authMethod | Enum | Y | 인증 방식<br/>- TRUST: `트러스트 (패스워드 불필요)`<br/>- REJECT: `접속 차단`<br/>- SCRAM_SHA_256: `패스워드 (SCRAM-SHA-256)` |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| hbaRuleId | Body | UUID | 접근 제어 규칙 ID |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2392,16 +2529,15 @@ POST /v1.0/db-instances/{dbInstanceId}/hba-rules
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| hbaRuleId | UUID | 접근 제어 규칙 ID |
 
 ---
 
 ### DB 인스턴스 접근제어 규칙 적용
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/hba-rules/apply
-```
 
 #### 필요 권한
 
@@ -2411,20 +2547,24 @@ POST /v1.0/db-instances/{dbInstanceId}/hba-rules/apply
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+POST /v1.0/db-instances/{dbInstanceId}/hba-rules/apply
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2437,16 +2577,15 @@ POST /v1.0/db-instances/{dbInstanceId}/hba-rules/apply
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 인스턴스 접근제어 규칙 순서 조정
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/hba-rules/orders
-```
 
 #### 필요 권한
 
@@ -2456,13 +2595,20 @@ PUT /v1.0/db-instances/{dbInstanceId}/hba-rules/orders
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| hbaRuleIds | Body | Array | O | 정렬된 접속제어 규칙 ID 리스트 (요청받은 순서대로 저장) |
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/hba-rules/orders
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2470,8 +2616,11 @@ PUT /v1.0/db-instances/{dbInstanceId}/hba-rules/orders
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| hbaRuleIds | Array | Y | 정렬된 접속제어 규칙 ID 리스트 (요청받은 순서대로 저장) |
 
 #### 응답
 
@@ -2481,10 +2630,6 @@ PUT /v1.0/db-instances/{dbInstanceId}/hba-rules/orders
 
 ### DB 인스턴스 접근제어 설정 삭제
 
-```http
-DELETE /v1.0/db-instances/{dbInstanceId}/hba-rules/{hbaRuleId}
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -2493,12 +2638,20 @@ DELETE /v1.0/db-instances/{dbInstanceId}/hba-rules/{hbaRuleId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+DELETE /v1.0/db-instances/{dbInstanceId}/hba-rules/{hbaRuleId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| hbaRuleId | URL | UUID | O | 접근제어 규칙의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+| hbaRuleId | URL | UUID | Y | 접근제어 규칙의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
@@ -2508,10 +2661,6 @@ DELETE /v1.0/db-instances/{dbInstanceId}/hba-rules/{hbaRuleId}
 
 ### DB 인스턴스 접근제어 규칙 수정
 
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/hba-rules/{hbaRuleId}
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -2520,20 +2669,21 @@ PUT /v1.0/db-instances/{dbInstanceId}/hba-rules/{hbaRuleId}
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| hbaRuleId | URL | UUID | O | 접근제어 규칙의 식별자 |
-| connectionTypeCode | Body | Enum | X | 접근 제어 레코드 타입<br/>- HOST: `TCP/IP로 접속 시 유효`<br/>- HOST_NO_SSL: `SSL 암호화를 사용하지 않는 접속 시에만 유효` |
-| databaseApplyType | Body | Enum | O | Database 적용 타입<br/>- ENTIRE: `전체`<br/>- USER_CUSTOM: `사용자 지정` |
-| dbUserApplyType | Body | Enum | O | DB 사용자 적용 타입<br/>- ENTIRE: `전체`<br/>- USER_CUSTOM: `사용자 지정` |
-| databaseIds | Body | Array | X | 데이터베이스의 식별자 목록 |
-| dbUserIds | Body | Array | X | DB 사용자의 식별자 목록 |
-| address | Body | String | O | 접속 주소 |
-| authMethod | Body | Enum | O | 인증 방식<br/>- TRUST: `트러스트 (패스워드 불필요)`<br/>- REJECT: `접속 차단`<br/>- SCRAM_SHA_256: `패스워드 (SCRAM-SHA-256)` |
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/hba-rules/{hbaRuleId}
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+| hbaRuleId | URL | UUID | Y | 접근제어 규칙의 식별자 |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2547,8 +2697,17 @@ PUT /v1.0/db-instances/{dbInstanceId}/hba-rules/{hbaRuleId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| connectionTypeCode | Enum | N | 접근 제어 레코드 타입<br/>- HOST: `TCP/IP로 접속 시 유효`<br/>- HOST_NO_SSL: `SSL 암호화를 사용하지 않는 접속 시에만 유효` |
+| databaseApplyType | Enum | Y | Database 적용 타입<br/>- ENTIRE: `전체`<br/>- USER_CUSTOM: `사용자 지정` |
+| dbUserApplyType | Enum | Y | DB 사용자 적용 타입<br/>- ENTIRE: `전체`<br/>- USER_CUSTOM: `사용자 지정` |
+| databaseIds | Array | N | 데이터베이스의 식별자 목록 |
+| dbUserIds | Array | N | DB 사용자의 식별자 목록 |
+| address | String | Y | 접속 주소 |
+| authMethod | Enum | Y | 인증 방식<br/>- TRUST: `트러스트 (패스워드 불필요)`<br/>- REJECT: `접속 차단`<br/>- SCRAM_SHA_256: `패스워드 (SCRAM-SHA-256)` |
 
 #### 응답
 
@@ -2558,10 +2717,6 @@ PUT /v1.0/db-instances/{dbInstanceId}/hba-rules/{hbaRuleId}
 
 ### 고가용성 정보 조회
 
-```http
-GET /v1.0/db-instances/{dbInstanceId}/high-availability
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -2570,22 +2725,24 @@ GET /v1.0/db-instances/{dbInstanceId}/high-availability
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v1.0/db-instances/{dbInstanceId}/high-availability
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| haStatus | Body | Enum | 고가용성 상태<br/>- CREATED: `생성됨`<br/>- STABLE: `정상`<br/>- PAUSING: `일시 중지 중`<br/>- DISABLE: `정지`<br/>- DISABLE_MASTER_IN_REPLICATION: `마스터 비정상 복제 감지로 인한 고가용성 중단`<br/>- DISABLE_MHA_PROCESS: `고가용성 프로세스 중단`<br/>- DISABLE_REPLICATION_STOP: `복제 중단으로 인한 고가용성 중단`<br/>- DISABLE_REPLICATION_DELAY: `복제 지연으로 인한 고가용성 중단`<br/>- FAILOVER_STARTED: `장애 조치 시작`<br/>- FAILOVER_FAILED: `장애 조치 실패`<br/>- FAILOVER_COMPLETED: `장애 조치 완료`<br/>- DELETED: `삭제됨`<br/>- PAUSED: `일시 중지`<br/>- PAUSED_DUE_TO_TASK: `작업으로 인한 일시 중지`<br/>- MASTER_FAILURE_DETECTION: `마스터 장애 감지` |
-| pingInterval | Body | Number | Ping 간격(초) |
-| failoverReplWaitingTime | Body | Number | 장애조치 복제 지연 대기 시간(초) |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2600,16 +2757,17 @@ GET /v1.0/db-instances/{dbInstanceId}/high-availability
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| haStatus | Enum | 고가용성 상태<br/>- CREATED: `생성됨`<br/>- STABLE: `정상`<br/>- PAUSING: `일시 중지 중`<br/>- DISABLE: `정지`<br/>- DISABLE_MASTER_IN_REPLICATION: `마스터 비정상 복제 감지로 인한 고가용성 중단`<br/>- DISABLE_MHA_PROCESS: `고가용성 프로세스 중단`<br/>- DISABLE_REPLICATION_STOP: `복제 중단으로 인한 고가용성 중단`<br/>- DISABLE_REPLICATION_DELAY: `복제 지연으로 인한 고가용성 중단`<br/>- FAILOVER_STARTED: `장애 조치 시작`<br/>- FAILOVER_FAILED: `장애 조치 실패`<br/>- FAILOVER_COMPLETED: `장애 조치 완료`<br/>- DELETED: `삭제됨`<br/>- PAUSED: `일시 중지`<br/>- PAUSED_DUE_TO_TASK: `작업으로 인한 일시 중지`<br/>- MASTER_FAILURE_DETECTION: `마스터 장애 감지` |
+| pingInterval | Number | Ping 간격(초) |
+| failoverReplWaitingTime | Number | 장애조치 복제 지연 대기 시간(초) |
 
 ---
 
 ### 고가용성 수정하기
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/high-availability
-```
 
 #### 필요 권한
 
@@ -2619,15 +2777,20 @@ PUT /v1.0/db-instances/{dbInstanceId}/high-availability
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| useHighAvailability | Body | Boolean | O | 고가용성 사용 여부 |
-| pingInterval | Body | Number | X | Ping 간격(초)<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
-| failoverReplWaitingTime | Body | Number | X | 장애조치 복제 지연 대기 시간(초)<br/>- 최솟값: `-1` |
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/high-availability
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2637,17 +2800,18 @@ PUT /v1.0/db-instances/{dbInstanceId}/high-availability
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| useHighAvailability | Boolean | Y | 고가용성 사용 여부 |
+| pingInterval | Number | N | Ping 간격(초)<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
+| failoverReplWaitingTime | Number | N | 장애조치 복제 지연 대기 시간(초)<br/>- 최솟값: `-1` |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2660,16 +2824,15 @@ PUT /v1.0/db-instances/{dbInstanceId}/high-availability
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### 고가용성 일시 중지하기
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/high-availability/pause
-```
 
 #### 필요 권한
 
@@ -2679,20 +2842,24 @@ POST /v1.0/db-instances/{dbInstanceId}/high-availability/pause
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+POST /v1.0/db-instances/{dbInstanceId}/high-availability/pause
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2705,16 +2872,15 @@ POST /v1.0/db-instances/{dbInstanceId}/high-availability/pause
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### 고가용성 복구하기
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/high-availability/repair
-```
 
 #### 필요 권한
 
@@ -2724,20 +2890,24 @@ POST /v1.0/db-instances/{dbInstanceId}/high-availability/repair
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+POST /v1.0/db-instances/{dbInstanceId}/high-availability/repair
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2750,16 +2920,15 @@ POST /v1.0/db-instances/{dbInstanceId}/high-availability/repair
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### 고가용성 다시 시작하기
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/high-availability/resume
-```
 
 #### 필요 권한
 
@@ -2769,20 +2938,24 @@ POST /v1.0/db-instances/{dbInstanceId}/high-availability/resume
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+POST /v1.0/db-instances/{dbInstanceId}/high-availability/resume
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2795,16 +2968,15 @@ POST /v1.0/db-instances/{dbInstanceId}/high-availability/resume
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### 고가용성 분리하기
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/high-availability/split
-```
 
 #### 필요 권한
 
@@ -2814,20 +2986,24 @@ POST /v1.0/db-instances/{dbInstanceId}/high-availability/split
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+POST /v1.0/db-instances/{dbInstanceId}/high-availability/split
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2840,16 +3016,15 @@ POST /v1.0/db-instances/{dbInstanceId}/high-availability/split
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 인스턴스 유지보수 정보 조회
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}/maintenance-info
-```
 
 #### 필요 권한
 
@@ -2859,24 +3034,24 @@ GET /v1.0/db-instances/{dbInstanceId}/maintenance-info
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v1.0/db-instances/{dbInstanceId}/maintenance-info
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| allowAutoMaintenance | Body | Boolean | 자동 유지보수 허용 여부 |
-| useAutoStorageCleanup | Body | Boolean | 자동 스토리지 정리 사용 여부 |
-| maintWndBgnTime | Body | Time | 자동 유지보수 시작 시간 |
-| maintWndDuration | Body | Enum | 유지보수 윈도우<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
-| logRetentionPeriod | Body | Number | 로그 보관 기간 (일) |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2893,16 +3068,19 @@ GET /v1.0/db-instances/{dbInstanceId}/maintenance-info
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| allowAutoMaintenance | Boolean | 자동 유지보수 허용 여부 |
+| useAutoStorageCleanup | Boolean | 자동 스토리지 정리 사용 여부 |
+| maintWndBgnTime | Time | 자동 유지보수 시작 시간 |
+| maintWndDuration | Enum | 유지보수 윈도우<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
+| logRetentionPeriod | Number | 로그 보관 기간 (일) |
 
 ---
 
 ### DB 인스턴스 유지보수 정보 수정
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/maintenance-info
-```
 
 #### 필요 권한
 
@@ -2912,17 +3090,20 @@ PUT /v1.0/db-instances/{dbInstanceId}/maintenance-info
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| allowAutoMaintenance | Body | Boolean | X | 자동 유지보수 허용 여부 |
-| useAutoStorageCleanup | Body | Boolean | X | 자동 스토리지 정리 사용 여부 |
-| maintWndBgnTime | Body | Time | X | 자동 유지보수 시작 시간 |
-| maintWndDuration | Body | Enum | X | 유지보수 윈도우<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
-| logRetentionPeriod | Body | Number | X | 로그 보관 기간 (일)<br/>- 최솟값: `1`<br/>- 최댓값: `30` |
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/maintenance-info
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2934,17 +3115,20 @@ PUT /v1.0/db-instances/{dbInstanceId}/maintenance-info
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| allowAutoMaintenance | Boolean | N | 자동 유지보수 허용 여부 |
+| useAutoStorageCleanup | Boolean | N | 자동 스토리지 정리 사용 여부 |
+| maintWndBgnTime | Time | N | 자동 유지보수 시작 시간 |
+| maintWndDuration | Enum | N | 유지보수 윈도우<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
+| logRetentionPeriod | Number | N | 로그 보관 기간 (일)<br/>- 최솟값: `1`<br/>- 최댓값: `30` |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2957,16 +3141,15 @@ PUT /v1.0/db-instances/{dbInstanceId}/maintenance-info
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 인스턴스 네트워크 정보 조회
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}/network-info
-```
 
 #### 필요 권한
 
@@ -2976,29 +3159,24 @@ GET /v1.0/db-instances/{dbInstanceId}/network-info
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v1.0/db-instances/{dbInstanceId}/network-info
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| availabilityZone | Body | Enum | DB 인스턴스를 생성할 가용성 영역 |
-| subnet | Body | Object | 서브넷 정보 |
-| subnet.subnetId | Body | UUID | 서브넷의 식별자 |
-| subnet.subnetName | Body | String | 서브넷을 식별할 수 있는 이름 |
-| subnet.subnetCidr | Body | String | 서브넷의 CIDR |
-| subnet.publicAccessible | Body | Boolean | 퍼블릭 접근 가능 여부 |
-| endPoints | Body | Array | 접속 정보 |
-| endPoints.domain | Body | String | 도메인 |
-| endPoints.ipAddress | Body | String | IP 주소 |
-| endPoints.endPointType | Body | String | 접속 정보 타입 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3024,16 +3202,24 @@ GET /v1.0/db-instances/{dbInstanceId}/network-info
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| availabilityZone | Enum | DB 인스턴스를 생성할 가용성 영역 |
+| subnet | Object | 서브넷 정보 |
+| subnet.subnetId | UUID | 서브넷의 식별자 |
+| subnet.subnetName | String | 서브넷을 식별할 수 있는 이름 |
+| subnet.subnetCidr | String | 서브넷의 CIDR |
+| subnet.publicAccessible | Boolean | 퍼블릭 접근 가능 여부 |
+| endPoints | Array | 접속 정보 |
+| endPoints.domain | String | 도메인 |
+| endPoints.ipAddress | String | IP 주소 |
+| endPoints.endPointType | String | 접속 정보 타입 |
 
 ---
 
 ### DB 인스턴스 네트워크 정보 수정하기
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/network-info
-```
 
 #### 필요 권한
 
@@ -3043,13 +3229,20 @@ PUT /v1.0/db-instances/{dbInstanceId}/network-info
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| usePublicAccess | Body | Boolean | O | 외부 접속 가능 여부 |
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/network-info
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3057,17 +3250,16 @@ PUT /v1.0/db-instances/{dbInstanceId}/network-info
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| usePublicAccess | Boolean | Y | 외부 접속 가능 여부 |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3080,16 +3272,15 @@ PUT /v1.0/db-instances/{dbInstanceId}/network-info
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 인스턴스 승격하기
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/promote
-```
 
 #### 필요 권한
 
@@ -3099,20 +3290,24 @@ POST /v1.0/db-instances/{dbInstanceId}/promote
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+POST /v1.0/db-instances/{dbInstanceId}/promote
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3125,16 +3320,15 @@ POST /v1.0/db-instances/{dbInstanceId}/promote
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### 읽기 복제본 생성
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/replicate
-```
 
 #### 필요 권한
 
@@ -3144,27 +3338,20 @@ POST /v1.0/db-instances/{dbInstanceId}/replicate
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| dbInstanceName | Body | String | O | DB 인스턴스를 식별할 수 있는 이름 |
-| description | Body | String | X | DB 인스턴스에 대한 추가 정보 |
-| dbFlavorId | Body | UUID | X | DB 인스턴스 사양의 식별자 |
-| dbPort | Body | Number | X | DB 포트<br/>- 최솟값: 5432, 최댓값: 45432 |
-| parameterGroupId | Body | UUID | X | 파라미터 그룹의 식별자 |
-| dbSecurityGroupIds | Body | Array | X | DB 보안 그룹의 식별자 목록 |
-| userGroupIds | Body | Array | X | 사용자 그룹의 식별자 목록 |
-| useDefaultNotification | Body | Boolean | X | 기본 알림 사용 여부<br/>- 기본값: `false` |
-| useDeletionProtection | Body | Boolean | X | 삭제 보호 여부<br/>- 기본값: `false` |
-| network | Body | Object | X | 네트워크 정보 객체 |
-| network.usePublicAccess | Body | Boolean | X | 외부 접속 가능 여부<br/>- 기본값: `false` |
-| network.availabilityZone | Body | Enum | X | DB 인스턴스를 생성할 가용성 영역 |
-| storage | Body | Object | X | 스토리지 정보 객체 |
-| storage.storageType | Body | Enum | X | 데이터 스토리지 타입 |
-| storage.storageSize | Body | Number | X | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20`<br/>- 최댓값: `2048` |
+```http
+POST /v1.0/db-instances/{dbInstanceId}/replicate
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3188,17 +3375,30 @@ POST /v1.0/db-instances/{dbInstanceId}/replicate
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | DB 인스턴스를 식별할 수 있는 이름 |
+| description | String | N | DB 인스턴스에 대한 추가 정보 |
+| dbFlavorId | UUID | N | DB 인스턴스 사양의 식별자 |
+| dbPort | Number | N | DB 포트<br/>- 최솟값: 5432, 최댓값: 45432 |
+| parameterGroupId | UUID | N | 파라미터 그룹의 식별자 |
+| dbSecurityGroupIds | Array | N | DB 보안 그룹의 식별자 목록 |
+| userGroupIds | Array | N | 사용자 그룹의 식별자 목록 |
+| useDefaultNotification | Boolean | N | 기본 알림 사용 여부<br/>- 기본값: `false` |
+| useDeletionProtection | Boolean | N | 삭제 보호 여부<br/>- 기본값: `false` |
+| network | Object | N | 네트워크 정보 객체 |
+| network.usePublicAccess | Boolean | N | 외부 접속 가능 여부<br/>- 기본값: `false` |
+| network.availabilityZone | Enum | N | DB 인스턴스를 생성할 가용성 영역 |
+| storage | Object | N | 스토리지 정보 객체 |
+| storage.storageType | Enum | N | 데이터 스토리지 타입 |
+| storage.storageSize | Number | N | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20`<br/>- 최댓값: `2048` |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3211,16 +3411,15 @@ POST /v1.0/db-instances/{dbInstanceId}/replicate
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 인스턴스 재시작하기
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/restart
-```
 
 #### 필요 권한
 
@@ -3230,20 +3429,24 @@ POST /v1.0/db-instances/{dbInstanceId}/restart
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+POST /v1.0/db-instances/{dbInstanceId}/restart
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3256,16 +3459,15 @@ POST /v1.0/db-instances/{dbInstanceId}/restart
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 인스턴스 복원 정보 조회
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}/restoration-info
-```
 
 #### 필요 권한
 
@@ -3275,36 +3477,24 @@ GET /v1.0/db-instances/{dbInstanceId}/restoration-info
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v1.0/db-instances/{dbInstanceId}/restoration-info
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| oldestRestorableYmdt | Body | DateTime | 가장 오래된 복원 가능한 시각 |
-| latestRestorableYmdt | Body | DateTime | 가장 최신의 복원 가능한 시각 |
-| restorableBackups | Body | Array | 복원 가능한 백업 목록 |
-| restorableBackups.backupId | Body | UUID | 백업의 식별자 |
-| restorableBackups.backupName | Body | String | 백업 이름 |
-| restorableBackups.backupStatus | Body | Enum | 백업 상태<br/>- BACKING_UP: `백업 중 (스피너)`<br/>- VERIFYING: `검증 중 (스피너)`<br/>- COMPLETED: `사용 가능 (녹색 아이콘)`<br/>- DELETING: `삭제 중 (스피너)`<br/>- DELETED: `삭제 됨 (회색 아이콘)`<br/>- ERROR: `에러 (적색 아이콘)` |
-| restorableBackups.dbInstanceId | Body | UUID | 원본 DB 인스턴스의 식별자 |
-| restorableBackups.dbInstanceName | Body | String | 원본 DB 인스턴스의 이름 |
-| restorableBackups.dbVersion | Body | Enum | DB 엔진 유형 |
-| restorableBackups.backupType | Body | Enum | 백업 유형<br/>- AUTO<br/>- MANUAL |
-| restorableBackups.backupSize | Body | Number | 백업 크기 |
-| restorableBackups.failoverCount | Body | Number | 장애 조치 횟수 |
-| restorableBackups.walFileName | Body | String | WAL 로그 파일 이름 |
-| restorableBackups.createdYmdt | Body | DateTime | 백업 생성 일시 |
-| restorableBackups.updatedYmdt | Body | DateTime | 백업 갱신 일시 |
-| restorableBackups.startYmdt | Body | DateTime | 백업 시작 일시 |
-| restorableBackups.completedYmdt | Body | DateTime | 백업 완료 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3336,16 +3526,31 @@ GET /v1.0/db-instances/{dbInstanceId}/restoration-info
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| oldestRestorableYmdt | DateTime | 가장 오래된 복원 가능한 시각 |
+| latestRestorableYmdt | DateTime | 가장 최신의 복원 가능한 시각 |
+| restorableBackups | Array | 복원 가능한 백업 목록 |
+| restorableBackups.backupId | UUID | 백업의 식별자 |
+| restorableBackups.backupName | String | 백업 이름 |
+| restorableBackups.backupStatus | Enum | 백업 상태<br/>- BACKING_UP: `백업 중 (스피너)`<br/>- VERIFYING: `검증 중 (스피너)`<br/>- COMPLETED: `사용 가능 (녹색 아이콘)`<br/>- DELETING: `삭제 중 (스피너)`<br/>- DELETED: `삭제 됨 (회색 아이콘)`<br/>- ERROR: `에러 (적색 아이콘)` |
+| restorableBackups.dbInstanceId | UUID | 원본 DB 인스턴스의 식별자 |
+| restorableBackups.dbInstanceName | String | 원본 DB 인스턴스의 이름 |
+| restorableBackups.dbVersion | String | DB 엔진 유형 |
+| restorableBackups.backupType | Enum | 백업 유형<br/>- AUTO<br/>- MANUAL |
+| restorableBackups.backupSize | Number | 백업 크기 |
+| restorableBackups.failoverCount | Number | 장애 조치 횟수 |
+| restorableBackups.walFileName | String | WAL 로그 파일 이름 |
+| restorableBackups.createdYmdt | DateTime | 백업 생성 일시 |
+| restorableBackups.updatedYmdt | DateTime | 백업 갱신 일시 |
+| restorableBackups.startYmdt | DateTime | 백업 시작 일시 |
+| restorableBackups.completedYmdt | DateTime | 백업 완료 일시 |
 
 ---
 
 ### DB 인스턴스 복원
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/restore
-```
 
 #### 필요 권한
 
@@ -3355,44 +3560,20 @@ POST /v1.0/db-instances/{dbInstanceId}/restore
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| dbInstanceName | Body | String | X | DB 인스턴스를 식별할 수 있는 이름 |
-| dbInstanceCandidateName | Body | String | X | DB 인스턴스를 식별할 수 있는 예비 마스터 이름 |
-| description | Body | String | X | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
-| dbFlavorId | Body | UUID | O | DB 인스턴스 사양의 식별자 |
-| dbPort | Body | Number | X | DB 포트<br/>- 최솟값: 5432, 최댓값: 45432 |
-| useHighAvailability | Body | Boolean | X | 고가용성 사용 여부<br/>- 기본값: `false` |
-| imageId | Body | UUID | X | 이미지의 식별자 |
-| pingInterval | Body | Number | X | 고가용성 사용 시 Ping 간격(초)<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
-| failoverReplWaitingTime | Body | Number | X | 장애조치 복제 지연 대기 시간(초)<br/>- 최솟값: `-1` |
-| storage | Body | Object | O | 스토리지 정보 객체 |
-| storage.storageType | Body | Enum | O | 스토리지 타입 |
-| storage.storageSize | Body | Number | O | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20` |
-| network | Body | Object | O | 네트워크 정보 객체 |
-| network.subnetId | Body | UUID | O | 서브넷의 식별자 |
-| network.usePublicAccess | Body | Boolean | X | 외부 접속 가능 여부<br/>- 기본값: `false` |
-| network.availabilityZone | Body | Enum | X | DB 인스턴스를 생성할 가용성 영역 |
-| backup | Body | Object | O | 백업 정보 객체 |
-| backup.backupPeriod | Body | Number | O | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
-| backup.backupRetryCount | Body | Number | X | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
-| backup.replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)`<br/>- KR2: `한국(평촌)` |
-| backup.backupSchedules | Body | Array | O | 백업 스케쥴 목록 |
-| backup.backupSchedules.backupWndBgnTime | Body | Time | O | 백업 시작 시각 |
-| backup.backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
-| restore | Body | Object | O | 복원 정보 객체 |
-| restore.restoreType | Body | Enum | O | 복원 타입<br/>- BACKUP: `기존에 생성한 백업을 이용한 복원`<br/>- TIMESTAMP: `복원 가능한 시간 이내의 시간을 이용한 시점 복원` |
-| restore.restoreYmdt | Body | DateTime | X | DB 인스턴스 복원 일시 |
-| restore.backupId | Body | UUID | X | 복원에 사용할 백업의 식별자 |
-| useDefaultNotification | Body | Boolean | X | 기본 알림 사용 여부<br/>- 기본값: `false` |
-| parameterGroupId | Body | UUID | O | 파라미터 그룹의 식별자 |
-| dbSecurityGroupIds | Body | Array | X | DB 보안 그룹의 식별자 목록 |
-| userGroupIds | Body | Array | X | 사용자 그룹의 식별자 목록 |
-| useDeletionProtection | Body | Boolean | X | 삭제 보호 여부<br/>- 기본값: `false` |
+```http
+POST /v1.0/db-instances/{dbInstanceId}/restore
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3438,17 +3619,47 @@ POST /v1.0/db-instances/{dbInstanceId}/restore
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | N | DB 인스턴스를 식별할 수 있는 이름 |
+| dbInstanceCandidateName | String | N | DB 인스턴스를 식별할 수 있는 예비 마스터 이름 |
+| description | String | N | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbFlavorId | UUID | Y | DB 인스턴스 사양의 식별자 |
+| dbPort | Number | N | DB 포트<br/>- 최솟값: 5432, 최댓값: 45432 |
+| useHighAvailability | Boolean | N | 고가용성 사용 여부<br/>- 기본값: `false` |
+| imageId | UUID | N | 이미지의 식별자 |
+| pingInterval | Number | N | 고가용성 사용 시 Ping 간격(초)<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
+| failoverReplWaitingTime | Number | N | 장애조치 복제 지연 대기 시간(초)<br/>- 최솟값: `-1` |
+| storage | Object | Y | 스토리지 정보 객체 |
+| storage.storageType | Enum | Y | 스토리지 타입 |
+| storage.storageSize | Number | Y | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20` |
+| network | Object | Y | 네트워크 정보 객체 |
+| network.subnetId | UUID | Y | 서브넷의 식별자 |
+| network.usePublicAccess | Boolean | N | 외부 접속 가능 여부<br/>- 기본값: `false` |
+| network.availabilityZone | Enum | N | DB 인스턴스를 생성할 가용성 영역 |
+| backup | Object | Y | 백업 정보 객체 |
+| backup.backupPeriod | Number | Y | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
+| backup.backupRetryCount | Number | N | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
+| backup.replicationRegion | Enum | N | 백업 복제 리전<br/>- KR1: `한국(판교)`<br/>- KR2: `한국(평촌)` |
+| backup.backupSchedules | Array | Y | 백업 스케쥴 목록 |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | 백업 시작 시각 |
+| backup.backupSchedules.backupWndDuration | Enum | Y | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
+| restore | Object | Y | 복원 정보 객체 |
+| restore.restoreType | Enum | Y | 복원 타입<br/>- BACKUP: `기존에 생성한 백업을 이용한 복원`<br/>- TIMESTAMP: `복원 가능한 시간 이내의 시간을 이용한 시점 복원` |
+| restore.restoreYmdt | DateTime | N | DB 인스턴스 복원 일시 |
+| restore.backupId | UUID | N | 복원에 사용할 백업의 식별자 |
+| useDefaultNotification | Boolean | N | 기본 알림 사용 여부<br/>- 기본값: `false` |
+| parameterGroupId | UUID | Y | 파라미터 그룹의 식별자 |
+| dbSecurityGroupIds | Array | N | DB 보안 그룹의 식별자 목록 |
+| userGroupIds | Array | N | 사용자 그룹의 식별자 목록 |
+| useDeletionProtection | Boolean | N | 삭제 보호 여부<br/>- 기본값: `false` |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3461,16 +3672,15 @@ POST /v1.0/db-instances/{dbInstanceId}/restore
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 인스턴스 시작하기
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/start
-```
 
 #### 필요 권한
 
@@ -3480,20 +3690,24 @@ POST /v1.0/db-instances/{dbInstanceId}/start
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+POST /v1.0/db-instances/{dbInstanceId}/start
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3506,16 +3720,15 @@ POST /v1.0/db-instances/{dbInstanceId}/start
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 인스턴스 정지하기
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/stop
-```
 
 #### 필요 권한
 
@@ -3525,20 +3738,24 @@ POST /v1.0/db-instances/{dbInstanceId}/stop
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+POST /v1.0/db-instances/{dbInstanceId}/stop
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3551,16 +3768,15 @@ POST /v1.0/db-instances/{dbInstanceId}/stop
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 인스턴스 스토리지 정보 조회
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}/storage-info
-```
 
 #### 필요 권한
 
@@ -3570,22 +3786,24 @@ GET /v1.0/db-instances/{dbInstanceId}/storage-info
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v1.0/db-instances/{dbInstanceId}/storage-info
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| storageType | Body | Enum | 데이터 스토리지 타입 |
-| storageSize | Body | Number | 데이터 스토리지 크기(GB) |
-| storageStatus | Body | Enum | 데이터 스토리지의 현재 상태<br/>- DELETED: `삭제됨`<br/>- PENDING_DELETION: `삭제 유예됨`<br/>- DELETION_RESERVED: `삭제 예약됨 (스냅샷 정리 대기)`<br/>- DETACHED: `해제됨`<br/>- ATTACHED: `할당됨` |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3600,16 +3818,17 @@ GET /v1.0/db-instances/{dbInstanceId}/storage-info
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| storageType | Enum | 데이터 스토리지 타입 |
+| storageSize | Number | 데이터 스토리지 크기(GB) |
+| storageStatus | Enum | 데이터 스토리지의 현재 상태<br/>- DELETED: `삭제됨`<br/>- PENDING_DELETION: `삭제 유예됨`<br/>- DELETION_RESERVED: `삭제 예약됨 (스냅샷 정리 대기)`<br/>- DETACHED: `해제됨`<br/>- ATTACHED: `할당됨` |
 
 ---
 
 ### DB 인스턴스 스토리지 정보 수정하기
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/storage-info
-```
 
 #### 필요 권한
 
@@ -3619,13 +3838,20 @@ PUT /v1.0/db-instances/{dbInstanceId}/storage-info
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| storageSize | Body | Number | O | 데이터 스토리지 크기(GB)<br/>- 최댓값: `2048` |
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/storage-info
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3633,17 +3859,16 @@ PUT /v1.0/db-instances/{dbInstanceId}/storage-info
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| storageSize | Number | Y | 데이터 스토리지 크기(GB)<br/>- 최댓값: `2048` |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3656,8 +3881,11 @@ PUT /v1.0/db-instances/{dbInstanceId}/storage-info
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
@@ -3675,10 +3903,6 @@ PUT /v1.0/db-instances/{dbInstanceId}/storage-info
 
 ### 백업 목록 보기
 
-```http
-GET /v1.0/backups
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -3687,28 +3911,18 @@ GET /v1.0/backups
 
 #### 요청
 
+```http
+GET /v1.0/backups
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | 전체 백업 목록 수 |
-| backups | Body | Array | 백업 목록 |
-| backups.backupId | Body | UUID | 백업의 식별자 |
-| backups.backupName | Body | String | 백업을 식별할 수 있는 이름 |
-| backups.backupStatus | Body | Enum | 백업의 현재 상태<br/>- BACKING_UP: `백업 중 (스피너)`<br/>- VERIFYING: `검증 중 (스피너)`<br/>- COMPLETED: `사용 가능 (녹색 아이콘)`<br/>- DELETING: `삭제 중 (스피너)`<br/>- DELETED: `삭제 됨 (회색 아이콘)`<br/>- ERROR: `에러 (적색 아이콘)` |
-| backups.dbInstanceId | Body | UUID | 원본 DB 인스턴스의 식별자 |
-| backups.dbVersion | Body | Enum | DB 엔진 버전 |
-| backups.backupType | Body | Enum | 백업 유형<br/>- AUTO<br/>- MANUAL |
-| backups.backupSize | Body | Number | 백업의 크기(Byte) |
-| backups.startYmdt | Body | DateTime | 시작 일시 |
-| backups.createdYmdt | Body | DateTime | 생성 일시 |
-| backups.updatedYmdt | Body | DateTime | 수정 일시 |
-| backups.completedYmdt | Body | DateTime | 완료 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3736,16 +3950,27 @@ GET /v1.0/backups
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| totalCounts | Number | 전체 백업 목록 수 |
+| backups | Array | 백업 목록 |
+| backups.backupId | UUID | 백업의 식별자 |
+| backups.backupName | String | 백업을 식별할 수 있는 이름 |
+| backups.backupStatus | Enum | 백업의 현재 상태<br/>- BACKING_UP: `백업 중 (스피너)`<br/>- VERIFYING: `검증 중 (스피너)`<br/>- COMPLETED: `사용 가능 (녹색 아이콘)`<br/>- DELETING: `삭제 중 (스피너)`<br/>- DELETED: `삭제 됨 (회색 아이콘)`<br/>- ERROR: `에러 (적색 아이콘)` |
+| backups.dbInstanceId | UUID | 원본 DB 인스턴스의 식별자 |
+| backups.dbVersion | String | DB 엔진 버전 |
+| backups.backupType | Enum | 백업 유형<br/>- AUTO<br/>- MANUAL |
+| backups.backupSize | Number | 백업의 크기(Byte) |
+| backups.startYmdt | DateTime | 시작 일시 |
+| backups.createdYmdt | DateTime | 생성 일시 |
+| backups.updatedYmdt | DateTime | 수정 일시 |
+| backups.completedYmdt | DateTime | 완료 일시 |
 
 ---
 
 ### 백업 삭제하기
-
-```http
-DELETE /v1.0/backups/{backupId}
-```
 
 #### 필요 권한
 
@@ -3755,20 +3980,24 @@ DELETE /v1.0/backups/{backupId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+DELETE /v1.0/backups/{backupId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| backupId | URL | UUID | O | 백업의 식별자 |
+| backupId | URL | UUID | Y | 백업의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3781,16 +4010,15 @@ DELETE /v1.0/backups/{backupId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### 백업 내보내기
-
-```http
-POST /v1.0/backups/{backupId}/export
-```
 
 #### 필요 권한
 
@@ -3800,17 +4028,20 @@ POST /v1.0/backups/{backupId}/export
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| backupId | URL | UUID | O | 백업의 식별자 |
-| tenantId | Body | String | O | 백업이 저장될 오브젝트 스토리지의 테넌트 ID<br/>- 최소 길이: `32`<br/>- 최대 길이: `32` |
-| username | Body | String | O | NHN Cloud 계정 혹은 IAM 회원 ID |
-| password | Body | String | O | 백업이 저장될 오브젝트 스토리지의 API 비밀번호 |
-| targetContainer | Body | String | O | 백업이 저장될 오브젝트 스토리지의 컨테이너 |
-| objectPath | Body | String | O | 컨테이너에 저장될 백업의 경로 |
+```http
+POST /v1.0/backups/{backupId}/export
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | Y | 백업의 식별자 |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3822,17 +4053,20 @@ POST /v1.0/backups/{backupId}/export
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| tenantId | String | Y | 백업이 저장될 오브젝트 스토리지의 테넌트 ID<br/>- 최소 길이: `32`<br/>- 최대 길이: `32` |
+| username | String | Y | NHN Cloud 계정 혹은 IAM 회원 ID |
+| password | String | Y | 백업이 저장될 오브젝트 스토리지의 API 비밀번호 |
+| targetContainer | String | Y | 백업이 저장될 오브젝트 스토리지의 컨테이너 |
+| objectPath | String | Y | 컨테이너에 저장될 백업의 경로 |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3845,16 +4079,15 @@ POST /v1.0/backups/{backupId}/export
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### 백업 복원하기
-
-```http
-POST /v1.0/backups/{backupId}/restore
-```
 
 #### 필요 권한
 
@@ -3864,38 +4097,20 @@ POST /v1.0/backups/{backupId}/restore
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| backupId | URL | UUID | O | 백업의 식별자 |
-| dbInstanceName | Body | String | O | DB 인스턴스를 식별할 수 있는 이름 |
-| dbInstanceCandidateName | Body | String | X | DB 인스턴스를 식별할 수 있는 예비 마스터 이름 |
-| description | Body | String | X | DB 인스턴스에 대한 추가 정보 |
-| dbFlavorId | Body | UUID | O | DB 인스턴스 사양의 식별자 |
-| dbPort | Body | Number | O | DB 포트<br/>- 최솟값: 5432, 최댓값: 45432 |
-| parameterGroupId | Body | UUID | O | 파라미터 그룹의 식별자 |
-| dbSecurityGroupIds | Body | Array | X | DB 보안 그룹의 식별자 목록 |
-| userGroupIds | Body | Array | X | 사용자 그룹의 식별자 목록 |
-| useHighAvailability | Body | Boolean | X | 고가용성 사용 여부<br/>- 기본값: `false` |
-| useDefaultNotification | Body | Boolean | X | 기본 알림 사용 여부<br/>- 기본값: `false` |
-| useDeletionProtection | Body | Boolean | X | 삭제 보호 여부<br/>- 기본값: `false` |
-| pingInterval | Body | Number | X | Ping 간격(초)<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
-| failoverReplWaitingTime | Body | Number | X | 장애조치 복제 지연 대기 시간(초)<br/>- 최솟값: `-1` |
-| network | Body | Object | O | 네트워크 정보 객체 |
-| network.subnetId | Body | UUID | O | 서브넷의 식별자 |
-| network.usePublicAccess | Body | Boolean | X | 외부 접속 가능 여부<br/>- 기본값: `false` |
-| network.availabilityZone | Body | Enum | X | DB 인스턴스를 생성할 가용성 영역 |
-| storage | Body | Object | O | 스토리지 정보 객체 |
-| storage.storageType | Body | Enum | O | 스토리지 타입 |
-| storage.storageSize | Body | Number | O | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20` |
-| backup | Body | Object | O | 백업 정보 객체 |
-| backup.backupPeriod | Body | Number | O | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
-| backup.backupRetryCount | Body | Number | X | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
-| backup.backupSchedules | Body | Array | O | 백업 스케쥴 목록 |
-| backup.backupSchedules.backupWndBgnTime | Body | Time | O | 백업 시작 시간 |
-| backup.backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
+```http
+POST /v1.0/backups/{backupId}/restore
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | Y | 백업의 식별자 |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3934,17 +4149,41 @@ POST /v1.0/backups/{backupId}/restore
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | DB 인스턴스를 식별할 수 있는 이름 |
+| dbInstanceCandidateName | String | N | DB 인스턴스를 식별할 수 있는 예비 마스터 이름 |
+| description | String | N | DB 인스턴스에 대한 추가 정보 |
+| dbFlavorId | UUID | Y | DB 인스턴스 사양의 식별자 |
+| dbPort | Number | Y | DB 포트<br/>- 최솟값: 5432, 최댓값: 45432 |
+| parameterGroupId | UUID | Y | 파라미터 그룹의 식별자 |
+| dbSecurityGroupIds | Array | N | DB 보안 그룹의 식별자 목록 |
+| userGroupIds | Array | N | 사용자 그룹의 식별자 목록 |
+| useHighAvailability | Boolean | N | 고가용성 사용 여부<br/>- 기본값: `false` |
+| useDefaultNotification | Boolean | N | 기본 알림 사용 여부<br/>- 기본값: `false` |
+| useDeletionProtection | Boolean | N | 삭제 보호 여부<br/>- 기본값: `false` |
+| pingInterval | Number | N | Ping 간격(초)<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
+| failoverReplWaitingTime | Number | N | 장애조치 복제 지연 대기 시간(초)<br/>- 최솟값: `-1` |
+| network | Object | Y | 네트워크 정보 객체 |
+| network.subnetId | UUID | Y | 서브넷의 식별자 |
+| network.usePublicAccess | Boolean | N | 외부 접속 가능 여부<br/>- 기본값: `false` |
+| network.availabilityZone | Enum | N | DB 인스턴스를 생성할 가용성 영역 |
+| storage | Object | Y | 스토리지 정보 객체 |
+| storage.storageType | Enum | Y | 스토리지 타입 |
+| storage.storageSize | Number | Y | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20` |
+| backup | Object | Y | 백업 정보 객체 |
+| backup.backupPeriod | Number | Y | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
+| backup.backupRetryCount | Number | N | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
+| backup.backupSchedules | Array | Y | 백업 스케쥴 목록 |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | 백업 시작 시간 |
+| backup.backupSchedules.backupWndDuration | Enum | Y | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3957,8 +4196,11 @@ POST /v1.0/backups/{backupId}/restore
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
@@ -3975,10 +4217,6 @@ POST /v1.0/backups/{backupId}/restore
 
 ### DB 보안 그룹 목록 보기
 
-```http
-GET /v1.0/db-security-groups
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -3987,23 +4225,18 @@ GET /v1.0/db-security-groups
 
 #### 요청
 
+```http
+GET /v1.0/db-security-groups
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| dbSecurityGroups | Body | Array | DB 보안 그룹 목록 |
-| dbSecurityGroups.dbSecurityGroupId | Body | UUID | DB 보안 그룹의 식별자 |
-| dbSecurityGroups.dbSecurityGroupName | Body | String | DB 보안 그룹을 식별할 수 있는 이름 |
-| dbSecurityGroups.dbSecurityGroupStatus | Body | Enum | DB 보안 그룹의 현재 상태<br/>- CREATED: `생성됨`<br/>- DELETED: `삭제됨` |
-| dbSecurityGroups.description | Body | String | DB 보안 그룹에 대한 추가 정보 |
-| dbSecurityGroups.progressStatus | Body | Enum | DB 보안 그룹의 현재 진행 상태<br/>- NONE: `없음`<br/>- CREATING_RULE: `규칙 생성중`<br/>- UPDATING_RULE: `규칙 수정중`<br/>- DELETING_RULE: `규칙 삭제중`<br/>- APPLYING_DEFAULT_RULE: `기본 규칙 적용중` |
-| dbSecurityGroups.createdYmdt | Body | DateTime | 생성 일시 |
-| dbSecurityGroups.updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4026,16 +4259,22 @@ GET /v1.0/db-security-groups
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbSecurityGroups | Array | DB 보안 그룹 목록 |
+| dbSecurityGroups.dbSecurityGroupId | UUID | DB 보안 그룹의 식별자 |
+| dbSecurityGroups.dbSecurityGroupName | String | DB 보안 그룹을 식별할 수 있는 이름 |
+| dbSecurityGroups.dbSecurityGroupStatus | Enum | DB 보안 그룹의 현재 상태<br/>- CREATED: `생성됨`<br/>- DELETED: `삭제됨` |
+| dbSecurityGroups.description | String | DB 보안 그룹에 대한 추가 정보 |
+| dbSecurityGroups.progressStatus | Enum | DB 보안 그룹의 현재 진행 상태<br/>- NONE: `없음`<br/>- CREATING_RULE: `규칙 생성중`<br/>- UPDATING_RULE: `규칙 수정중`<br/>- DELETING_RULE: `규칙 삭제중`<br/>- APPLYING_DEFAULT_RULE: `기본 규칙 적용중` |
+| dbSecurityGroups.createdYmdt | DateTime | 생성 일시 |
+| dbSecurityGroups.updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
 ### DB 보안 그룹 생성하기
-
-```http
-POST /v1.0/db-security-groups
-```
 
 #### 필요 권한
 
@@ -4045,22 +4284,14 @@ POST /v1.0/db-security-groups
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbSecurityGroupName | Body | String | O | DB 보안 그룹을 식별할 수 있는 이름 |
-| description | Body | String | X | DB 보안 그룹에 대한 추가 정보 |
-| rules | Body | Array | O | DB 보안 그룹 규칙 정보 |
-| rules.direction | Body | Enum | O | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
-| rules.etherType | Body | Enum | O | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
-| rules.port | Body | Object | O | 포트 객체 |
-| rules.port.portType | Body | Enum | O | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
-| rules.port.minPort | Body | Number | X | 최소 포트 범위<br/>- 최솟값: `1` |
-| rules.port.maxPort | Body | Number | X | 최대 포트 범위<br/>- 최댓값: `65535` |
-| rules.cidr | Body | String | O | CIDR |
-| rules.description | Body | String | X | 보안 그룹 규칙에 대한 추가 정보 |
+```http
+POST /v1.0/db-security-groups
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4082,17 +4313,26 @@ POST /v1.0/db-security-groups
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbSecurityGroupName | String | Y | DB 보안 그룹을 식별할 수 있는 이름 |
+| description | String | N | DB 보안 그룹에 대한 추가 정보 |
+| rules | Array | Y | DB 보안 그룹 규칙 정보 |
+| rules.direction | Enum | Y | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
+| rules.etherType | Enum | Y | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
+| rules.port | Object | Y | 포트 객체 |
+| rules.port.portType | Enum | Y | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
+| rules.port.minPort | Number | N | 최소 포트 범위<br/>- 최솟값: `1` |
+| rules.port.maxPort | Number | N | 최대 포트 범위<br/>- 최댓값: `65535` |
+| rules.cidr | String | Y | CIDR |
+| rules.description | String | N | 보안 그룹 규칙에 대한 추가 정보 |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| dbSecurityGroupId | Body | UUID | DB 보안 그룹의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4105,16 +4345,15 @@ POST /v1.0/db-security-groups
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbSecurityGroupId | UUID | DB 보안 그룹의 식별자 |
 
 ---
 
 ### DB 보안 그룹 삭제하기
-
-```http
-DELETE /v1.0/db-security-groups/{dbSecurityGroupId}
-```
 
 #### 필요 권한
 
@@ -4124,11 +4363,19 @@ DELETE /v1.0/db-security-groups/{dbSecurityGroupId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+DELETE /v1.0/db-security-groups/{dbSecurityGroupId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
@@ -4138,10 +4385,6 @@ DELETE /v1.0/db-security-groups/{dbSecurityGroupId}
 
 ### DB 보안 그룹 상세 보기
 
-```http
-GET /v1.0/db-security-groups/{dbSecurityGroupId}
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -4150,39 +4393,24 @@ GET /v1.0/db-security-groups/{dbSecurityGroupId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v1.0/db-security-groups/{dbSecurityGroupId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| dbSecurityGroup | Body | Object | DB 보안 그룹 |
-| dbSecurityGroup.dbSecurityGroupId | Body | UUID | DB 보안 그룹의 식별자 |
-| dbSecurityGroup.dbSecurityGroupName | Body | String | DB 보안 그룹을 식별할 수 있는 이름 |
-| dbSecurityGroup.dbSecurityGroupStatus | Body | Enum | DB 보안 그룹의 현재 상태<br/>- CREATED: `생성됨`<br/>- DELETED: `삭제됨` |
-| dbSecurityGroup.description | Body | String | DB 보안 그룹에 대한 추가 정보 |
-| dbSecurityGroup.progressStatus | Body | Enum | DB 보안 그룹의 현재 진행 상태<br/>- NONE: `없음`<br/>- CREATING_RULE: `규칙 생성중`<br/>- UPDATING_RULE: `규칙 수정중`<br/>- DELETING_RULE: `규칙 삭제중`<br/>- APPLYING_DEFAULT_RULE: `기본 규칙 적용중` |
-| dbSecurityGroup.rules | Body | Array | DB 보안 그룹 규칙 목록 |
-| dbSecurityGroup.rules.ruleId | Body | UUID | DB 보안 그룹 규칙의 식별자 |
-| dbSecurityGroup.rules.description | Body | String | DB 보안 그룹 규칙에 대한 추가 정보 |
-| dbSecurityGroup.rules.direction | Body | Enum | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
-| dbSecurityGroup.rules.etherType | Body | Enum | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
-| dbSecurityGroup.rules.port | Body | Object | 포트 객체 |
-| dbSecurityGroup.rules.port.portType | Body | Enum | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
-| dbSecurityGroup.rules.port.minPort | Body | Number | 최소 포트 범위 |
-| dbSecurityGroup.rules.port.maxPort | Body | Number | 최대 포트 범위 |
-| dbSecurityGroup.rules.cidr | Body | String | CIDR |
-| dbSecurityGroup.rules.createdYmdt | Body | DateTime | 생성 일시 |
-| dbSecurityGroup.rules.updatedYmdt | Body | DateTime | 수정 일시 |
-| dbSecurityGroup.createdYmdt | Body | DateTime | 생성 일시 |
-| dbSecurityGroup.updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4219,16 +4447,34 @@ GET /v1.0/db-security-groups/{dbSecurityGroupId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbSecurityGroup | Object | DB 보안 그룹 |
+| dbSecurityGroup.dbSecurityGroupId | UUID | DB 보안 그룹의 식별자 |
+| dbSecurityGroup.dbSecurityGroupName | String | DB 보안 그룹을 식별할 수 있는 이름 |
+| dbSecurityGroup.dbSecurityGroupStatus | Enum | DB 보안 그룹의 현재 상태<br/>- CREATED: `생성됨`<br/>- DELETED: `삭제됨` |
+| dbSecurityGroup.description | String | DB 보안 그룹에 대한 추가 정보 |
+| dbSecurityGroup.progressStatus | Enum | DB 보안 그룹의 현재 진행 상태<br/>- NONE: `없음`<br/>- CREATING_RULE: `규칙 생성중`<br/>- UPDATING_RULE: `규칙 수정중`<br/>- DELETING_RULE: `규칙 삭제중`<br/>- APPLYING_DEFAULT_RULE: `기본 규칙 적용중` |
+| dbSecurityGroup.rules | Array | DB 보안 그룹 규칙 목록 |
+| dbSecurityGroup.rules.ruleId | UUID | DB 보안 그룹 규칙의 식별자 |
+| dbSecurityGroup.rules.description | String | DB 보안 그룹 규칙에 대한 추가 정보 |
+| dbSecurityGroup.rules.direction | Enum | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
+| dbSecurityGroup.rules.etherType | Enum | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
+| dbSecurityGroup.rules.port | Object | 포트 객체 |
+| dbSecurityGroup.rules.port.portType | Enum | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
+| dbSecurityGroup.rules.port.minPort | Number | 최소 포트 범위 |
+| dbSecurityGroup.rules.port.maxPort | Number | 최대 포트 범위 |
+| dbSecurityGroup.rules.cidr | String | CIDR |
+| dbSecurityGroup.rules.createdYmdt | DateTime | 생성 일시 |
+| dbSecurityGroup.rules.updatedYmdt | DateTime | 수정 일시 |
+| dbSecurityGroup.createdYmdt | DateTime | 생성 일시 |
+| dbSecurityGroup.updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
 ### DB 보안 그룹 수정하기
-
-```http
-PUT /v1.0/db-security-groups/{dbSecurityGroupId}
-```
 
 #### 필요 권한
 
@@ -4238,14 +4484,20 @@ PUT /v1.0/db-security-groups/{dbSecurityGroupId}
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
-| dbSecurityGroupName | Body | String | O | DB 보안 그룹을 식별할 수 있는 이름 |
-| description | Body | String | X | DB 보안 그룹에 대한 추가 정보 |
+```http
+PUT /v1.0/db-security-groups/{dbSecurityGroupId}
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4254,8 +4506,12 @@ PUT /v1.0/db-security-groups/{dbSecurityGroupId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbSecurityGroupName | String | Y | DB 보안 그룹을 식별할 수 있는 이름 |
+| description | String | N | DB 보안 그룹에 대한 추가 정보 |
 
 #### 응답
 
@@ -4265,10 +4521,6 @@ PUT /v1.0/db-security-groups/{dbSecurityGroupId}
 
 ### DB 보안 그룹 규칙 삭제하기
 
-```http
-DELETE /v1.0/db-security-groups/{dbSecurityGroupId}/rules
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -4277,21 +4529,25 @@ DELETE /v1.0/db-security-groups/{dbSecurityGroupId}/rules
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+DELETE /v1.0/db-security-groups/{dbSecurityGroupId}/rules
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
-| ruleIds | Query | String | O | DB 보안 그룹 규칙 ID 리스트 |
+| dbSecurityGroupId | URL | UUID | Y |  |
+| ruleIds | Query | String | Y | DB 보안 그룹 규칙 ID 리스트 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4304,16 +4560,15 @@ DELETE /v1.0/db-security-groups/{dbSecurityGroupId}/rules
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 보안 그룹 규칙 생성하기
-
-```http
-POST /v1.0/db-security-groups/{dbSecurityGroupId}/rules
-```
 
 #### 필요 권한
 
@@ -4323,20 +4578,20 @@ POST /v1.0/db-security-groups/{dbSecurityGroupId}/rules
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
-| direction | Body | Enum | O | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
-| etherType | Body | Enum | O | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
-| port | Body | Object | O | 포트 정보 |
-| port.portType | Body | Enum | O | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
-| port.minPort | Body | Number | X | 최소 포트 범위<br/>- 최솟값: `1` |
-| port.maxPort | Body | Number | X | 최대 포트 범위<br/>- 최댓값: `65535` |
-| cidr | Body | String | O | CIDR |
-| description | Body | String | X | DB 보안 그룹 규칙에 대한 추가 정보 |
+```http
+POST /v1.0/db-security-groups/{dbSecurityGroupId}/rules
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4352,17 +4607,23 @@ POST /v1.0/db-security-groups/{dbSecurityGroupId}/rules
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| direction | Enum | Y | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
+| etherType | Enum | Y | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
+| port | Object | Y | 포트 정보 |
+| port.portType | Enum | Y | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
+| port.minPort | Number | N | 최소 포트 범위<br/>- 최솟값: `1` |
+| port.maxPort | Number | N | 최대 포트 범위<br/>- 최댓값: `65535` |
+| cidr | String | Y | CIDR |
+| description | String | N | DB 보안 그룹 규칙에 대한 추가 정보 |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4375,16 +4636,15 @@ POST /v1.0/db-security-groups/{dbSecurityGroupId}/rules
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 보안 그룹 규칙 수정하기
-
-```http
-PUT /v1.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
-```
 
 #### 필요 권한
 
@@ -4394,21 +4654,21 @@ PUT /v1.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
-| ruleId | URL | UUID | O |  |
-| direction | Body | Enum | O | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
-| etherType | Body | Enum | O | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
-| port | Body | Object | O | 포트 정보 |
-| port.portType | Body | Enum | O | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
-| port.minPort | Body | Number | X | 최소 포트 범위<br/>- 최솟값: `1` |
-| port.maxPort | Body | Number | X | 최대 포트 범위<br/>- 최댓값: `65535` |
-| cidr | Body | String | O | CIDR |
-| description | Body | String | X | DB 보안 그룹 규칙에 대한 추가 정보 |
+```http
+PUT /v1.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+| ruleId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4424,17 +4684,23 @@ PUT /v1.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| direction | Enum | Y | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
+| etherType | Enum | Y | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
+| port | Object | Y | 포트 정보 |
+| port.portType | Enum | Y | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
+| port.minPort | Number | N | 최소 포트 범위<br/>- 최솟값: `1` |
+| port.maxPort | Number | N | 최대 포트 범위<br/>- 최댓값: `65535` |
+| cidr | String | Y | CIDR |
+| description | String | N | DB 보안 그룹 규칙에 대한 추가 정보 |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4447,18 +4713,17 @@ PUT /v1.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ## 파라미터 그룹
 
 ### 파라미터 그룹 목록 보기
-
-```http
-GET /v1.0/parameter-groups
-```
 
 #### 필요 권한
 
@@ -4468,23 +4733,18 @@ GET /v1.0/parameter-groups
 
 #### 요청
 
+```http
+GET /v1.0/parameter-groups
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| parameterGroups | Body | Array | 파라미터 그룹 목록 |
-| parameterGroups.parameterGroupId | Body | UUID | 파라미터 그룹의 식별자 |
-| parameterGroups.parameterGroupName | Body | String | 파라미터 그룹을 식별할 수 있는 이름 |
-| parameterGroups.description | Body | String | 파라미터 그룹에 대한 추가 정보 |
-| parameterGroups.dbVersion | Body | Enum | DB 엔진 버전 |
-| parameterGroups.parameterGroupStatus | Body | Enum | 파라미터 그룹의 현재 상태<br/>- STABLE: `적용 완료`<br/>- NEED_TO_APPLY: `적용 필요`<br/>- DELETED: `삭제됨` |
-| parameterGroups.createdYmdt | Body | DateTime | 생성 일시 |
-| parameterGroups.updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4507,16 +4767,22 @@ GET /v1.0/parameter-groups
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| parameterGroups | Array | 파라미터 그룹 목록 |
+| parameterGroups.parameterGroupId | UUID | 파라미터 그룹의 식별자 |
+| parameterGroups.parameterGroupName | String | 파라미터 그룹을 식별할 수 있는 이름 |
+| parameterGroups.description | String | 파라미터 그룹에 대한 추가 정보 |
+| parameterGroups.dbVersion | String | DB 엔진 버전 |
+| parameterGroups.parameterGroupStatus | Enum | 파라미터 그룹의 현재 상태<br/>- STABLE: `적용 완료`<br/>- NEED_TO_APPLY: `적용 필요`<br/>- DELETED: `삭제됨` |
+| parameterGroups.createdYmdt | DateTime | 생성 일시 |
+| parameterGroups.updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
 ### 파라미터 그룹 생성하기
-
-```http
-POST /v1.0/parameter-groups
-```
 
 #### 필요 권한
 
@@ -4526,14 +4792,14 @@ POST /v1.0/parameter-groups
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| parameterGroupName | Body | String | O | 파라미터 그룹을 식별할 수 있는 이름 |
-| description | Body | String | X | 파라미터 그룹에 대한 추가 정보 |
-| dbVersion | Body | Enum | O | DB 엔진 버전 |
+```http
+POST /v1.0/parameter-groups
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4543,17 +4809,18 @@ POST /v1.0/parameter-groups
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| parameterGroupName | String | Y | 파라미터 그룹을 식별할 수 있는 이름 |
+| description | String | N | 파라미터 그룹에 대한 추가 정보 |
+| dbVersion | String | Y | DB 엔진 버전 |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| parameterGroupId | Body | UUID | 파라미터 그룹의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4566,16 +4833,15 @@ POST /v1.0/parameter-groups
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| parameterGroupId | UUID | 파라미터 그룹의 식별자 |
 
 ---
 
 ### 파라미터 그룹 삭제하기
-
-```http
-DELETE /v1.0/parameter-groups/{parameterGroupId}
-```
 
 #### 필요 권한
 
@@ -4585,11 +4851,19 @@ DELETE /v1.0/parameter-groups/{parameterGroupId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+DELETE /v1.0/parameter-groups/{parameterGroupId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O | 파라미터 그룹 ID |
+| parameterGroupId | URL | UUID | Y | 파라미터 그룹 ID |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
@@ -4599,10 +4873,6 @@ DELETE /v1.0/parameter-groups/{parameterGroupId}
 
 ### 파라미터 그룹 상세 조회
 
-```http
-GET /v1.0/parameter-groups/{parameterGroupId}
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -4611,42 +4881,24 @@ GET /v1.0/parameter-groups/{parameterGroupId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v1.0/parameter-groups/{parameterGroupId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O | 파라미터 그룹 ID |
+| parameterGroupId | URL | UUID | Y | 파라미터 그룹 ID |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| parameterGroupId | Body | UUID | 파라미터 그룹의 식별자 |
-| parameterGroupName | Body | String | 파라미터 그룹을 식별할 수 있는 이름 |
-| description | Body | String | 파라미터 그룹에 대한 추가 정보 |
-| dbVersion | Body | Enum | DB 엔진 버전 |
-| parameterGroupStatus | Body | Enum | 파라미터 그룹의 현재 상태<br/>- STABLE: `적용 완료`<br/>- NEED_TO_APPLY: `적용 필요`<br/>- DELETED: `삭제됨` |
-| parameters | Body | Array | 파라미터 정보 |
-| parameters.parameterCategory | Body | String | 파라미터 카테고리 |
-| parameters.parameterName | Body | String | 파라미터 이름 |
-| parameters.value | Body | String | 현재 설정된 값 |
-| parameters.valueUnit | Body | String | 값 단위 (바이트: B,kB,MB,GB,TB, 시간: us,ms,s,min,h,d) |
-| parameters.defaultValue | Body | String | 기본값 |
-| parameters.allowedValue | Body | String | 허용된 값 |
-| parameters.valueType | Body | Enum | 값 타입<br/>- BOOLEAN: `불린 타입
- * ex) on, off, true, false, yes, no, 1, 0`<br/>- STRING: `문자열`<br/>- NUMERIC: `정수 및 부동 소수점`<br/>- NUMERIC_WITH_BYTE_UNIT: `단위가 있는 숫자
- * ex) 120kB, 100MB
- * 허용된 바이트 단위: B (bytes), kB (kilobytes), MB (megabytes), GB (gigabytes), and TB (terabytes)`<br/>- NUMERIC_WITH_TIME_UNIT: `단위가 있는 숫자
- * ex) 120ms, 100s, 1d
- * 허용된 시간 단위: us (microseconds), ms (milliseconds), s (seconds), min (minutes), h (hours), and d (days)`<br/>- ENUMERATED: `allowed_value에 선언된 값 중 한 개 선택 (콤마(,)로 구분됨)`<br/>- MULTI_ENUMERATED: `allowed_value에 선언된 값 중 여러개 선택 (콤마(,)로 구분됨)` |
-| parameters.updateType | Body | Enum | 수정 타입<br/>- VARIABLE: `동적, 언제든 수정 가능`<br/>- CONSTANT: `수정 불가능` |
-| parameters.applyType | Body | Enum | 적용 타입<br/>- BOTH: `세션, 파일 모두 적용`<br/>- SESSION: `세션에만 적용`<br/>- FILE: `파일에만 적용` |
-| parameters.expressionAvailable | Body | Boolean | 수식 허용 여부 |
-| createdYmdt | Body | DateTime | 생성 일시 |
-| updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4679,16 +4931,37 @@ GET /v1.0/parameter-groups/{parameterGroupId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| parameterGroupId | UUID | 파라미터 그룹의 식별자 |
+| parameterGroupName | String | 파라미터 그룹을 식별할 수 있는 이름 |
+| description | String | 파라미터 그룹에 대한 추가 정보 |
+| dbVersion | String | DB 엔진 버전 |
+| parameterGroupStatus | Enum | 파라미터 그룹의 현재 상태<br/>- STABLE: `적용 완료`<br/>- NEED_TO_APPLY: `적용 필요`<br/>- DELETED: `삭제됨` |
+| parameters | Array | 파라미터 정보 |
+| parameters.parameterCategory | String | 파라미터 카테고리 |
+| parameters.parameterName | String | 파라미터 이름 |
+| parameters.value | String | 현재 설정된 값 |
+| parameters.valueUnit | String | 값 단위 (바이트: B,kB,MB,GB,TB, 시간: us,ms,s,min,h,d) |
+| parameters.defaultValue | String | 기본값 |
+| parameters.allowedValue | String | 허용된 값 |
+| parameters.valueType | Enum | 값 타입<br/>- BOOLEAN: `불린 타입
+ * ex) on, off, true, false, yes, no, 1, 0`<br/>- STRING: `문자열`<br/>- NUMERIC: `정수 및 부동 소수점`<br/>- NUMERIC_WITH_BYTE_UNIT: `단위가 있는 숫자
+ * ex) 120kB, 100MB
+ * 허용된 바이트 단위: B (bytes), kB (kilobytes), MB (megabytes), GB (gigabytes), and TB (terabytes)`<br/>- NUMERIC_WITH_TIME_UNIT: `단위가 있는 숫자
+ * ex) 120ms, 100s, 1d
+ * 허용된 시간 단위: us (microseconds), ms (milliseconds), s (seconds), min (minutes), h (hours), and d (days)`<br/>- ENUMERATED: `allowed_value에 선언된 값 중 한 개 선택 (콤마(,)로 구분됨)`<br/>- MULTI_ENUMERATED: `allowed_value에 선언된 값 중 여러개 선택 (콤마(,)로 구분됨)` |
+| parameters.updateType | Enum | 수정 타입<br/>- VARIABLE: `동적, 언제든 수정 가능`<br/>- CONSTANT: `수정 불가능` |
+| parameters.applyType | Enum | 적용 타입<br/>- BOTH: `세션, 파일 모두 적용`<br/>- SESSION: `세션에만 적용`<br/>- FILE: `파일에만 적용` |
+| parameters.expressionAvailable | Boolean | 수식 허용 여부 |
+| createdYmdt | DateTime | 생성 일시 |
+| updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
 ### 파라미터 그룹 수정하기
-
-```http
-PUT /v1.0/parameter-groups/{parameterGroupId}
-```
 
 #### 필요 권한
 
@@ -4698,14 +4971,20 @@ PUT /v1.0/parameter-groups/{parameterGroupId}
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O | 파라미터 그룹 ID |
-| parameterGroupName | Body | String | X | 파라미터 그룹을 식별할 수 있는 이름 |
-| description | Body | String | X | 파라미터 그룹에 대한 추가 정보 |
+```http
+PUT /v1.0/parameter-groups/{parameterGroupId}
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y | 파라미터 그룹 ID |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4714,8 +4993,12 @@ PUT /v1.0/parameter-groups/{parameterGroupId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| parameterGroupName | String | N | 파라미터 그룹을 식별할 수 있는 이름 |
+| description | String | N | 파라미터 그룹에 대한 추가 정보 |
 
 #### 응답
 
@@ -4725,10 +5008,6 @@ PUT /v1.0/parameter-groups/{parameterGroupId}
 
 ### 파라미터 그룹 복사하기
 
-```http
-POST /v1.0/parameter-groups/{parameterGroupId}/copy
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -4737,14 +5016,20 @@ POST /v1.0/parameter-groups/{parameterGroupId}/copy
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O | 파라미터 그룹 ID |
-| parameterGroupName | Body | String | O | 파라미터 그룹을 식별할 수 있는 이름 |
-| description | Body | String | X | 파라미터 그룹에 대한 추가 정보 |
+```http
+POST /v1.0/parameter-groups/{parameterGroupId}/copy
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y | 파라미터 그룹 ID |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4753,17 +5038,17 @@ POST /v1.0/parameter-groups/{parameterGroupId}/copy
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| parameterGroupName | String | Y | 파라미터 그룹을 식별할 수 있는 이름 |
+| description | String | N | 파라미터 그룹에 대한 추가 정보 |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| parameterGroupId | Body | UUID | 파라미터 그룹의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4776,16 +5061,15 @@ POST /v1.0/parameter-groups/{parameterGroupId}/copy
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| parameterGroupId | UUID | 파라미터 그룹의 식별자 |
 
 ---
 
 ### 파라미터 그룹 내 파라미터 수정하기
-
-```http
-PUT /v1.0/parameter-groups/{parameterGroupId}/parameters
-```
 
 #### 필요 권한
 
@@ -4795,15 +5079,20 @@ PUT /v1.0/parameter-groups/{parameterGroupId}/parameters
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O | 파라미터 그룹 ID |
-| modifiedParameters | Body | Array | O | 변경할 파라미터 목록 |
-| modifiedParameters.parameterName | Body | String | O | 파라미터 이름 |
-| modifiedParameters.value | Body | String | O | 변경할 파라미터 값 |
+```http
+PUT /v1.0/parameter-groups/{parameterGroupId}/parameters
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y | 파라미터 그룹 ID |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4816,8 +5105,13 @@ PUT /v1.0/parameter-groups/{parameterGroupId}/parameters
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| modifiedParameters | Array | Y | 변경할 파라미터 목록 |
+| modifiedParameters.parameterName | String | Y | 파라미터 이름 |
+| modifiedParameters.value | String | Y | 변경할 파라미터 값 |
 
 #### 응답
 
@@ -4827,10 +5121,6 @@ PUT /v1.0/parameter-groups/{parameterGroupId}/parameters
 
 ### 파라미터 그룹 재설정하기
 
-```http
-PUT /v1.0/parameter-groups/{parameterGroupId}/reset
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -4839,11 +5129,19 @@ PUT /v1.0/parameter-groups/{parameterGroupId}/reset
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+PUT /v1.0/parameter-groups/{parameterGroupId}/reset
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O | 파라미터 그룹 ID |
+| parameterGroupId | URL | UUID | Y | 파라미터 그룹 ID |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
@@ -4855,10 +5153,6 @@ PUT /v1.0/parameter-groups/{parameterGroupId}/reset
 
 ### 사용자 그룹 목록 보기
 
-```http
-GET /v1.0/user-groups
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -4867,21 +5161,18 @@ GET /v1.0/user-groups
 
 #### 요청
 
+```http
+GET /v1.0/user-groups
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| userGroups | Body | Array | 사용자 그룹 정보 |
-| userGroups.userGroupId | Body | UUID | 사용자 그룹의 식별자 |
-| userGroups.userGroupName | Body | String | 사용자 그룹을 식별할 수 있는 이름 |
-| userGroups.userGroupStatus | Body | Enum | 사용자 그룹의 현재 상태<br/>- CREATED<br/>- DELETED |
-| userGroups.createdYmdt | Body | DateTime | 생성 일시 |
-| userGroups.updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4902,16 +5193,20 @@ GET /v1.0/user-groups
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| userGroups | Array | 사용자 그룹 정보 |
+| userGroups.userGroupId | UUID | 사용자 그룹의 식별자 |
+| userGroups.userGroupName | String | 사용자 그룹을 식별할 수 있는 이름 |
+| userGroups.userGroupStatus | Enum | 사용자 그룹의 현재 상태<br/>- CREATED<br/>- DELETED |
+| userGroups.createdYmdt | DateTime | 생성 일시 |
+| userGroups.updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
 ### 사용자 그룹 생성하기
-
-```http
-POST /v1.0/user-groups
-```
 
 #### 필요 권한
 
@@ -4921,14 +5216,14 @@ POST /v1.0/user-groups
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| userGroupName | Body | String | O | 사용자 그룹을 식별할 수 있는 이름 |
-| memberIds | Body | Array | O | 프로젝트 멤버의 식별자 목록 |
-| selectAllYN | Body | Boolean | O | 프로젝트 멤버 전체 유무<br/>- 기본값: `false` |
+```http
+POST /v1.0/user-groups
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4938,17 +5233,18 @@ POST /v1.0/user-groups
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| userGroupName | String | Y | 사용자 그룹을 식별할 수 있는 이름 |
+| memberIds | Array | Y | 프로젝트 멤버의 식별자 목록 |
+| selectAllYN | Boolean | Y | 프로젝트 멤버 전체 유무<br/>- 기본값: `false` |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| userGroupId | Body | UUID | 사용자 그룹의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4961,16 +5257,15 @@ POST /v1.0/user-groups
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| userGroupId | UUID | 사용자 그룹의 식별자 |
 
 ---
 
 ### 사용자 그룹 삭제하기
-
-```http
-DELETE /v1.0/user-groups/{userGroupId}
-```
 
 #### 필요 권한
 
@@ -4980,11 +5275,19 @@ DELETE /v1.0/user-groups/{userGroupId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+DELETE /v1.0/user-groups/{userGroupId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| userGroupId | URL | UUID | O | 사용자 그룹 ID |
+| userGroupId | URL | UUID | Y | 사용자 그룹 ID |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
@@ -4994,10 +5297,6 @@ DELETE /v1.0/user-groups/{userGroupId}
 
 ### 사용자 그룹 상세 보기
 
-```http
-GET /v1.0/user-groups/{userGroupId}
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -5006,27 +5305,24 @@ GET /v1.0/user-groups/{userGroupId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v1.0/user-groups/{userGroupId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| userGroupId | URL | UUID | O | 사용자 그룹 ID |
+| userGroupId | URL | UUID | Y | 사용자 그룹 ID |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| userGroupId | Body | UUID | 사용자 그룹의 식별자 |
-| userGroupName | Body | String | 사용자 그룹을 식별할 수 있는 이름 |
-| userGroupTypeCode | Body | Enum | 사용자 그룹 종류<br/>- ENTIRE: `전체 프로젝트 멤버`<br/>- INDIVIDUAL_MEMBER: `사용자 지정` |
-| userGroupStatus | Body | Enum | 사용자 그룹의 현재 상태<br/>- CREATED<br/>- DELETED |
-| members | Body | Array | 프로젝트 멤버 목록 |
-| members.memberId | Body | UUID | 프로젝트 멤버의 식별자 |
-| createdYmdt | Body | DateTime | 생성 일시 |
-| updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5049,16 +5345,22 @@ GET /v1.0/user-groups/{userGroupId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| userGroupId | UUID | 사용자 그룹의 식별자 |
+| userGroupName | String | 사용자 그룹을 식별할 수 있는 이름 |
+| userGroupTypeCode | Enum | 사용자 그룹 종류<br/>- ENTIRE: `전체 프로젝트 멤버`<br/>- INDIVIDUAL_MEMBER: `사용자 지정` |
+| userGroupStatus | Enum | 사용자 그룹의 현재 상태<br/>- CREATED<br/>- DELETED |
+| members | Array | 프로젝트 멤버 목록 |
+| members.memberId | UUID | 프로젝트 멤버의 식별자 |
+| createdYmdt | DateTime | 생성 일시 |
+| updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
 ### 사용자 그룹 수정하기
-
-```http
-PUT /v1.0/user-groups/{userGroupId}
-```
 
 #### 필요 권한
 
@@ -5068,15 +5370,20 @@ PUT /v1.0/user-groups/{userGroupId}
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| userGroupId | URL | UUID | O | 사용자 그룹 ID |
-| userGroupName | Body | String | X | 사용자 그룹을 식별할 수 있는 이름 |
-| memberIds | Body | Array | X | 프로젝트 멤버의 식별자 목록 |
-| selectAllYN | Body | Boolean | O | 프로젝트 멤버 전체 유무<br/>- 기본값: `false` |
+```http
+PUT /v1.0/user-groups/{userGroupId}
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | Y | 사용자 그룹 ID |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5086,8 +5393,13 @@ PUT /v1.0/user-groups/{userGroupId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| userGroupName | String | N | 사용자 그룹을 식별할 수 있는 이름 |
+| memberIds | Array | N | 프로젝트 멤버의 식별자 목록 |
+| selectAllYN | Boolean | Y | 프로젝트 멤버 전체 유무<br/>- 기본값: `false` |
 
 #### 응답
 
@@ -5099,10 +5411,6 @@ PUT /v1.0/user-groups/{userGroupId}
 
 ### 알림 그룹 목록 보기
 
-```http
-GET /v1.0/notification-groups
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -5111,24 +5419,18 @@ GET /v1.0/notification-groups
 
 #### 요청
 
+```http
+GET /v1.0/notification-groups
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| notificationGroups | Body | Array |  |
-| notificationGroups.notificationGroupId | Body | UUID | 알림 그룹의 식별자 |
-| notificationGroups.notificationGroupName | Body | String | 알림 그룹을 식별할 수 있는 이름 |
-| notificationGroups.notificationGroupStatus | Body | Enum | 알림 그룹의 현재 상태<br/>- CREATED: `생성됨`<br/>- DELETED: `삭제됨` |
-| notificationGroups.notifyEmail | Body | Boolean | 이메일 알림 여부 |
-| notificationGroups.notifySms | Body | Boolean | SMS 알림 여부 |
-| notificationGroups.isEnabled | Body | Boolean | 활성화 여부 |
-| notificationGroups.createdYmdt | Body | DateTime | 생성 일시 |
-| notificationGroups.updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5152,16 +5454,23 @@ GET /v1.0/notification-groups
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| notificationGroups | Array |  |
+| notificationGroups.notificationGroupId | UUID | 알림 그룹의 식별자 |
+| notificationGroups.notificationGroupName | String | 알림 그룹을 식별할 수 있는 이름 |
+| notificationGroups.notificationGroupStatus | Enum | 알림 그룹의 현재 상태<br/>- CREATED: `생성됨`<br/>- DELETED: `삭제됨` |
+| notificationGroups.notifyEmail | Boolean | 이메일 알림 여부 |
+| notificationGroups.notifySms | Boolean | SMS 알림 여부 |
+| notificationGroups.isEnabled | Boolean | 활성화 여부 |
+| notificationGroups.createdYmdt | DateTime | 생성 일시 |
+| notificationGroups.updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
 ### 알림 그룹 생성하기
-
-```http
-POST /v1.0/notification-groups
-```
 
 #### 필요 권한
 
@@ -5171,17 +5480,14 @@ POST /v1.0/notification-groups
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| notificationGroupName | Body | String | O | 알림 그룹을 식별할 수 있는 이름 |
-| notifyEmail | Body | Boolean | X | 이메일 알림 여부<br/>- 기본값: `true` |
-| notifySms | Body | Boolean | X | SMS 알림 여부<br/>- 기본값: `true` |
-| isEnabled | Body | Boolean | X | 활성화 여부<br/>- 기본값: `true` |
-| dbInstanceIds | Body | Array | O | 감시 대상 DB 인스턴스의 식별자 목록 |
-| userGroupIds | Body | Array | O | 사용자 그룹의 식별자 목록 |
+```http
+POST /v1.0/notification-groups
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5194,17 +5500,21 @@ POST /v1.0/notification-groups
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| notificationGroupName | String | Y | 알림 그룹을 식별할 수 있는 이름 |
+| notifyEmail | Boolean | N | 이메일 알림 여부<br/>- 기본값: `true` |
+| notifySms | Boolean | N | SMS 알림 여부<br/>- 기본값: `true` |
+| isEnabled | Boolean | N | 활성화 여부<br/>- 기본값: `true` |
+| dbInstanceIds | Array | Y | 감시 대상 DB 인스턴스의 식별자 목록 |
+| userGroupIds | Array | Y | 사용자 그룹의 식별자 목록 |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| notificationGroupId | Body | UUID | 알림 그룹의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5217,16 +5527,15 @@ POST /v1.0/notification-groups
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| notificationGroupId | UUID | 알림 그룹의 식별자 |
 
 ---
 
 ### 알림 그룹 삭제하기
-
-```http
-DELETE /v1.0/notification-groups/{notificationGroupId}
-```
 
 #### 필요 권한
 
@@ -5236,11 +5545,19 @@ DELETE /v1.0/notification-groups/{notificationGroupId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+DELETE /v1.0/notification-groups/{notificationGroupId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| notificationGroupId | URL | UUID | O | 알림 그룹의 식별자 |
+| notificationGroupId | URL | UUID | Y | 알림 그룹의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
@@ -5250,10 +5567,6 @@ DELETE /v1.0/notification-groups/{notificationGroupId}
 
 ### 알림 그룹 상세 보기
 
-```http
-GET /v1.0/notification-groups/{notificationGroupId}
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -5262,33 +5575,24 @@ GET /v1.0/notification-groups/{notificationGroupId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v1.0/notification-groups/{notificationGroupId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| notificationGroupId | URL | UUID | O | 알림 그룹의 식별자 |
+| notificationGroupId | URL | UUID | Y | 알림 그룹의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| notificationGroupId | Body | UUID | 알림 그룹의 식별자 |
-| notificationGroupName | Body | String | 알림 그룹을 식별할 수 있는 이름 |
-| notificationGroupStatus | Body | Enum | 알림 그룹의 현재 상태<br/>- CREATED: `생성됨`<br/>- DELETED: `삭제됨` |
-| notifyEmail | Body | Boolean | 이메일 알림 여부 |
-| notifySms | Body | Boolean | SMS 알림 여부 |
-| isEnabled | Body | Boolean | 활성화 여부 |
-| dbInstances | Body | Array | 감시 대상 DB 인스턴스 목록 |
-| dbInstances.dbInstanceId | Body | UUID | DB 인스턴스의 식별자 |
-| dbInstances.dbInstanceName | Body | String | DB 인스턴스를 식별할 수 있는 이름 |
-| userGroups | Body | Array | 사용자 그룹 목록 |
-| userGroups.userGroupId | Body | UUID | 사용자 그룹의 식별자 |
-| userGroups.userGroupName | Body | String | 사용자 그룹을 식별할 수 있는 이름 |
-| createdYmdt | Body | DateTime | 생성 일시 |
-| updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5320,16 +5624,28 @@ GET /v1.0/notification-groups/{notificationGroupId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| notificationGroupId | UUID | 알림 그룹의 식별자 |
+| notificationGroupName | String | 알림 그룹을 식별할 수 있는 이름 |
+| notificationGroupStatus | Enum | 알림 그룹의 현재 상태<br/>- CREATED: `생성됨`<br/>- DELETED: `삭제됨` |
+| notifyEmail | Boolean | 이메일 알림 여부 |
+| notifySms | Boolean | SMS 알림 여부 |
+| isEnabled | Boolean | 활성화 여부 |
+| dbInstances | Array | 감시 대상 DB 인스턴스 목록 |
+| dbInstances.dbInstanceId | UUID | DB 인스턴스의 식별자 |
+| dbInstances.dbInstanceName | String | DB 인스턴스를 식별할 수 있는 이름 |
+| userGroups | Array | 사용자 그룹 목록 |
+| userGroups.userGroupId | UUID | 사용자 그룹의 식별자 |
+| userGroups.userGroupName | String | 사용자 그룹을 식별할 수 있는 이름 |
+| createdYmdt | DateTime | 생성 일시 |
+| updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
 ### 알림 그룹 수정하기
-
-```http
-PUT /v1.0/notification-groups/{notificationGroupId}
-```
 
 #### 필요 권한
 
@@ -5339,18 +5655,20 @@ PUT /v1.0/notification-groups/{notificationGroupId}
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| notificationGroupId | URL | UUID | O | 알림 그룹의 식별자 |
-| notificationGroupName | Body | String | X | 알림 그룹을 식별할 수 있는 이름 |
-| notifyEmail | Body | Boolean | X | 이메일 알림 여부<br/>- 기본값: `false` |
-| notifySms | Body | Boolean | X | SMS 알림 여부<br/>- 기본값: `false` |
-| isEnabled | Body | Boolean | X | 활성화 여부<br/>- 기본값: `false` |
-| dbInstanceIds | Body | Array | O | 감시 대상 DB 인스턴스의 식별자 목록 |
-| userGroupIds | Body | Array | O | 사용자 그룹의 식별자 목록 |
+```http
+PUT /v1.0/notification-groups/{notificationGroupId}
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | Y | 알림 그룹의 식별자 |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5363,8 +5681,16 @@ PUT /v1.0/notification-groups/{notificationGroupId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| notificationGroupName | String | N | 알림 그룹을 식별할 수 있는 이름 |
+| notifyEmail | Boolean | N | 이메일 알림 여부<br/>- 기본값: `false` |
+| notifySms | Boolean | N | SMS 알림 여부<br/>- 기본값: `false` |
+| isEnabled | Boolean | N | 활성화 여부<br/>- 기본값: `false` |
+| dbInstanceIds | Array | Y | 감시 대상 DB 인스턴스의 식별자 목록 |
+| userGroupIds | Array | Y | 사용자 그룹의 식별자 목록 |
 
 #### 응답
 
@@ -5374,10 +5700,6 @@ PUT /v1.0/notification-groups/{notificationGroupId}
 
 ### 감시 설정 목록 보기
 
-```http
-GET /v1.0/notification-groups/{notificationGroupId}/watchdogs
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -5386,26 +5708,24 @@ GET /v1.0/notification-groups/{notificationGroupId}/watchdogs
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v1.0/notification-groups/{notificationGroupId}/watchdogs
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| notificationGroupId | URL | UUID | O | 알림 그룹의 식별자 |
+| notificationGroupId | URL | UUID | Y | 알림 그룹의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| notificationWatchdogs | Body | Array | 감시 설정 정보 |
-| notificationWatchdogs.watchdogId | Body | UUID | 감시 설정의 식별자 |
-| notificationWatchdogs.metricName | Body | String | 감시 대상 성능 지표 |
-| notificationWatchdogs.comparisonOperator | Body | Enum | 감시 대상 비교 방법<br/>- LE: `<=`<br/>- LT: `<`<br/>- GE: `>=`<br/>- GT: `>` |
-| notificationWatchdogs.threshold | Body | Number | 감시 대상 임곗값 |
-| notificationWatchdogs.duration | Body | Number | 감시 대상 지속 시간 |
-| notificationWatchdogs.createdYmdt | Body | DateTime | 생성 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5427,16 +5747,21 @@ GET /v1.0/notification-groups/{notificationGroupId}/watchdogs
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| notificationWatchdogs | Array | 감시 설정 정보 |
+| notificationWatchdogs.watchdogId | UUID | 감시 설정의 식별자 |
+| notificationWatchdogs.metricName | String | 감시 대상 성능 지표 |
+| notificationWatchdogs.comparisonOperator | Enum | 감시 대상 비교 방법<br/>- LE: `<=`<br/>- LT: `<`<br/>- GE: `>=`<br/>- GT: `>` |
+| notificationWatchdogs.threshold | Number | 감시 대상 임곗값 |
+| notificationWatchdogs.duration | Number | 감시 대상 지속 시간 |
+| notificationWatchdogs.createdYmdt | DateTime | 생성 일시 |
 
 ---
 
 ### 감시 설정 생성하기
-
-```http
-POST /v1.0/notification-groups/{notificationGroupId}/watchdogs
-```
 
 #### 필요 권한
 
@@ -5446,16 +5771,20 @@ POST /v1.0/notification-groups/{notificationGroupId}/watchdogs
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| notificationGroupId | URL | UUID | O | 알림 그룹의 식별자 |
-| metricName | Body | String | O | 감시 대상 성능 지표 |
-| comparisonOperator | Body | Enum | O | 감시 대상 비교 방법<br/>- LE: `<=`<br/>- LT: `<`<br/>- GE: `>=`<br/>- GT: `>` |
-| threshold | Body | Number | O | 감시 대상 임곗값<br/>- 최솟값: `0` |
-| duration | Body | Number | O | 감시 대상 지속 시간 (분)<br/>- 최솟값: `0` |
+```http
+POST /v1.0/notification-groups/{notificationGroupId}/watchdogs
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | Y | 알림 그룹의 식별자 |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5466,17 +5795,19 @@ POST /v1.0/notification-groups/{notificationGroupId}/watchdogs
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| metricName | String | Y | 감시 대상 성능 지표 |
+| comparisonOperator | Enum | Y | 감시 대상 비교 방법<br/>- LE: `<=`<br/>- LT: `<`<br/>- GE: `>=`<br/>- GT: `>` |
+| threshold | Number | Y | 감시 대상 임곗값<br/>- 최솟값: `0` |
+| duration | Number | Y | 감시 대상 지속 시간 (분)<br/>- 최솟값: `0` |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| watchdogId | Body | UUID | 감시 설정의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5489,31 +5820,38 @@ POST /v1.0/notification-groups/{notificationGroupId}/watchdogs
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| watchdogId | UUID | 감시 설정의 식별자 |
 
 ---
 
-### 알림 그룹 삭제하기
-
-```http
-DELETE /v1.0/notification-groups/{notificationGroupId}/watchdogs/{watchdogId}
-```
+### 감시 설정 삭제하기
 
 #### 필요 권한
 
 | 권한명 | 설명 |
 |-----|-----|
-| RDSforPostgreSQL:NotificationWatchdog.Delete | 알림 그룹 삭제하기 |
+| RDSforPostgreSQL:NotificationWatchdog.Delete | 감시 설정 삭제하기 |
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+DELETE /v1.0/notification-groups/{notificationGroupId}/watchdogs/{watchdogId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| notificationGroupId | URL | UUID | O | 알림 그룹의 식별자 |
-| watchdogId | URL | UUID | O | 감시 설정의 식별자 |
+| notificationGroupId | URL | UUID | Y | 알림 그룹의 식별자 |
+| watchdogId | URL | UUID | Y | 감시 설정의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
@@ -5523,10 +5861,6 @@ DELETE /v1.0/notification-groups/{notificationGroupId}/watchdogs/{watchdogId}
 
 ### 감시 설정 수정하기
 
-```http
-PUT /v1.0/notification-groups/{notificationGroupId}/watchdogs/{watchdogId}
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -5535,17 +5869,21 @@ PUT /v1.0/notification-groups/{notificationGroupId}/watchdogs/{watchdogId}
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| notificationGroupId | URL | UUID | O | 알림 그룹의 식별자 |
-| watchdogId | URL | UUID | O | 감시 설정의 식별자 |
-| metricName | Body | String | O | 감시 대상 성능 지표 |
-| comparisonOperator | Body | Enum | O | 감시 대상 비교 방법<br/>- LE: `<=`<br/>- LT: `<`<br/>- GE: `>=`<br/>- GT: `>` |
-| threshold | Body | Number | O | 감시 대상 임곗값<br/>- 최솟값: `0` |
-| duration | Body | Number | O | 감시 대상 지속 시간 (분)<br/>- 최솟값: `0` |
+```http
+PUT /v1.0/notification-groups/{notificationGroupId}/watchdogs/{watchdogId}
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | Y | 알림 그룹의 식별자 |
+| watchdogId | URL | UUID | Y | 감시 설정의 식별자 |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5556,8 +5894,14 @@ PUT /v1.0/notification-groups/{notificationGroupId}/watchdogs/{watchdogId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| metricName | String | Y | 감시 대상 성능 지표 |
+| comparisonOperator | Enum | Y | 감시 대상 비교 방법<br/>- LE: `<=`<br/>- LT: `<`<br/>- GE: `>=`<br/>- GT: `>` |
+| threshold | Number | Y | 감시 대상 임곗값<br/>- 최솟값: `0` |
+| duration | Number | Y | 감시 대상 지속 시간 (분)<br/>- 최솟값: `0` |
 
 #### 응답
 
@@ -5569,10 +5913,6 @@ PUT /v1.0/notification-groups/{notificationGroupId}/watchdogs/{watchdogId}
 
 ### 통계 정보 조회
 
-```http
-GET /v1.0/metric-statistics
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -5580,6 +5920,12 @@ GET /v1.0/metric-statistics
 | RDSforPostgreSQL:Metric.List | 통계 정보 조회 |
 
 #### 요청
+
+```http
+GET /v1.0/metric-statistics
+```
+
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
@@ -5591,10 +5937,6 @@ GET /v1.0/metric-statistics
 
 ### 성능 지표 목록 보기
 
-```http
-GET /v1.0/metrics
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -5603,18 +5945,18 @@ GET /v1.0/metrics
 
 #### 요청
 
+```http
+GET /v1.0/metrics
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| metrics | Body | Array | Metric 목록 |
-| metrics.metricName | Body | String | 조회 지표 유형 |
-| metrics.unit | Body | String | 측정값 단위 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5632,8 +5974,13 @@ GET /v1.0/metrics
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| metrics | Array | Metric 목록 |
+| metrics.metricName | String | 조회 지표 유형 |
+| metrics.unit | String | 측정값 단위 |
 
 ---
 
@@ -5654,10 +6001,6 @@ GET /v1.0/metrics
 
 ### 구독 가능한 이벤트 코드 목록 보기
 
-```http
-GET /v1.0/event-codes
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -5666,18 +6009,18 @@ GET /v1.0/event-codes
 
 #### 요청
 
+```http
+GET /v1.0/event-codes
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| eventCodes | Body | Array | 이벤트 코드 목록 |
-| eventCodes.eventCode | Body | Enum | 이벤트 코드 |
-| eventCodes.eventCategoryType | Body | Enum | 이벤트 카테고리 유형<br/>- ALL: `전체`<br/>- DB_INSTANCE: `DB 인스턴스로 발생한 이벤트`<br/>- DB_SECURITY_GROUP: `DB 보안 그룹으로 발생한 이벤트`<br/>- MONITORING: `모니터링으로 발생한 이벤트`<br/>- JOB: `JOB으로 발생한 이벤트`<br/>- BACKUP: `백업으로 발생한 이벤트`<br/>- TENANT: `테넌트로 발생한 이벤트` |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5695,16 +6038,17 @@ GET /v1.0/event-codes
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| eventCodes | Array | 이벤트 코드 목록 |
+| eventCodes.eventCode | Enum | 이벤트 코드 |
+| eventCodes.eventCategoryType | Enum | 이벤트 카테고리 유형<br/>- ALL: `전체`<br/>- DB_INSTANCE: `DB 인스턴스로 발생한 이벤트`<br/>- DB_SECURITY_GROUP: `DB 보안 그룹으로 발생한 이벤트`<br/>- MONITORING: `모니터링으로 발생한 이벤트`<br/>- JOB: `JOB으로 발생한 이벤트`<br/>- BACKUP: `백업으로 발생한 이벤트`<br/>- TENANT: `테넌트로 발생한 이벤트` |
 
 ---
 
 ### 이벤트 목록 보기
-
-```http
-GET /v1.0/events
-```
 
 #### 필요 권한
 
@@ -5714,25 +6058,18 @@ GET /v1.0/events
 
 #### 요청
 
+```http
+GET /v1.0/events
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | 전체 이벤트 목록 수 |
-| events | Body | Array | 이벤트 목록 |
-| events.eventCategoryType | Body | Enum | 이벤트 카테고리 유형<br/>- ALL: `전체`<br/>- DB_INSTANCE: `DB 인스턴스로 발생한 이벤트`<br/>- DB_SECURITY_GROUP: `DB 보안 그룹으로 발생한 이벤트`<br/>- MONITORING: `모니터링으로 발생한 이벤트`<br/>- JOB: `JOB으로 발생한 이벤트`<br/>- BACKUP: `백업으로 발생한 이벤트`<br/>- TENANT: `테넌트로 발생한 이벤트` |
-| events.eventCode | Body | Enum | 발생한 이벤트의 유형 |
-| events.sourceId | Body | UUID | 이벤트 소스의 식별자 |
-| events.sourceName | Body | String | 이벤트 소스를 식별할 수 있는 이름 |
-| events.messages | Body | Array | 이벤트 메세지 목록 |
-| events.messages.langCode | Body | Enum | 언어 코드<br/>- KO<br/>- EN<br/>- JA<br/>- ZH |
-| events.messages.message | Body | String | 이벤트 메세지 |
-| events.eventYmdt | Body | DateTime | 이벤트 발생 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5760,8 +6097,20 @@ GET /v1.0/events
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| totalCounts | Number | 전체 이벤트 목록 수 |
+| events | Array | 이벤트 목록 |
+| events.eventCategoryType | Enum | 이벤트 카테고리 유형<br/>- ALL: `전체`<br/>- DB_INSTANCE: `DB 인스턴스로 발생한 이벤트`<br/>- DB_SECURITY_GROUP: `DB 보안 그룹으로 발생한 이벤트`<br/>- MONITORING: `모니터링으로 발생한 이벤트`<br/>- JOB: `JOB으로 발생한 이벤트`<br/>- BACKUP: `백업으로 발생한 이벤트`<br/>- TENANT: `테넌트로 발생한 이벤트` |
+| events.eventCode | Enum | 발생한 이벤트의 유형 |
+| events.sourceId | UUID | 이벤트 소스의 식별자 |
+| events.sourceName | String | 이벤트 소스를 식별할 수 있는 이름 |
+| events.messages | Array | 이벤트 메세지 목록 |
+| events.messages.langCode | Enum | 언어 코드<br/>- KO<br/>- EN<br/>- JA<br/>- ZH |
+| events.messages.message | String | 이벤트 메세지 |
+| events.eventYmdt | DateTime | 이벤트 발생 일시 |
 
 ---
 

--- a/ko/api-guide-v1.0.md
+++ b/ko/api-guide-v1.0.md
@@ -205,8 +205,8 @@ GET /v1.0/project/members
         {
             "memberId": "550e8400-e29b-41d4-a716-446655440000",
             "memberName": "memberName-example",
-            "emailAddress": "emailAddress-example",
-            "phoneNumber": "phoneNumber-example"
+            "emailAddress": "user@example.com",
+            "phoneNumber": "010-1234-5678"
         }
     ]
 }
@@ -308,7 +308,7 @@ GET /v1.0/network/subnets
         {
             "subnetId": "550e8400-e29b-41d4-a716-446655440000",
             "subnetName": "subnetName-example",
-            "subnetCidr": "subnetCidr-example",
+            "subnetCidr": "192.168.0.0/24",
             "usingGateway": false,
             "availableIpCount": 1
         }
@@ -956,7 +956,7 @@ POST /v1.0/db-instances
 | backup.backupPeriod | Body | Number | O | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
 | backup.backupRetryCount | Body | Number | X | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
 | backup.backupSchedules | Body | Array | O | 백업 스케쥴 정보 |
-| backup.backupSchedules.backupWndBgnTime | Body | String | O | 백업 시작 시각 |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | O | 백업 시작 시각 |
 | backup.backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 
 <details><summary>예시</summary>
@@ -995,7 +995,7 @@ POST /v1.0/db-instances
         "backupRetryCount": 0,
         "backupSchedules": [
             {
-                "backupWndBgnTime": "backupWndBgnTime-example",
+                "backupWndBgnTime": "00:00:00",
                 "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
@@ -1069,7 +1069,7 @@ POST /v1.0/db-instances/restore-from-obs
 | backup.backupRetryCount | Body | Number | X | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
 | backup.replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)`<br/>- KR2: `한국(평촌)` |
 | backup.backupSchedules | Body | Array | O | 백업 스케쥴 목록 |
-| backup.backupSchedules.backupWndBgnTime | Body | String | O | 백업 시작 시각 |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | O | 백업 시작 시각 |
 | backup.backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 | restore | Body | Object | O | 복원 정보 객체 |
 | restore.tenantId | Body | String | O | 백업이 저장된 오브젝트 스토리지의 테넌트 ID |
@@ -1113,7 +1113,7 @@ POST /v1.0/db-instances/restore-from-obs
         "replicationRegion": "KR1",
         "backupSchedules": [
             {
-                "backupWndBgnTime": "backupWndBgnTime-example",
+                "backupWndBgnTime": "00:00:00",
                 "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
@@ -1555,7 +1555,7 @@ GET /v1.0/db-instances/{dbInstanceId}/backup-info
 | backupPeriod | Body | Number | 백업 보관 기간(일) |
 | backupRetryCount | Body | Number | 백업 재시도 횟수 |
 | backupSchedules | Body | Array | 백업 스케쥴 목록 |
-| backupSchedules.backupWndBgnTime | Body | String | 백업 시작 시각 |
+| backupSchedules.backupWndBgnTime | Body | Time | 백업 시작 시각 |
 | backupSchedules.backupWndDuration | Body | Enum | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 
 <details><summary>예시</summary>
@@ -1574,7 +1574,7 @@ GET /v1.0/db-instances/{dbInstanceId}/backup-info
     "backupRetryCount": 1,
     "backupSchedules": [
         {
-            "backupWndBgnTime": "backupWndBgnTime-example",
+            "backupWndBgnTime": "00:00:00",
             "backupWndDuration": "HALF_AN_HOUR"
         }
     ]
@@ -1608,7 +1608,7 @@ PUT /v1.0/db-instances/{dbInstanceId}/backup-info
 | backupPeriod | Body | Number | X | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
 | backupRetryCount | Body | Number | X | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
 | backupSchedules | Body | Array | X | 백업 스케쥴 목록 |
-| backupSchedules.backupWndBgnTime | Body | String | O | 백업 시작 시각 |
+| backupSchedules.backupWndBgnTime | Body | Time | O | 백업 시작 시각 |
 | backupSchedules.backupWndDuration | Body | Enum | O | 백업 윈도우<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 
 <details><summary>예시</summary>
@@ -1622,7 +1622,7 @@ PUT /v1.0/db-instances/{dbInstanceId}/backup-info
     "backupRetryCount": 0,
     "backupSchedules": [
         {
-            "backupWndBgnTime": "backupWndBgnTime-example",
+            "backupWndBgnTime": "00:00:00",
             "backupWndDuration": "HALF_AN_HOUR"
         }
     ]
@@ -2871,7 +2871,7 @@ GET /v1.0/db-instances/{dbInstanceId}/maintenance-info
 |-----|-----|-----|-----|
 | allowAutoMaintenance | Body | Boolean | 자동 유지보수 허용 여부 |
 | useAutoStorageCleanup | Body | Boolean | 자동 스토리지 정리 사용 여부 |
-| maintWndBgnTime | Body | String | 자동 유지보수 시작 시간 |
+| maintWndBgnTime | Body | Time | 자동 유지보수 시작 시간 |
 | maintWndDuration | Body | Enum | 유지보수 윈도우<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 | logRetentionPeriod | Body | Number | 로그 보관 기간 (일) |
 
@@ -2887,7 +2887,7 @@ GET /v1.0/db-instances/{dbInstanceId}/maintenance-info
     },
     "allowAutoMaintenance": false,
     "useAutoStorageCleanup": false,
-    "maintWndBgnTime": "maintWndBgnTime-example",
+    "maintWndBgnTime": "00:00:00",
     "maintWndDuration": "HALF_AN_HOUR",
     "logRetentionPeriod": 1
 }
@@ -2917,7 +2917,7 @@ PUT /v1.0/db-instances/{dbInstanceId}/maintenance-info
 | dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
 | allowAutoMaintenance | Body | Boolean | X | 자동 유지보수 허용 여부 |
 | useAutoStorageCleanup | Body | Boolean | X | 자동 스토리지 정리 사용 여부 |
-| maintWndBgnTime | Body | String | X | 자동 유지보수 시작 시간 |
+| maintWndBgnTime | Body | Time | X | 자동 유지보수 시작 시간 |
 | maintWndDuration | Body | Enum | X | 유지보수 윈도우<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 | logRetentionPeriod | Body | Number | X | 로그 보관 기간 (일)<br/>- 최솟값: `1`<br/>- 최댓값: `30` |
 
@@ -2928,7 +2928,7 @@ PUT /v1.0/db-instances/{dbInstanceId}/maintenance-info
 {
     "allowAutoMaintenance": false,
     "useAutoStorageCleanup": false,
-    "maintWndBgnTime": "maintWndBgnTime-example",
+    "maintWndBgnTime": "00:00:00",
     "maintWndDuration": "HALF_AN_HOUR",
     "logRetentionPeriod": 1
 }
@@ -3011,14 +3011,14 @@ GET /v1.0/db-instances/{dbInstanceId}/network-info
     "subnet": {
         "subnetId": "550e8400-e29b-41d4-a716-446655440000",
         "subnetName": "subnetName-example",
-        "subnetCidr": "subnetCidr-example",
+        "subnetCidr": "192.168.0.0/24",
         "publicAccessible": false
     },
     "endPoints": [
         {
             "domain": "domain-example",
-            "ipAddress": "ipAddress-example",
-            "endPointType": "endPointType-example"
+            "ipAddress": "192.168.0.1",
+            "endPointType": "https://example.com"
         }
     ]
 }
@@ -3379,7 +3379,7 @@ POST /v1.0/db-instances/{dbInstanceId}/restore
 | backup.backupRetryCount | Body | Number | X | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
 | backup.replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)`<br/>- KR2: `한국(평촌)` |
 | backup.backupSchedules | Body | Array | O | 백업 스케쥴 목록 |
-| backup.backupSchedules.backupWndBgnTime | Body | String | O | 백업 시작 시각 |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | O | 백업 시작 시각 |
 | backup.backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 | restore | Body | Object | O | 복원 정보 객체 |
 | restore.restoreType | Body | Enum | O | 복원 타입<br/>- BACKUP: `기존에 생성한 백업을 이용한 복원`<br/>- TIMESTAMP: `복원 가능한 시간 이내의 시간을 이용한 시점 복원` |
@@ -3420,7 +3420,7 @@ POST /v1.0/db-instances/{dbInstanceId}/restore
         "replicationRegion": "KR1",
         "backupSchedules": [
             {
-                "backupWndBgnTime": "backupWndBgnTime-example",
+                "backupWndBgnTime": "00:00:00",
                 "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
@@ -3891,7 +3891,7 @@ POST /v1.0/backups/{backupId}/restore
 | backup.backupPeriod | Body | Number | O | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
 | backup.backupRetryCount | Body | Number | X | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
 | backup.backupSchedules | Body | Array | O | 백업 스케쥴 목록 |
-| backup.backupSchedules.backupWndBgnTime | Body | String | O | 백업 시작 시간 |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | O | 백업 시작 시간 |
 | backup.backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 
 <details><summary>예시</summary>
@@ -3926,7 +3926,7 @@ POST /v1.0/backups/{backupId}/restore
         "backupRetryCount": 0,
         "backupSchedules": [
             {
-                "backupWndBgnTime": "backupWndBgnTime-example",
+                "backupWndBgnTime": "00:00:00",
                 "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
@@ -4075,7 +4075,7 @@ POST /v1.0/db-security-groups
                 "minPort": 1,
                 "maxPort": 1
             },
-            "cidr": "cidr-example",
+            "cidr": "192.168.0.0/24",
             "description": "description-example"
         }
     ]
@@ -4208,7 +4208,7 @@ GET /v1.0/db-security-groups/{dbSecurityGroupId}
                     "minPort": 1,
                     "maxPort": 1
                 },
-                "cidr": "cidr-example",
+                "cidr": "192.168.0.0/24",
                 "createdYmdt": "2023-12-31T15:00:00+09:00",
                 "updatedYmdt": "2023-12-31T15:00:00+09:00"
             }
@@ -4347,7 +4347,7 @@ POST /v1.0/db-security-groups/{dbSecurityGroupId}/rules
         "minPort": 1,
         "maxPort": 1
     },
-    "cidr": "cidr-example",
+    "cidr": "192.168.0.0/24",
     "description": "description-example"
 }
 ```
@@ -4419,7 +4419,7 @@ PUT /v1.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
         "minPort": 1,
         "maxPort": 1
     },
-    "cidr": "cidr-example",
+    "cidr": "192.168.0.0/24",
     "description": "description-example"
 }
 ```

--- a/ko/api-guide-v1.0.md
+++ b/ko/api-guide-v1.0.md
@@ -132,7 +132,7 @@ GET /v1.0/db-flavors
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
 | dbFlavors | Body | Array | DB 인스턴스 사양 정보 |
-| dbFlavors.dbFlavorId | Body | String | DB 인스턴스 사양의 식별자 |
+| dbFlavors.dbFlavorId | Body | UUID | DB 인스턴스 사양의 식별자 |
 | dbFlavors.dbFlavorName | Body | String | DB 인스턴스 사양명 |
 | dbFlavors.ram | Body | Number | 메모리 용량(MB) |
 | dbFlavors.vcpus | Body | Number | CPU 코어 수 |
@@ -186,7 +186,7 @@ GET /v1.0/project/members
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
 | projectMembers | Body | Array | 프로젝트 멤버 정보 |
-| projectMembers.memberId | Body | String | 프로젝트 멤버의 식별자 |
+| projectMembers.memberId | Body | UUID | 프로젝트 멤버의 식별자 |
 | projectMembers.memberName | Body | String | 프로젝트 멤버의 이름 |
 | projectMembers.emailAddress | Body | String | 프로젝트 멤버의 이메일 주소 |
 | projectMembers.phoneNumber | Body | String | 프로젝트 멤버의 전화번호 |
@@ -203,7 +203,7 @@ GET /v1.0/project/members
     },
     "projectMembers": [
         {
-            "memberId": "memberId-example",
+            "memberId": "550e8400-e29b-41d4-a716-446655440000",
             "memberName": "memberName-example",
             "emailAddress": "emailAddress-example",
             "phoneNumber": "phoneNumber-example"
@@ -407,7 +407,7 @@ GET /v1.0/jobs/{jobId}
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| jobId | Body | String | 작업의 식별자 |
+| jobId | Body | UUID | 작업의 식별자 |
 | jobStatus | Body | Enum | 작업의 현재 상태<br/>- DELETED<br/>- CANNOT_PROGRESS<br/>- FAILED<br/>- ERROR<br/>- CANCELED<br/>- INTERRUPTED<br/>- COMPLETED<br/>- COMPLETED_WITH_ERROR<br/>- RUNNING<br/>- PREPARING<br/>- READY<br/>- CREATED<br/>- FAIL_TO_READY<br/>- REGISTERED<br/>- FAIL_TO_REGISTER<br/>- WAIT_TO_REGISTER |
 | resourceRelations | Body | Array | 연관 리소스 목록 |
 | resourceRelations.resourceType | Body | String | 연관 리소스 유형 |
@@ -425,7 +425,7 @@ GET /v1.0/jobs/{jobId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "jobId-example",
+    "jobId": "550e8400-e29b-41d4-a716-446655440000",
     "jobStatus": "DELETED",
     "resourceRelations": [
         {
@@ -466,7 +466,7 @@ GET /v1.0/db-instance-groups
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
 | dbInstanceGroups | Body | Array | DB 인스턴스 그룹 정보 |
-| dbInstanceGroups.dbInstanceGroupId | Body | String | DB 인스턴스 그룹의 식별자 |
+| dbInstanceGroups.dbInstanceGroupId | Body | UUID | DB 인스턴스 그룹의 식별자 |
 | dbInstanceGroups.dbInstanceGroupStatus | Body | Enum | DB 인스턴스 그룹의 현재 형태<br/>- CREATED: `생성됨`<br/>- DELETED: `삭제됨` |
 | dbInstanceGroups.replicationType | Body | Enum | DB 인스턴스 그룹의 복제 형태<br/>- STANDALONE: `고가용성 사용 안함`<br/>- HIGH_AVAILABILITY: `고가용성 사용` |
 | dbInstanceGroups.createdYmdt | Body | DateTime | 생성 일시 |
@@ -484,7 +484,7 @@ GET /v1.0/db-instance-groups
     },
     "dbInstanceGroups": [
         {
-            "dbInstanceGroupId": "dbInstanceGroupId-example",
+            "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
             "dbInstanceGroupStatus": "CREATED",
             "replicationType": "STANDALONE",
             "createdYmdt": "2023-12-31T15:00:00+09:00",
@@ -523,11 +523,11 @@ GET /v1.0/db-instance-groups/{dbInstanceGroupId}
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| dbInstanceGroupId | Body | String | DB 인스턴스 그룹의 식별자 |
+| dbInstanceGroupId | Body | UUID | DB 인스턴스 그룹의 식별자 |
 | dbInstanceGroupStatus | Body | Enum | DB 인스턴스 그룹의 현재 상태<br/>- CREATED: `생성됨`<br/>- DELETED: `삭제됨` |
 | replicationType | Body | Enum | DB 인스턴스 그룹의 복제 형태<br/>- STANDALONE: `고가용성 사용 안함`<br/>- HIGH_AVAILABILITY: `고가용성 사용` |
 | dbInstances | Body | Array | DB 인스턴스 그룹에 속한 DB 인스턴스 목록 |
-| dbInstances.dbInstanceId | Body | String | DB 인스턴스의 식별자 |
+| dbInstances.dbInstanceId | Body | UUID | DB 인스턴스의 식별자 |
 | dbInstances.dbInstanceType | Body | Enum | DB 인스턴스의 역할 타입<br/>- MASTER: `마스터`<br/>- FAILED_MASTER: `장애 마스터`<br/>- CANDIDATE_MASTER: `예비 마스터`<br/>- READ_ONLY_SLAVE: `읽기 복제본` |
 | dbInstances.dbInstanceStatus | Body | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전 (회색)`<br/>- AVAILABLE: `사용 가능 (녹색)`<br/>- STORAGE_FULL: `용량 부족 (적색)`<br/>- FAIL_TO_CREATE: `생성 실패 (적색)`<br/>- FAIL_TO_CONNECT: `연결 실패 (적색)`<br/>- REPLICATION_STOP: `복제 중단 (적색)`<br/>- REPLICATION_DELAY: `복제 지연 (황색)`<br/>- FAILOVER: `장애 조치 완료 (적색)`<br/>- SHUTDOWN: `중지 됨 (회색)`<br/>- DELETED: `삭제됨 (회색)` |
 | createdYmdt | Body | DateTime | 생성 일시 |
@@ -543,12 +543,12 @@ GET /v1.0/db-instance-groups/{dbInstanceGroupId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "dbInstanceGroupId": "dbInstanceGroupId-example",
+    "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
     "dbInstanceGroupStatus": "CREATED",
     "replicationType": "STANDALONE",
     "dbInstances": [
         {
-            "dbInstanceId": "dbInstanceId-example",
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
             "dbInstanceType": "MASTER",
             "dbInstanceStatus": "BEFORE_CREATE"
         }
@@ -588,12 +588,12 @@ GET /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
 | extensions | Body | Array | 확장 정보 |
-| extensions.extensionId | Body | String | 확장 ID |
+| extensions.extensionId | Body | UUID | 확장 ID |
 | extensions.extensionName | Body | String | 확장 이름 |
 | extensions.extensionStatus | Body | Enum | 확장 상태<br/>- AVAILABLE: `사용 가능`<br/>- NEED_TO_APPLY: `적용 필요`<br/>- APPLYING: `적용 중` |
 | extensions.databases | Body | Array | 데이터베이스 정보 |
-| extensions.databases.dbInstanceGroupExtensionId | Body | String | DB 인스턴스 그룹 확장 ID |
-| extensions.databases.databaseId | Body | String | 데이터베이스 ID |
+| extensions.databases.dbInstanceGroupExtensionId | Body | UUID | DB 인스턴스 그룹 확장 ID |
+| extensions.databases.databaseId | Body | UUID | 데이터베이스 ID |
 | extensions.databases.databaseName | Body | String | 데이터베이스 이름 |
 | extensions.databases.dbInstanceGroupExtensionStatus | Body | Enum | 데이터베이스 확장 설치 상태<br/>- CREATED: `생성 됨`<br/>- INSTALLED: `설치 됨`<br/>- INSTALLING: `설치 중`<br/>- INSTALL_ERROR: `설치 에러`<br/>- DELETED: `삭제 됨`<br/>- DELETING: `삭제 중`<br/>- DELETE_ERROR: `삭제 에러` |
 | extensions.databases.reservedAction | Body | Enum | 예약 작업<br/>- NONE: `없음`<br/>- INSTALL: `설치 예약 (적용 필요)`<br/>- INSTALL_WITH_CASCADE: `강제 설치 예약 (적용 필요)`<br/>- DELETE: `삭제 예약 (적용 필요)`<br/>- DELETE_WITH_CASCADE: `강제 삭제 예약 (적용 필요)` |
@@ -612,13 +612,13 @@ GET /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions
     },
     "extensions": [
         {
-            "extensionId": "extensionId-example",
+            "extensionId": "550e8400-e29b-41d4-a716-446655440000",
             "extensionName": "extensionName-example",
             "extensionStatus": "AVAILABLE",
             "databases": [
                 {
-                    "dbInstanceGroupExtensionId": "dbInstanceGroupExtensionId-example",
-                    "databaseId": "databaseId-example",
+                    "dbInstanceGroupExtensionId": "550e8400-e29b-41d4-a716-446655440000",
+                    "databaseId": "550e8400-e29b-41d4-a716-446655440000",
                     "databaseName": "databaseName-example",
                     "dbInstanceGroupExtensionStatus": "CREATED",
                     "reservedAction": "NONE",
@@ -864,8 +864,8 @@ GET /v1.0/db-instances
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
 | dbInstances | Body | Array | DB 인스턴스 정보 |
-| dbInstances.dbInstanceId | Body | String | DB 인스턴스의 식별자 |
-| dbInstances.dbInstanceGroupId | Body | String | DB 인스턴스 그룹의 식별자 |
+| dbInstances.dbInstanceId | Body | UUID | DB 인스턴스의 식별자 |
+| dbInstances.dbInstanceGroupId | Body | UUID | DB 인스턴스 그룹의 식별자 |
 | dbInstances.dbInstanceName | Body | String | DB 인스턴스를 식별할 수 있는 이름 |
 | dbInstances.description | Body | String | DB 인스턴스에 대한 추가 정보 |
 | dbInstances.dbVersion | Body | Enum | DB 엔진 유형 |
@@ -888,11 +888,11 @@ GET /v1.0/db-instances
     },
     "dbInstances": [
         {
-            "dbInstanceId": "dbInstanceId-example",
-            "dbInstanceGroupId": "dbInstanceGroupId-example",
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
             "dbInstanceName": "dbInstanceName-example",
             "description": "description-example",
-            "dbVersion": "ENUM_VALUE",
+            "dbVersion": "POSTGRESQL_V14_17",
             "dbPort": 1,
             "dbInstanceType": "MASTER",
             "dbInstanceStatus": "BEFORE_CREATE",
@@ -965,7 +965,7 @@ POST /v1.0/db-instances
     "dbInstanceCandidateName": "dbInstanceCandidateName-example",
     "description": "description-example",
     "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbVersion": "ENUM_VALUE",
+    "dbVersion": "POSTGRESQL_V14_17",
     "dbPort": 1,
     "databaseName": "databaseName-example",
     "dbUserName": "dbUserName-example",
@@ -981,10 +981,10 @@ POST /v1.0/db-instances
     "network": {
         "subnetId": "550e8400-e29b-41d4-a716-446655440000",
         "usePublicAccess": false,
-        "availabilityZone": "ENUM_VALUE"
+        "availabilityZone": "kr-pub-a"
     },
     "storage": {
-        "storageType": "ENUM_VALUE",
+        "storageType": "General SSD",
         "storageSize": 20
     },
     "backup": {
@@ -1090,19 +1090,19 @@ POST /v1.0/db-instances/restore-from-obs
     "description": "description-example",
     "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
     "dbPort": 1,
-    "dbVersion": "ENUM_VALUE",
+    "dbVersion": "POSTGRESQL_V14_17",
     "useHighAvailability": false,
     "imageId": "550e8400-e29b-41d4-a716-446655440000",
     "pingInterval": 3,
     "failoverReplWaitingTime": 60,
     "storage": {
-        "storageType": "ENUM_VALUE",
+        "storageType": "General SSD",
         "storageSize": 20
     },
     "network": {
         "subnetId": "550e8400-e29b-41d4-a716-446655440000",
         "usePublicAccess": false,
-        "availabilityZone": "ENUM_VALUE"
+        "availabilityZone": "kr-pub-a"
     },
     "backup": {
         "backupPeriod": 0,
@@ -1227,8 +1227,8 @@ GET /v1.0/db-instances/{dbInstanceId}
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| dbInstanceId | Body | String | DB 인스턴스의 식별자 |
-| dbInstanceGroupId | Body | String | DB 인스턴스 그룹의 식별자 |
+| dbInstanceId | Body | UUID | DB 인스턴스의 식별자 |
+| dbInstanceGroupId | Body | UUID | DB 인스턴스 그룹의 식별자 |
 | dbInstanceName | Body | String | DB 인스턴스를 식별할 수 있는 이름 |
 | description | Body | String | DB 인스턴스에 대한 추가 정보 |
 | dbVersion | Body | Enum | DB 엔진 유형 |
@@ -1236,8 +1236,8 @@ GET /v1.0/db-instances/{dbInstanceId}
 | dbInstanceType | Body | Enum | DB 인스턴스 역할 타입<br/>- MASTER: `마스터`<br/>- FAILED_MASTER: `장애 마스터`<br/>- CANDIDATE_MASTER: `예비 마스터`<br/>- READ_ONLY_SLAVE: `읽기 복제본` |
 | dbInstanceStatus | Body | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전 (회색)`<br/>- AVAILABLE: `사용 가능 (녹색)`<br/>- STORAGE_FULL: `용량 부족 (적색)`<br/>- FAIL_TO_CREATE: `생성 실패 (적색)`<br/>- FAIL_TO_CONNECT: `연결 실패 (적색)`<br/>- REPLICATION_STOP: `복제 중단 (적색)`<br/>- REPLICATION_DELAY: `복제 지연 (황색)`<br/>- FAILOVER: `장애 조치 완료 (적색)`<br/>- SHUTDOWN: `중지 됨 (회색)`<br/>- DELETED: `삭제됨 (회색)` |
 | progressStatus | Body | String | DB 인스턴스의 현재 진행 상태 |
-| dbFlavorId | Body | String | DB 인스턴스 사양의 식별자 |
-| parameterGroupId | Body | String | DB 인스턴스에 적용된 파라미터 그룹의 식별자 |
+| dbFlavorId | Body | UUID | DB 인스턴스 사양의 식별자 |
+| parameterGroupId | Body | UUID | DB 인스턴스에 적용된 파라미터 그룹의 식별자 |
 | dbSecurityGroupIds | Body | Array | DB 인스턴스에 적용된 DB 보안 그룹의 식별자 목록 |
 | notificationGroupIds | Body | Array | DB 인스턴스에 적용된 알림 그룹의 식별자 목록 |
 | useDeletionProtection | Body | Boolean | DB 인스턴스 삭제 보호 여부 |
@@ -1257,17 +1257,17 @@ GET /v1.0/db-instances/{dbInstanceId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "dbInstanceId": "dbInstanceId-example",
-    "dbInstanceGroupId": "dbInstanceGroupId-example",
+    "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
     "dbInstanceName": "dbInstanceName-example",
     "description": "description-example",
-    "dbVersion": "ENUM_VALUE",
+    "dbVersion": "POSTGRESQL_V14_17",
     "dbPort": 1,
     "dbInstanceType": "MASTER",
     "dbInstanceStatus": "BEFORE_CREATE",
     "progressStatus": "progressStatus-example",
-    "dbFlavorId": "dbFlavorId-example",
-    "parameterGroupId": "parameterGroupId-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
     "dbSecurityGroupIds": [],
     "notificationGroupIds": [],
     "useDeletionProtection": false,
@@ -1325,7 +1325,7 @@ PUT /v1.0/db-instances/{dbInstanceId}
     "dbPort": 1,
     "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
     "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbVersion": "ENUM_VALUE",
+    "dbVersion": "POSTGRESQL_V14_17",
     "dbSecurityGroupIds": [],
     "executeBackup": false,
     "useOnlineFailover": false,
@@ -1739,7 +1739,7 @@ GET /v1.0/db-instances/{dbInstanceId}/databases
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
 | databases | Body | Array | 데이터베이스 정보 |
-| databases.databaseId | Body | String | 데이터베이스의 식별자 |
+| databases.databaseId | Body | UUID | 데이터베이스의 식별자 |
 | databases.databaseName | Body | String | 데이터베이스 이름 |
 | databases.databaseStatus | Body | Enum | 데이터베이스의 현재 상태<br/>- STABLE: `사용 가능`<br/>- CREATING: `생성 중`<br/>- MODIFYING: `수정 중`<br/>- DELETING: `삭제 중`<br/>- DELETED: `삭제됨`<br/>- SYNCING: `동기화 중` |
 | databases.createdYmdt | Body | DateTime | 생성 일시 |
@@ -1759,7 +1759,7 @@ GET /v1.0/db-instances/{dbInstanceId}/databases
     },
     "databases": [
         {
-            "databaseId": "databaseId-example",
+            "databaseId": "550e8400-e29b-41d4-a716-446655440000",
             "databaseName": "databaseName-example",
             "databaseStatus": "STABLE",
             "createdYmdt": "2023-12-31T15:00:00+09:00",
@@ -1965,7 +1965,7 @@ GET /v1.0/db-instances/{dbInstanceId}/db-users
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
 | dbUsers | Body | Array | DB 사용자 목록 |
-| dbUsers.dbUserId | Body | String | DB 사용자의 식별자 |
+| dbUsers.dbUserId | Body | UUID | DB 사용자의 식별자 |
 | dbUsers.dbUserName | Body | String | DB 사용자 계정 이름 |
 | dbUsers.authorityType | Body | Enum | DB 사용자 권한 타입<br/>- CUSTOM: `커스텀 권한 권한`<br/>- READ: `READ 권한 (읽기 전용 권한)`<br/>- CRUD: `CRUD 권한 (읽기 권한 포함)`<br/>- DDL: `DDL 권한 (CRUD 권한 포함)` |
 | dbUsers.dbUserStatus | Body | Enum | DB 사용자의 현재 상태<br/>- STABLE: `사용 가능`<br/>- CREATING: `생성 중`<br/>- MODIFYING: `수정 중`<br/>- DELETING: `삭제 중`<br/>- DELETED: `삭제됨`<br/>- SYNCING: `동기화 중` |
@@ -1984,7 +1984,7 @@ GET /v1.0/db-instances/{dbInstanceId}/db-users
     },
     "dbUsers": [
         {
-            "dbUserId": "dbUserId-example",
+            "dbUserId": "550e8400-e29b-41d4-a716-446655440000",
             "dbUserName": "dbUserName-example",
             "authorityType": "CUSTOM",
             "dbUserStatus": "STABLE",
@@ -2261,15 +2261,15 @@ GET /v1.0/db-instances/{dbInstanceId}/hba-rules
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
 | hbaRules | Body | Array | 접근 제어 규칙 정보 |
-| hbaRules.hbaRuleId | Body | String | 접근 제어 규칙의 식별자 |
+| hbaRules.hbaRuleId | Body | UUID | 접근 제어 규칙의 식별자 |
 | hbaRules.hbaRuleStatus | Body | Enum | 접근 제어 규칙의 현재 상태<br/>- CREATED: `생성됨`<br/>- APPLIED: `적용됨`<br/>- CREATING: `생성 중`<br/>- MODIFYING: `수정 중`<br/>- DELETING: `삭제 중`<br/>- DELETED: `삭제됨` |
 | hbaRules.databaseApplyType | Body | Enum | DB 데이터베이스 적용 타입<br/>- ENTIRE: `전체`<br/>- USER_CUSTOM: `사용자 지정` |
 | hbaRules.dbUserApplyTypeCode | Body | Enum | DB 사용자 적용 타입<br/>- ENTIRE: `전체`<br/>- USER_CUSTOM: `사용자 지정` |
 | hbaRules.databases | Body | Array | 사용자 지정 데이터베이스 리스트 |
-| hbaRules.databases.databaseId | Body | String | 데이터베이스 ID |
+| hbaRules.databases.databaseId | Body | UUID | 데이터베이스 ID |
 | hbaRules.databases.databaseName | Body | String | 데이터베이스 이름 |
 | hbaRules.dbUsers | Body | Array | 사용자 지정 DB 사용자 리스트 |
-| hbaRules.dbUsers.dbUserId | Body | String | DB 사용자 ID |
+| hbaRules.dbUsers.dbUserId | Body | UUID | DB 사용자 ID |
 | hbaRules.dbUsers.dbUserName | Body | String | DB 사용자 이름 |
 | hbaRules.address | Body | String | 접속 주소 |
 | hbaRules.authMethod | Body | Enum | 인증 방식<br/>- TRUST: `트러스트 (패스워드 불필요)`<br/>- REJECT: `접속 차단`<br/>- SCRAM_SHA_256: `패스워드 (SCRAM-SHA-256)` |
@@ -2290,19 +2290,19 @@ GET /v1.0/db-instances/{dbInstanceId}/hba-rules
     },
     "hbaRules": [
         {
-            "hbaRuleId": "hbaRuleId-example",
+            "hbaRuleId": "550e8400-e29b-41d4-a716-446655440000",
             "hbaRuleStatus": "CREATED",
             "databaseApplyType": "ENTIRE",
             "dbUserApplyTypeCode": "ENTIRE",
             "databases": [
                 {
-                    "databaseId": "databaseId-example",
+                    "databaseId": "550e8400-e29b-41d4-a716-446655440000",
                     "databaseName": "databaseName-example"
                 }
             ],
             "dbUsers": [
                 {
-                    "dbUserId": "dbUserId-example",
+                    "dbUserId": "550e8400-e29b-41d4-a716-446655440000",
                     "dbUserName": "dbUserName-example"
                 }
             ],
@@ -2369,7 +2369,7 @@ POST /v1.0/db-instances/{dbInstanceId}/hba-rules
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| hbaRuleId | Body | String | 접근 제어 규칙 ID |
+| hbaRuleId | Body | UUID | 접근 제어 규칙 ID |
 
 <details><summary>예시</summary>
 <p>
@@ -2381,7 +2381,7 @@ POST /v1.0/db-instances/{dbInstanceId}/hba-rules
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "hbaRuleId": "hbaRuleId-example"
+    "hbaRuleId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -2981,7 +2981,7 @@ GET /v1.0/db-instances/{dbInstanceId}/network-info
 |-----|-----|-----|-----|
 | availabilityZone | Body | Enum | DB 인스턴스를 생성할 가용성 영역 |
 | subnet | Body | Object | 서브넷 정보 |
-| subnet.subnetId | Body | String | 서브넷의 식별자 |
+| subnet.subnetId | Body | UUID | 서브넷의 식별자 |
 | subnet.subnetName | Body | String | 서브넷을 식별할 수 있는 이름 |
 | subnet.subnetCidr | Body | String | 서브넷의 CIDR |
 | subnet.publicAccessible | Body | Boolean | 퍼블릭 접근 가능 여부 |
@@ -3000,9 +3000,9 @@ GET /v1.0/db-instances/{dbInstanceId}/network-info
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "availabilityZone": "ENUM_VALUE",
+    "availabilityZone": "kr-pub-a",
     "subnet": {
-        "subnetId": "subnetId-example",
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
         "subnetName": "subnetName-example",
         "subnetCidr": "subnetCidr-example",
         "publicAccessible": false
@@ -3172,10 +3172,10 @@ POST /v1.0/db-instances/{dbInstanceId}/replicate
     "useDeletionProtection": false,
     "network": {
         "usePublicAccess": false,
-        "availabilityZone": "ENUM_VALUE"
+        "availabilityZone": "kr-pub-a"
     },
     "storage": {
-        "storageType": "ENUM_VALUE",
+        "storageType": "General SSD",
         "storageSize": 20
     }
 }
@@ -3281,10 +3281,10 @@ GET /v1.0/db-instances/{dbInstanceId}/restoration-info
 | oldestRestorableYmdt | Body | DateTime | 가장 오래된 복원 가능한 시각 |
 | latestRestorableYmdt | Body | DateTime | 가장 최신의 복원 가능한 시각 |
 | restorableBackups | Body | Array | 복원 가능한 백업 목록 |
-| restorableBackups.backupId | Body | String | 백업의 식별자 |
+| restorableBackups.backupId | Body | UUID | 백업의 식별자 |
 | restorableBackups.backupName | Body | String | 백업 이름 |
 | restorableBackups.backupStatus | Body | Enum | 백업 상태<br/>- BACKING_UP: `백업 중 (스피너)`<br/>- VERIFYING: `검증 중 (스피너)`<br/>- COMPLETED: `사용 가능 (녹색 아이콘)`<br/>- DELETING: `삭제 중 (스피너)`<br/>- DELETED: `삭제 됨 (회색 아이콘)`<br/>- ERROR: `에러 (적색 아이콘)` |
-| restorableBackups.dbInstanceId | Body | String | 원본 DB 인스턴스의 식별자 |
+| restorableBackups.dbInstanceId | Body | UUID | 원본 DB 인스턴스의 식별자 |
 | restorableBackups.dbInstanceName | Body | String | 원본 DB 인스턴스의 이름 |
 | restorableBackups.dbVersion | Body | Enum | DB 엔진 유형 |
 | restorableBackups.backupType | Body | Enum | 백업 유형<br/>- AUTO<br/>- MANUAL |
@@ -3310,12 +3310,12 @@ GET /v1.0/db-instances/{dbInstanceId}/restoration-info
     "latestRestorableYmdt": "2023-12-31T15:00:00+09:00",
     "restorableBackups": [
         {
-            "backupId": "backupId-example",
+            "backupId": "550e8400-e29b-41d4-a716-446655440000",
             "backupName": "backupName-example",
             "backupStatus": "BACKING_UP",
-            "dbInstanceId": "dbInstanceId-example",
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
             "dbInstanceName": "dbInstanceName-example",
-            "dbVersion": "ENUM_VALUE",
+            "dbVersion": "POSTGRESQL_V14_17",
             "backupType": "AUTO",
             "backupSize": 1,
             "failoverCount": 1,
@@ -3399,13 +3399,13 @@ POST /v1.0/db-instances/{dbInstanceId}/restore
     "pingInterval": 3,
     "failoverReplWaitingTime": 60,
     "storage": {
-        "storageType": "ENUM_VALUE",
+        "storageType": "General SSD",
         "storageSize": 20
     },
     "network": {
         "subnetId": "550e8400-e29b-41d4-a716-446655440000",
         "usePublicAccess": false,
-        "availabilityZone": "ENUM_VALUE"
+        "availabilityZone": "kr-pub-a"
     },
     "backup": {
         "backupPeriod": 0,
@@ -3587,7 +3587,7 @@ GET /v1.0/db-instances/{dbInstanceId}/storage-info
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "storageType": "ENUM_VALUE",
+    "storageType": "General SSD",
     "storageSize": 1,
     "storageStatus": "DELETED"
 }
@@ -3688,10 +3688,10 @@ GET /v1.0/backups
 |-----|-----|-----|-----|
 | totalCounts | Body | Number | 전체 백업 목록 수 |
 | backups | Body | Array | 백업 목록 |
-| backups.backupId | Body | String | 백업의 식별자 |
+| backups.backupId | Body | UUID | 백업의 식별자 |
 | backups.backupName | Body | String | 백업을 식별할 수 있는 이름 |
 | backups.backupStatus | Body | Enum | 백업의 현재 상태<br/>- BACKING_UP: `백업 중 (스피너)`<br/>- VERIFYING: `검증 중 (스피너)`<br/>- COMPLETED: `사용 가능 (녹색 아이콘)`<br/>- DELETING: `삭제 중 (스피너)`<br/>- DELETED: `삭제 됨 (회색 아이콘)`<br/>- ERROR: `에러 (적색 아이콘)` |
-| backups.dbInstanceId | Body | String | 원본 DB 인스턴스의 식별자 |
+| backups.dbInstanceId | Body | UUID | 원본 DB 인스턴스의 식별자 |
 | backups.dbVersion | Body | Enum | DB 엔진 버전 |
 | backups.backupType | Body | Enum | 백업 유형<br/>- AUTO<br/>- MANUAL |
 | backups.backupSize | Body | Number | 백업의 크기(Byte) |
@@ -3713,11 +3713,11 @@ GET /v1.0/backups
     "totalCounts": 1,
     "backups": [
         {
-            "backupId": "backupId-example",
+            "backupId": "550e8400-e29b-41d4-a716-446655440000",
             "backupName": "backupName-example",
             "backupStatus": "BACKING_UP",
-            "dbInstanceId": "dbInstanceId-example",
-            "dbVersion": "ENUM_VALUE",
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbVersion": "POSTGRESQL_V14_17",
             "backupType": "AUTO",
             "backupSize": 1,
             "startYmdt": "2023-12-31T15:00:00+09:00",
@@ -3908,10 +3908,10 @@ POST /v1.0/backups/{backupId}/restore
     "network": {
         "subnetId": "550e8400-e29b-41d4-a716-446655440000",
         "usePublicAccess": false,
-        "availabilityZone": "ENUM_VALUE"
+        "availabilityZone": "kr-pub-a"
     },
     "storage": {
-        "storageType": "ENUM_VALUE",
+        "storageType": "General SSD",
         "storageSize": 20
     },
     "backup": {
@@ -3987,7 +3987,7 @@ GET /v1.0/db-security-groups
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
 | dbSecurityGroups | Body | Array | DB 보안 그룹 목록 |
-| dbSecurityGroups.dbSecurityGroupId | Body | String | DB 보안 그룹의 식별자 |
+| dbSecurityGroups.dbSecurityGroupId | Body | UUID | DB 보안 그룹의 식별자 |
 | dbSecurityGroups.dbSecurityGroupName | Body | String | DB 보안 그룹을 식별할 수 있는 이름 |
 | dbSecurityGroups.dbSecurityGroupStatus | Body | Enum | DB 보안 그룹의 현재 상태<br/>- CREATED: `생성됨`<br/>- DELETED: `삭제됨` |
 | dbSecurityGroups.description | Body | String | DB 보안 그룹에 대한 추가 정보 |
@@ -4007,7 +4007,7 @@ GET /v1.0/db-security-groups
     },
     "dbSecurityGroups": [
         {
-            "dbSecurityGroupId": "dbSecurityGroupId-example",
+            "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
             "dbSecurityGroupName": "dbSecurityGroupName-example",
             "dbSecurityGroupStatus": "CREATED",
             "description": "description-example",
@@ -4082,7 +4082,7 @@ POST /v1.0/db-security-groups
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| dbSecurityGroupId | Body | String | DB 보안 그룹의 식별자 |
+| dbSecurityGroupId | Body | UUID | DB 보안 그룹의 식별자 |
 
 <details><summary>예시</summary>
 <p>
@@ -4094,7 +4094,7 @@ POST /v1.0/db-security-groups
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "dbSecurityGroupId": "dbSecurityGroupId-example"
+    "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -4154,13 +4154,13 @@ GET /v1.0/db-security-groups/{dbSecurityGroupId}
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
 | dbSecurityGroup | Body | Object | DB 보안 그룹 |
-| dbSecurityGroup.dbSecurityGroupId | Body | String | DB 보안 그룹의 식별자 |
+| dbSecurityGroup.dbSecurityGroupId | Body | UUID | DB 보안 그룹의 식별자 |
 | dbSecurityGroup.dbSecurityGroupName | Body | String | DB 보안 그룹을 식별할 수 있는 이름 |
 | dbSecurityGroup.dbSecurityGroupStatus | Body | Enum | DB 보안 그룹의 현재 상태<br/>- CREATED: `생성됨`<br/>- DELETED: `삭제됨` |
 | dbSecurityGroup.description | Body | String | DB 보안 그룹에 대한 추가 정보 |
 | dbSecurityGroup.progressStatus | Body | Enum | DB 보안 그룹의 현재 진행 상태<br/>- NONE: `없음`<br/>- CREATING_RULE: `규칙 생성중`<br/>- UPDATING_RULE: `규칙 수정중`<br/>- DELETING_RULE: `규칙 삭제중`<br/>- APPLYING_DEFAULT_RULE: `기본 규칙 적용중` |
 | dbSecurityGroup.rules | Body | Array | DB 보안 그룹 규칙 목록 |
-| dbSecurityGroup.rules.ruleId | Body | String | DB 보안 그룹 규칙의 식별자 |
+| dbSecurityGroup.rules.ruleId | Body | UUID | DB 보안 그룹 규칙의 식별자 |
 | dbSecurityGroup.rules.description | Body | String | DB 보안 그룹 규칙에 대한 추가 정보 |
 | dbSecurityGroup.rules.direction | Body | Enum | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
 | dbSecurityGroup.rules.etherType | Body | Enum | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
@@ -4185,14 +4185,14 @@ GET /v1.0/db-security-groups/{dbSecurityGroupId}
         "isSuccessful": true
     },
     "dbSecurityGroup": {
-        "dbSecurityGroupId": "dbSecurityGroupId-example",
+        "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
         "dbSecurityGroupName": "dbSecurityGroupName-example",
         "dbSecurityGroupStatus": "CREATED",
         "description": "description-example",
         "progressStatus": "NONE",
         "rules": [
             {
-                "ruleId": "ruleId-example",
+                "ruleId": "550e8400-e29b-41d4-a716-446655440000",
                 "description": "description-example",
                 "direction": "INGRESS",
                 "etherType": "IPV4",
@@ -4468,7 +4468,7 @@ GET /v1.0/parameter-groups
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
 | parameterGroups | Body | Array | 파라미터 그룹 목록 |
-| parameterGroups.parameterGroupId | Body | String | 파라미터 그룹의 식별자 |
+| parameterGroups.parameterGroupId | Body | UUID | 파라미터 그룹의 식별자 |
 | parameterGroups.parameterGroupName | Body | String | 파라미터 그룹을 식별할 수 있는 이름 |
 | parameterGroups.description | Body | String | 파라미터 그룹에 대한 추가 정보 |
 | parameterGroups.dbVersion | Body | Enum | DB 엔진 버전 |
@@ -4488,10 +4488,10 @@ GET /v1.0/parameter-groups
     },
     "parameterGroups": [
         {
-            "parameterGroupId": "parameterGroupId-example",
+            "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
             "parameterGroupName": "parameterGroupName-example",
             "description": "description-example",
-            "dbVersion": "ENUM_VALUE",
+            "dbVersion": "POSTGRESQL_V14_17",
             "parameterGroupStatus": "STABLE",
             "createdYmdt": "2023-12-31T15:00:00+09:00",
             "updatedYmdt": "2023-12-31T15:00:00+09:00"
@@ -4532,7 +4532,7 @@ POST /v1.0/parameter-groups
 {
     "parameterGroupName": "parameterGroupName-example",
     "description": "description-example",
-    "dbVersion": "ENUM_VALUE"
+    "dbVersion": "POSTGRESQL_V14_17"
 }
 ```
 
@@ -4543,7 +4543,7 @@ POST /v1.0/parameter-groups
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| parameterGroupId | Body | String | 파라미터 그룹의 식별자 |
+| parameterGroupId | Body | UUID | 파라미터 그룹의 식별자 |
 
 <details><summary>예시</summary>
 <p>
@@ -4555,7 +4555,7 @@ POST /v1.0/parameter-groups
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "parameterGroupId": "parameterGroupId-example"
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -4614,7 +4614,7 @@ GET /v1.0/parameter-groups/{parameterGroupId}
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| parameterGroupId | Body | String | 파라미터 그룹의 식별자 |
+| parameterGroupId | Body | UUID | 파라미터 그룹의 식별자 |
 | parameterGroupName | Body | String | 파라미터 그룹을 식별할 수 있는 이름 |
 | description | Body | String | 파라미터 그룹에 대한 추가 정보 |
 | dbVersion | Body | Enum | DB 엔진 버전 |
@@ -4648,10 +4648,10 @@ GET /v1.0/parameter-groups/{parameterGroupId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "parameterGroupId": "parameterGroupId-example",
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
     "parameterGroupName": "parameterGroupName-example",
     "description": "description-example",
-    "dbVersion": "ENUM_VALUE",
+    "dbVersion": "POSTGRESQL_V14_17",
     "parameterGroupStatus": "STABLE",
     "parameters": [
         {
@@ -4753,7 +4753,7 @@ POST /v1.0/parameter-groups/{parameterGroupId}/copy
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| parameterGroupId | Body | String | 파라미터 그룹의 식별자 |
+| parameterGroupId | Body | UUID | 파라미터 그룹의 식별자 |
 
 <details><summary>예시</summary>
 <p>
@@ -4765,7 +4765,7 @@ POST /v1.0/parameter-groups/{parameterGroupId}/copy
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "parameterGroupId": "parameterGroupId-example"
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -4867,7 +4867,7 @@ GET /v1.0/user-groups
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
 | userGroups | Body | Array | 사용자 그룹 정보 |
-| userGroups.userGroupId | Body | String | 사용자 그룹의 식별자 |
+| userGroups.userGroupId | Body | UUID | 사용자 그룹의 식별자 |
 | userGroups.userGroupName | Body | String | 사용자 그룹을 식별할 수 있는 이름 |
 | userGroups.userGroupStatus | Body | Enum | 사용자 그룹의 현재 상태<br/>- CREATED<br/>- DELETED |
 | userGroups.createdYmdt | Body | DateTime | 생성 일시 |
@@ -4885,7 +4885,7 @@ GET /v1.0/user-groups
     },
     "userGroups": [
         {
-            "userGroupId": "userGroupId-example",
+            "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
             "userGroupName": "userGroupName-example",
             "userGroupStatus": "CREATED",
             "createdYmdt": "2023-12-31T15:00:00+09:00",
@@ -4938,7 +4938,7 @@ POST /v1.0/user-groups
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| userGroupId | Body | String | 사용자 그룹의 식별자 |
+| userGroupId | Body | UUID | 사용자 그룹의 식별자 |
 
 <details><summary>예시</summary>
 <p>
@@ -4950,7 +4950,7 @@ POST /v1.0/user-groups
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "userGroupId": "userGroupId-example"
+    "userGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -5009,12 +5009,12 @@ GET /v1.0/user-groups/{userGroupId}
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| userGroupId | Body | String | 사용자 그룹의 식별자 |
+| userGroupId | Body | UUID | 사용자 그룹의 식별자 |
 | userGroupName | Body | String | 사용자 그룹을 식별할 수 있는 이름 |
 | userGroupTypeCode | Body | Enum | 사용자 그룹 종류<br/>- ENTIRE: `전체 프로젝트 멤버`<br/>- INDIVIDUAL_MEMBER: `사용자 지정` |
 | userGroupStatus | Body | Enum | 사용자 그룹의 현재 상태<br/>- CREATED<br/>- DELETED |
 | members | Body | Array | 프로젝트 멤버 목록 |
-| members.memberId | Body | String | 프로젝트 멤버의 식별자 |
+| members.memberId | Body | UUID | 프로젝트 멤버의 식별자 |
 | createdYmdt | Body | DateTime | 생성 일시 |
 | updatedYmdt | Body | DateTime | 수정 일시 |
 
@@ -5028,13 +5028,13 @@ GET /v1.0/user-groups/{userGroupId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "userGroupId": "userGroupId-example",
+    "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
     "userGroupName": "userGroupName-example",
     "userGroupTypeCode": "ENTIRE",
     "userGroupStatus": "CREATED",
     "members": [
         {
-            "memberId": "memberId-example"
+            "memberId": "550e8400-e29b-41d4-a716-446655440000"
         }
     ],
     "createdYmdt": "2023-12-31T15:00:00+09:00",
@@ -5111,7 +5111,7 @@ GET /v1.0/notification-groups
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
 | notificationGroups | Body | Array |  |
-| notificationGroups.notificationGroupId | Body | String | 알림 그룹의 식별자 |
+| notificationGroups.notificationGroupId | Body | UUID | 알림 그룹의 식별자 |
 | notificationGroups.notificationGroupName | Body | String | 알림 그룹을 식별할 수 있는 이름 |
 | notificationGroups.notificationGroupStatus | Body | Enum | 알림 그룹의 현재 상태<br/>- CREATED: `생성됨`<br/>- DELETED: `삭제됨` |
 | notificationGroups.notifyEmail | Body | Boolean | 이메일 알림 여부 |
@@ -5132,7 +5132,7 @@ GET /v1.0/notification-groups
     },
     "notificationGroups": [
         {
-            "notificationGroupId": "notificationGroupId-example",
+            "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
             "notificationGroupName": "notificationGroupName-example",
             "notificationGroupStatus": "CREATED",
             "notifyEmail": false,
@@ -5194,7 +5194,7 @@ POST /v1.0/notification-groups
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| notificationGroupId | Body | String | 알림 그룹의 식별자 |
+| notificationGroupId | Body | UUID | 알림 그룹의 식별자 |
 
 <details><summary>예시</summary>
 <p>
@@ -5206,7 +5206,7 @@ POST /v1.0/notification-groups
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "notificationGroupId": "notificationGroupId-example"
+    "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -5265,17 +5265,17 @@ GET /v1.0/notification-groups/{notificationGroupId}
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| notificationGroupId | Body | String | 알림 그룹의 식별자 |
+| notificationGroupId | Body | UUID | 알림 그룹의 식별자 |
 | notificationGroupName | Body | String | 알림 그룹을 식별할 수 있는 이름 |
 | notificationGroupStatus | Body | Enum | 알림 그룹의 현재 상태<br/>- CREATED: `생성됨`<br/>- DELETED: `삭제됨` |
 | notifyEmail | Body | Boolean | 이메일 알림 여부 |
 | notifySms | Body | Boolean | SMS 알림 여부 |
 | isEnabled | Body | Boolean | 활성화 여부 |
 | dbInstances | Body | Array | 감시 대상 DB 인스턴스 목록 |
-| dbInstances.dbInstanceId | Body | String | DB 인스턴스의 식별자 |
+| dbInstances.dbInstanceId | Body | UUID | DB 인스턴스의 식별자 |
 | dbInstances.dbInstanceName | Body | String | DB 인스턴스를 식별할 수 있는 이름 |
 | userGroups | Body | Array | 사용자 그룹 목록 |
-| userGroups.userGroupId | Body | String | 사용자 그룹의 식별자 |
+| userGroups.userGroupId | Body | UUID | 사용자 그룹의 식별자 |
 | userGroups.userGroupName | Body | String | 사용자 그룹을 식별할 수 있는 이름 |
 | createdYmdt | Body | DateTime | 생성 일시 |
 | updatedYmdt | Body | DateTime | 수정 일시 |
@@ -5290,7 +5290,7 @@ GET /v1.0/notification-groups/{notificationGroupId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "notificationGroupId": "notificationGroupId-example",
+    "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
     "notificationGroupName": "notificationGroupName-example",
     "notificationGroupStatus": "CREATED",
     "notifyEmail": false,
@@ -5298,13 +5298,13 @@ GET /v1.0/notification-groups/{notificationGroupId}
     "isEnabled": false,
     "dbInstances": [
         {
-            "dbInstanceId": "dbInstanceId-example",
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
             "dbInstanceName": "dbInstanceName-example"
         }
     ],
     "userGroups": [
         {
-            "userGroupId": "userGroupId-example",
+            "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
             "userGroupName": "userGroupName-example"
         }
     ],
@@ -5390,7 +5390,7 @@ GET /v1.0/notification-groups/{notificationGroupId}/watchdogs
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
 | notificationWatchdogs | Body | Array | 감시 설정 정보 |
-| notificationWatchdogs.watchdogId | Body | String | 감시 설정의 식별자 |
+| notificationWatchdogs.watchdogId | Body | UUID | 감시 설정의 식별자 |
 | notificationWatchdogs.metricName | Body | String | 감시 대상 성능 지표 |
 | notificationWatchdogs.comparisonOperator | Body | Enum | 감시 대상 비교 방법<br/>- LE: `<=`<br/>- LT: `<`<br/>- GE: `>=`<br/>- GT: `>` |
 | notificationWatchdogs.threshold | Body | Number | 감시 대상 임곗값 |
@@ -5409,7 +5409,7 @@ GET /v1.0/notification-groups/{notificationGroupId}/watchdogs
     },
     "notificationWatchdogs": [
         {
-            "watchdogId": "watchdogId-example",
+            "watchdogId": "550e8400-e29b-41d4-a716-446655440000",
             "metricName": "metricName-example",
             "comparisonOperator": "LE",
             "threshold": 1,
@@ -5466,7 +5466,7 @@ POST /v1.0/notification-groups/{notificationGroupId}/watchdogs
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| watchdogId | Body | String | 감시 설정의 식별자 |
+| watchdogId | Body | UUID | 감시 설정의 식별자 |
 
 <details><summary>예시</summary>
 <p>
@@ -5478,7 +5478,7 @@ POST /v1.0/notification-groups/{notificationGroupId}/watchdogs
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "watchdogId": "watchdogId-example"
+    "watchdogId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 

--- a/ko/api-guide-v1.0.md
+++ b/ko/api-guide-v1.0.md
@@ -63,6 +63,12 @@ API 요청 시 인증에 실패하거나 권한이 없을 경우 다음과 같�
 GET /v1.0/db-versions
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbVersion.List | DB 버전 목록 보기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -110,6 +116,12 @@ GET /v1.0/db-versions
 ```http
 GET /v1.0/db-flavors
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbFlavor.List | DB 인스턴스 유형 목록 보기 |
 
 #### 요청
 
@@ -159,6 +171,12 @@ GET /v1.0/db-flavors
 GET /v1.0/project/members
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:Project.Get | 프로젝트의 멤버 목록 조회 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -205,6 +223,12 @@ GET /v1.0/project/members
 GET /v1.0/project/regions
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:Project.Get | 프로젝트의 리전 목록 조회 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -248,6 +272,12 @@ GET /v1.0/project/regions
 ```http
 GET /v1.0/network/subnets
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:Network.List | 서브넷 목록 보기 |
 
 #### 요청
 
@@ -298,6 +328,12 @@ GET /v1.0/network/subnets
 ```http
 GET /v1.0/storage-types
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:Storage.List | 스토리지 유형 목록 보기 |
 
 #### 요청
 
@@ -352,6 +388,12 @@ GET /v1.0/storage-types
 ```http
 GET /v1.0/jobs/{jobId}
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:Job.Get | 작업 정보 상세 보기 |
 
 #### 요청
 
@@ -409,6 +451,12 @@ GET /v1.0/jobs/{jobId}
 GET /v1.0/db-instance-groups
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceGroup.List | DB 인스턴스 그룹 목록 보기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -456,6 +504,12 @@ GET /v1.0/db-instance-groups
 ```http
 GET /v1.0/db-instance-groups/{dbInstanceGroupId}
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceGroup.Get | DB 인스턴스 그룹 상세 보기 |
 
 #### 요청
 
@@ -514,6 +568,12 @@ GET /v1.0/db-instance-groups/{dbInstanceGroupId}
 ```http
 GET /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceGroupExtension.List | 확장 리스트 조회 |
 
 #### 요청
 
@@ -582,6 +642,12 @@ GET /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions
 POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/apply
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceGroupExtension.Apply | 확장 변경사항 적용 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -620,6 +686,12 @@ POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/apply
 ```http
 POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/sync
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceGroupExtension.Sync | 확장 동기화 |
 
 #### 요청
 
@@ -660,6 +732,12 @@ POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/sync
 DELETE /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{dbInstanceGroupExtensionId}
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceGroupExtension.Delete | 확장 삭제(취소) |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -681,6 +759,12 @@ DELETE /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{dbInstanceGroupE
 ```http
 POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{extensionId}
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceGroupExtension.Install | 확장 설치 |
 
 #### 요청
 
@@ -765,6 +849,12 @@ POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{extensionId}
 GET /v1.0/db-instances
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.List | DB 인스턴스 목록 보기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -824,6 +914,12 @@ GET /v1.0/db-instances
 ```http
 POST /v1.0/db-instances
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Create | DB 인스턴스 생성하기 |
 
 #### 요청
 
@@ -937,6 +1033,12 @@ POST /v1.0/db-instances
 ```http
 POST /v1.0/db-instances/restore-from-obs
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.RestoreFromObs | DB 인스턴스 오브젝트 스토리지에 있는 백업으로 복원 |
 
 #### 요청
 
@@ -1062,6 +1164,12 @@ POST /v1.0/db-instances/restore-from-obs
 DELETE /v1.0/db-instances/{dbInstanceId}
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Delete | DB 인스턴스 삭제하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -1100,6 +1208,12 @@ DELETE /v1.0/db-instances/{dbInstanceId}
 ```http
 GET /v1.0/db-instances/{dbInstanceId}
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Get | DB 인스턴스 상세 보기 |
 
 #### 요청
 
@@ -1176,6 +1290,12 @@ GET /v1.0/db-instances/{dbInstanceId}
 PUT /v1.0/db-instances/{dbInstanceId}
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Modify | DB 인스턴스 수정하기 |
+
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -1248,6 +1368,12 @@ PUT /v1.0/db-instances/{dbInstanceId}
 POST /v1.0/db-instances/{dbInstanceId}/apply-recent-parameter-group
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Modify | DB 인스턴스 최신 파라미터 그룹 적용하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -1286,6 +1412,12 @@ POST /v1.0/db-instances/{dbInstanceId}/apply-recent-parameter-group
 ```http
 GET /v1.0/db-instances/{dbInstanceId}/available-db-versions
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Get | 현 DB 인스턴스에서 선택 가능한 DB 버전 조회 |
 
 #### 요청
 
@@ -1337,6 +1469,12 @@ GET /v1.0/db-instances/{dbInstanceId}/available-db-versions
 POST /v1.0/db-instances/{dbInstanceId}/backup
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Backup | DB 인스턴스 백업하기 |
+
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -1386,6 +1524,12 @@ POST /v1.0/db-instances/{dbInstanceId}/backup
 ```http
 GET /v1.0/db-instances/{dbInstanceId}/backup-info
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Get | DB 인스턴스 백업 정보 조회 |
 
 #### 요청
 
@@ -1440,6 +1584,12 @@ GET /v1.0/db-instances/{dbInstanceId}/backup-info
 ```http
 PUT /v1.0/db-instances/{dbInstanceId}/backup-info
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Modify | DB 인스턴스 백업 정보 수정하기 |
 
 #### 요청
 
@@ -1506,6 +1656,12 @@ PUT /v1.0/db-instances/{dbInstanceId}/backup-info
 POST /v1.0/db-instances/{dbInstanceId}/backup-to-object-storage
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.BackupToObjectStorage | DB 인스턴스 오브젝트 스토리지로 백업 |
+
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -1563,6 +1719,12 @@ POST /v1.0/db-instances/{dbInstanceId}/backup-to-object-storage
 ```http
 GET /v1.0/db-instances/{dbInstanceId}/databases
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceDatabase.List | 데이터베이스 목록 보기 |
 
 #### 요청
 
@@ -1623,6 +1785,12 @@ GET /v1.0/db-instances/{dbInstanceId}/databases
 POST /v1.0/db-instances/{dbInstanceId}/databases
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceDatabase.Create | 데이터베이스 생성하기 |
+
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -1673,6 +1841,12 @@ POST /v1.0/db-instances/{dbInstanceId}/databases
 DELETE /v1.0/db-instances/{dbInstanceId}/databases/{databaseId}
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceDatabase.Delete | 데이터베이스 삭제하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -1712,6 +1886,12 @@ DELETE /v1.0/db-instances/{dbInstanceId}/databases/{databaseId}
 ```http
 PUT /v1.0/db-instances/{dbInstanceId}/databases/{databaseId}
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceDatabase.Modify | 데이터베이스 수정하기 |
 
 #### 요청
 
@@ -1766,6 +1946,12 @@ PUT /v1.0/db-instances/{dbInstanceId}/databases/{databaseId}
 GET /v1.0/db-instances/{dbInstanceId}/db-users
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceUser.List | 사용자 목록 보기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -1819,6 +2005,12 @@ GET /v1.0/db-instances/{dbInstanceId}/db-users
 ```http
 POST /v1.0/db-instances/{dbInstanceId}/db-users
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceUser.Create | 사용자 생성하기 |
 
 #### 요청
 
@@ -1878,6 +2070,12 @@ POST /v1.0/db-instances/{dbInstanceId}/db-users
 DELETE /v1.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceUser.Delete | 사용자 삭제하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -1917,6 +2115,12 @@ DELETE /v1.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
 ```http
 PUT /v1.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceUser.Modify | 사용자 수정하기 |
 
 #### 요청
 
@@ -1975,6 +2179,12 @@ PUT /v1.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
 PUT /v1.0/db-instances/{dbInstanceId}/deletion-protection
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Modify | DB 인스턴스 삭제 보호 설정 변경하기 |
+
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -2006,6 +2216,12 @@ PUT /v1.0/db-instances/{dbInstanceId}/deletion-protection
 POST /v1.0/db-instances/{dbInstanceId}/force-restart
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.ForceRestart | DB 인스턴스 강제 재시작하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -2025,6 +2241,12 @@ POST /v1.0/db-instances/{dbInstanceId}/force-restart
 ```http
 GET /v1.0/db-instances/{dbInstanceId}/hba-rules
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceHba.List | 접근 제어 규칙 목록 보기 |
 
 #### 요청
 
@@ -2106,6 +2328,12 @@ GET /v1.0/db-instances/{dbInstanceId}/hba-rules
 POST /v1.0/db-instances/{dbInstanceId}/hba-rules
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceHba.Create | DB 인스턴스 접근제어 규칙 추가 |
+
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -2168,6 +2396,12 @@ POST /v1.0/db-instances/{dbInstanceId}/hba-rules
 POST /v1.0/db-instances/{dbInstanceId}/hba-rules/apply
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Modify | DB 인스턴스 접근제어 규칙 적용 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -2207,6 +2441,12 @@ POST /v1.0/db-instances/{dbInstanceId}/hba-rules/apply
 PUT /v1.0/db-instances/{dbInstanceId}/hba-rules/orders
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceHba.Modify | DB 인스턴스 접근제어 규칙 순서 조정 |
+
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -2238,6 +2478,12 @@ PUT /v1.0/db-instances/{dbInstanceId}/hba-rules/orders
 DELETE /v1.0/db-instances/{dbInstanceId}/hba-rules/{hbaRuleId}
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceHba.Delete | DB 인스턴스 접근제어 설정 삭제 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -2258,6 +2504,12 @@ DELETE /v1.0/db-instances/{dbInstanceId}/hba-rules/{hbaRuleId}
 ```http
 PUT /v1.0/db-instances/{dbInstanceId}/hba-rules/{hbaRuleId}
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceHba.Modify | DB 인스턴스 접근제어 규칙 수정 |
 
 #### 요청
 
@@ -2303,6 +2555,12 @@ PUT /v1.0/db-instances/{dbInstanceId}/hba-rules/{hbaRuleId}
 GET /v1.0/db-instances/{dbInstanceId}/high-availability
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:HighAvailability.Get | 고가용성 정보 조회 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -2345,6 +2603,12 @@ GET /v1.0/db-instances/{dbInstanceId}/high-availability
 ```http
 PUT /v1.0/db-instances/{dbInstanceId}/high-availability
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:HighAvailability.Modify | 고가용성 수정하기 |
 
 #### 요청
 
@@ -2400,6 +2664,12 @@ PUT /v1.0/db-instances/{dbInstanceId}/high-availability
 POST /v1.0/db-instances/{dbInstanceId}/high-availability/pause
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:HighAvailability.Pause | 고가용성 일시 중지하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -2438,6 +2708,12 @@ POST /v1.0/db-instances/{dbInstanceId}/high-availability/pause
 ```http
 POST /v1.0/db-instances/{dbInstanceId}/high-availability/repair
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:HighAvailability.Repair | 고가용성 복구하기 |
 
 #### 요청
 
@@ -2478,6 +2754,12 @@ POST /v1.0/db-instances/{dbInstanceId}/high-availability/repair
 POST /v1.0/db-instances/{dbInstanceId}/high-availability/resume
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:HighAvailability.Resume | 고가용성 다시 시작하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -2517,6 +2799,12 @@ POST /v1.0/db-instances/{dbInstanceId}/high-availability/resume
 POST /v1.0/db-instances/{dbInstanceId}/high-availability/split
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:HighAvailability.Split | 고가용성 분리하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -2555,6 +2843,12 @@ POST /v1.0/db-instances/{dbInstanceId}/high-availability/split
 ```http
 GET /v1.0/db-instances/{dbInstanceId}/maintenance-info
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Get | DB 인스턴스 유지보수 정보 조회 |
 
 #### 요청
 
@@ -2602,6 +2896,12 @@ GET /v1.0/db-instances/{dbInstanceId}/maintenance-info
 ```http
 PUT /v1.0/db-instances/{dbInstanceId}/maintenance-info
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Modify | DB 인스턴스 유지보수 정보 수정 |
 
 #### 요청
 
@@ -2660,6 +2960,12 @@ PUT /v1.0/db-instances/{dbInstanceId}/maintenance-info
 ```http
 GET /v1.0/db-instances/{dbInstanceId}/network-info
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Get | DB 인스턴스 네트워크 정보 조회 |
 
 #### 요청
 
@@ -2722,6 +3028,12 @@ GET /v1.0/db-instances/{dbInstanceId}/network-info
 PUT /v1.0/db-instances/{dbInstanceId}/network-info
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Modify | DB 인스턴스 네트워크 정보 수정하기 |
+
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -2772,6 +3084,12 @@ PUT /v1.0/db-instances/{dbInstanceId}/network-info
 POST /v1.0/db-instances/{dbInstanceId}/promote
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Promote | DB 인스턴스 승격하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -2810,6 +3128,12 @@ POST /v1.0/db-instances/{dbInstanceId}/promote
 ```http
 POST /v1.0/db-instances/{dbInstanceId}/replicate
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Replicate | 읽기 복제본 생성 |
 
 #### 요청
 
@@ -2891,6 +3215,12 @@ POST /v1.0/db-instances/{dbInstanceId}/replicate
 POST /v1.0/db-instances/{dbInstanceId}/restart
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Restart | DB 인스턴스 재시작하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -2929,6 +3259,12 @@ POST /v1.0/db-instances/{dbInstanceId}/restart
 ```http
 GET /v1.0/db-instances/{dbInstanceId}/restoration-info
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Get | DB 인스턴스 복원 정보 조회 |
 
 #### 요청
 
@@ -3003,6 +3339,12 @@ GET /v1.0/db-instances/{dbInstanceId}/restoration-info
 ```http
 POST /v1.0/db-instances/{dbInstanceId}/restore
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Restore | DB 인스턴스 복원 |
 
 #### 요청
 
@@ -3123,6 +3465,12 @@ POST /v1.0/db-instances/{dbInstanceId}/restore
 POST /v1.0/db-instances/{dbInstanceId}/start
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Start | DB 인스턴스 시작하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -3162,6 +3510,12 @@ POST /v1.0/db-instances/{dbInstanceId}/start
 POST /v1.0/db-instances/{dbInstanceId}/stop
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Stop | DB 인스턴스 정지하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -3200,6 +3554,12 @@ POST /v1.0/db-instances/{dbInstanceId}/stop
 ```http
 GET /v1.0/db-instances/{dbInstanceId}/storage-info
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Get | DB 인스턴스 스토리지 정보 조회 |
 
 #### 요청
 
@@ -3243,6 +3603,12 @@ GET /v1.0/db-instances/{dbInstanceId}/storage-info
 ```http
 PUT /v1.0/db-instances/{dbInstanceId}/storage-info
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Modify | DB 인스턴스 스토리지 정보 수정하기 |
 
 #### 요청
 
@@ -3306,6 +3672,12 @@ PUT /v1.0/db-instances/{dbInstanceId}/storage-info
 GET /v1.0/backups
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:Backup.List | 백업 목록 보기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -3368,6 +3740,12 @@ GET /v1.0/backups
 DELETE /v1.0/backups/{backupId}
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:Backup.Delete | 백업 삭제하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -3406,6 +3784,12 @@ DELETE /v1.0/backups/{backupId}
 ```http
 POST /v1.0/backups/{backupId}/export
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:Backup.Export | 백업 내보내기 |
 
 #### 요청
 
@@ -3464,6 +3848,12 @@ POST /v1.0/backups/{backupId}/export
 ```http
 POST /v1.0/backups/{backupId}/restore
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:Backup.Restore | 백업 복원하기 |
 
 #### 요청
 
@@ -3582,6 +3972,12 @@ POST /v1.0/backups/{backupId}/restore
 GET /v1.0/db-security-groups
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbSecurityGroup.List | DB 보안 그룹 목록 보기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -3633,6 +4029,12 @@ GET /v1.0/db-security-groups
 ```http
 POST /v1.0/db-security-groups
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbSecurityGroup.Create | DB 보안 그룹 생성하기 |
 
 #### 요청
 
@@ -3707,6 +4109,12 @@ POST /v1.0/db-security-groups
 DELETE /v1.0/db-security-groups/{dbSecurityGroupId}
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbSecurityGroup.Delete | DB 보안 그룹 삭제하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -3726,6 +4134,12 @@ DELETE /v1.0/db-security-groups/{dbSecurityGroupId}
 ```http
 GET /v1.0/db-security-groups/{dbSecurityGroupId}
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbSecurityGroup.Get | DB 보안 그룹 상세 보기 |
 
 #### 요청
 
@@ -3809,6 +4223,12 @@ GET /v1.0/db-security-groups/{dbSecurityGroupId}
 PUT /v1.0/db-security-groups/{dbSecurityGroupId}
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbSecurityGroup.Modify | DB 보안 그룹 수정하기 |
+
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -3841,6 +4261,12 @@ PUT /v1.0/db-security-groups/{dbSecurityGroupId}
 ```http
 DELETE /v1.0/db-security-groups/{dbSecurityGroupId}/rules
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbSecurityGroupRule.Delete | DB 보안 그룹 규칙 삭제하기 |
 
 #### 요청
 
@@ -3881,6 +4307,12 @@ DELETE /v1.0/db-security-groups/{dbSecurityGroupId}/rules
 ```http
 POST /v1.0/db-security-groups/{dbSecurityGroupId}/rules
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbSecurityGroupRule.Create | DB 보안 그룹 규칙 생성하기 |
 
 #### 요청
 
@@ -3946,6 +4378,12 @@ POST /v1.0/db-security-groups/{dbSecurityGroupId}/rules
 ```http
 PUT /v1.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:DbSecurityGroupRule.Modify | DB 보안 그룹 규칙 수정하기 |
 
 #### 요청
 
@@ -4015,6 +4453,12 @@ PUT /v1.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
 GET /v1.0/parameter-groups
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:ParameterGroup.List | 파라미터 그룹 목록 보기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -4066,6 +4510,12 @@ GET /v1.0/parameter-groups
 ```http
 POST /v1.0/parameter-groups
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:ParameterGroup.Create | 파라미터 그룹 생성하기 |
 
 #### 요청
 
@@ -4120,6 +4570,12 @@ POST /v1.0/parameter-groups
 DELETE /v1.0/parameter-groups/{parameterGroupId}
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:ParameterGroup.Delete | 파라미터 그룹 삭제하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -4139,6 +4595,12 @@ DELETE /v1.0/parameter-groups/{parameterGroupId}
 ```http
 GET /v1.0/parameter-groups/{parameterGroupId}
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:ParameterGroup.Get | 파라미터 그룹 상세 조회 |
 
 #### 요청
 
@@ -4221,6 +4683,12 @@ GET /v1.0/parameter-groups/{parameterGroupId}
 PUT /v1.0/parameter-groups/{parameterGroupId}
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:ParameterGroup.Modify | 파라미터 그룹 수정하기 |
+
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -4253,6 +4721,12 @@ PUT /v1.0/parameter-groups/{parameterGroupId}
 ```http
 POST /v1.0/parameter-groups/{parameterGroupId}/copy
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:ParameterGroup.Copy | 파라미터 그룹 복사하기 |
 
 #### 요청
 
@@ -4306,6 +4780,12 @@ POST /v1.0/parameter-groups/{parameterGroupId}/copy
 PUT /v1.0/parameter-groups/{parameterGroupId}/parameters
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:ParameterGroup.Modify | 파라미터 그룹 내 파라미터 수정하기 |
+
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -4344,6 +4824,12 @@ PUT /v1.0/parameter-groups/{parameterGroupId}/parameters
 PUT /v1.0/parameter-groups/{parameterGroupId}/reset
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:ParameterGroup.Reset | 파라미터 그룹 재설정하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -4365,6 +4851,12 @@ PUT /v1.0/parameter-groups/{parameterGroupId}/reset
 ```http
 GET /v1.0/user-groups
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:UserGroup.List | 사용자 그룹 목록 보기 |
 
 #### 요청
 
@@ -4413,6 +4905,12 @@ GET /v1.0/user-groups
 ```http
 POST /v1.0/user-groups
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:UserGroup.Create | 사용자 그룹 생성하기 |
 
 #### 요청
 
@@ -4467,6 +4965,12 @@ POST /v1.0/user-groups
 DELETE /v1.0/user-groups/{userGroupId}
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:UserGroup.Delete | 사용자 그룹 삭제하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -4486,6 +4990,12 @@ DELETE /v1.0/user-groups/{userGroupId}
 ```http
 GET /v1.0/user-groups/{userGroupId}
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:UserGroup.Get | 사용자 그룹 상세 보기 |
 
 #### 요청
 
@@ -4543,6 +5053,12 @@ GET /v1.0/user-groups/{userGroupId}
 PUT /v1.0/user-groups/{userGroupId}
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:UserGroup.Modify | 사용자 그룹 수정하기 |
+
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -4579,6 +5095,12 @@ PUT /v1.0/user-groups/{userGroupId}
 ```http
 GET /v1.0/notification-groups
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:NotificationGroup.List | 알림 그룹 목록 보기 |
 
 #### 요청
 
@@ -4633,6 +5155,12 @@ GET /v1.0/notification-groups
 ```http
 POST /v1.0/notification-groups
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:NotificationGroup.Create | 알림 그룹 생성하기 |
 
 #### 요청
 
@@ -4693,6 +5221,12 @@ POST /v1.0/notification-groups
 DELETE /v1.0/notification-groups/{notificationGroupId}
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:NotificationGroup.Delete | 알림 그룹 삭제하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -4712,6 +5246,12 @@ DELETE /v1.0/notification-groups/{notificationGroupId}
 ```http
 GET /v1.0/notification-groups/{notificationGroupId}
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:NotificationGroup.Get | 알림 그룹 상세 보기 |
 
 #### 요청
 
@@ -4784,6 +5324,12 @@ GET /v1.0/notification-groups/{notificationGroupId}
 PUT /v1.0/notification-groups/{notificationGroupId}
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:NotificationGroup.Modify | 알림 그룹 수정하기 |
+
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -4824,6 +5370,12 @@ PUT /v1.0/notification-groups/{notificationGroupId}
 ```http
 GET /v1.0/notification-groups/{notificationGroupId}/watchdogs
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:NotificationWatchdog.List | 감시 설정 목록 보기 |
 
 #### 요청
 
@@ -4878,6 +5430,12 @@ GET /v1.0/notification-groups/{notificationGroupId}/watchdogs
 ```http
 POST /v1.0/notification-groups/{notificationGroupId}/watchdogs
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:NotificationWatchdog.Create | 감시 설정 생성하기 |
 
 #### 요청
 
@@ -4935,6 +5493,12 @@ POST /v1.0/notification-groups/{notificationGroupId}/watchdogs
 DELETE /v1.0/notification-groups/{notificationGroupId}/watchdogs/{watchdogId}
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:NotificationWatchdog.Delete | 알림 그룹 삭제하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -4955,6 +5519,12 @@ DELETE /v1.0/notification-groups/{notificationGroupId}/watchdogs/{watchdogId}
 ```http
 PUT /v1.0/notification-groups/{notificationGroupId}/watchdogs/{watchdogId}
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:NotificationWatchdog.Modify | 감시 설정 수정하기 |
 
 #### 요청
 
@@ -4996,6 +5566,12 @@ PUT /v1.0/notification-groups/{notificationGroupId}/watchdogs/{watchdogId}
 GET /v1.0/metric-statistics
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:Metric.List | 통계 정보 조회 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -5011,6 +5587,12 @@ GET /v1.0/metric-statistics
 ```http
 GET /v1.0/metrics
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:Metric.List | 성능 지표 목록 보기 |
 
 #### 요청
 
@@ -5069,6 +5651,12 @@ GET /v1.0/metrics
 GET /v1.0/event-codes
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:Event.List | 구독 가능한 이벤트 코드 목록 보기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -5110,6 +5698,12 @@ GET /v1.0/event-codes
 ```http
 GET /v1.0/events
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforPostgreSQL:Event.List | 이벤트 목록 보기 |
 
 #### 요청
 

--- a/ko/api-guide-v1.0.md
+++ b/ko/api-guide-v1.0.md
@@ -1,6 +1,14 @@
-## Database > RDS for PostgreSQL > API 가이드
+## Database > RDS for PostgreSQL > API v1.0 가이드
 
 ## RDS for PostgreSQL API 공통 정보
+
+### API 엔드포인트
+
+| 리전 | 엔드포인트 |
+|------|----------|
+| 한국(판교) 리전 | https://kr1-rds-postgres.api.nhncloudservice.com |
+| 한국(평촌) 리전 | https://kr2-rds-postgres.api.nhncloudservice.com |
+
 
 ### 인증 및 권한
 
@@ -47,13 +55,6 @@ API 요청 시 인증에 실패하거나 권한이 없을 경우 다음과 같�
 | resultCode | Number | 결과 코드<br/>- 성공: `0`<br/>- 실패: `0`이 아닌 값 |
 | resultMessage | String | 결과 메시지 |
 | isSuccessful | Boolean | 성공 여부 |
-### API 엔드포인트
-
-| 리전 | 엔드포인트 |
-|------|----------|
-| 한국(판교) 리전 | https://kr1-rds-postgres.api.nhncloudservice.com |
-| 한국(평촌) 리전 | https://kr2-rds-postgres.api.nhncloudservice.com |
-
 ## DB 버전
 
 ### DB 버전 목록 보기

--- a/ko/api-guide-v1.0.md
+++ b/ko/api-guide-v1.0.md
@@ -15,7 +15,7 @@
 ### 인증 및 권한
 
 RDS for PostgreSQL은(는) API 호출 시 인증/인가를 위해 User Access Key 토큰을 사용합니다. User Access Key 토큰은 User Access Key를 기반으로 발급되는 Bearer 타입의 일시적 액세스 토큰입니다. User Access Key 토큰 발급 및 사용에 대한 자세한 내용은 [User Access Key 토큰](/nhncloud/ko/public-api/user-access-key-token)을 참고하세요.
-발급 받은 토큰은 Appkey와 함께 요청 Header에 포함해야 합니다.
+발급 받은 토큰은 Appkey와 함께 요청 헤더에 포함해야 합니다.
 
 | 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
@@ -593,7 +593,7 @@ GET /v1.0/db-instance-groups/{dbInstanceGroupId}
 | dbInstances | Array | DB 인스턴스 그룹에 속한 DB 인스턴스 목록 |
 | dbInstances.dbInstanceId | UUID | DB 인스턴스의 식별자 |
 | dbInstances.dbInstanceType | Enum | DB 인스턴스의 역할 타입<br/>- MASTER: `마스터`<br/>- FAILED_MASTER: `장애 마스터`<br/>- CANDIDATE_MASTER: `예비 마스터`<br/>- READ_ONLY_SLAVE: `읽기 복제본` |
-| dbInstances.dbInstanceStatus | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전 (회색)`<br/>- AVAILABLE: `사용 가능 (녹색)`<br/>- STORAGE_FULL: `용량 부족 (적색)`<br/>- FAIL_TO_CREATE: `생성 실패 (적색)`<br/>- FAIL_TO_CONNECT: `연결 실패 (적색)`<br/>- REPLICATION_STOP: `복제 중단 (적색)`<br/>- REPLICATION_DELAY: `복제 지연 (황색)`<br/>- FAILOVER: `장애 조치 완료 (적색)`<br/>- SHUTDOWN: `중지 됨 (회색)`<br/>- DELETED: `삭제됨 (회색)` |
+| dbInstances.dbInstanceStatus | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전(회색)`<br/>- AVAILABLE: `사용 가능(녹색)`<br/>- STORAGE_FULL: `용량 부족(적색)`<br/>- FAIL_TO_CREATE: `생성 실패(적색)`<br/>- FAIL_TO_CONNECT: `연결 실패(적색)`<br/>- REPLICATION_STOP: `복제 중단(적색)`<br/>- REPLICATION_DELAY: `복제 지연(황색)`<br/>- FAILOVER: `장애 조치 완료(적색)`<br/>- SHUTDOWN: `중지됨(회색)`<br/>- DELETED: `삭제됨(회색)` |
 | createdYmdt | DateTime | 생성 일시 |
 | updatedYmdt | DateTime | 수정 일시 |
 
@@ -668,8 +668,8 @@ GET /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions
 | extensions.databases.dbInstanceGroupExtensionId | UUID | DB 인스턴스 그룹 확장 ID |
 | extensions.databases.databaseId | UUID | 데이터베이스 ID |
 | extensions.databases.databaseName | String | 데이터베이스 이름 |
-| extensions.databases.dbInstanceGroupExtensionStatus | Enum | 데이터베이스 확장 설치 상태<br/>- CREATED: `생성 됨`<br/>- INSTALLED: `설치 됨`<br/>- INSTALLING: `설치 중`<br/>- INSTALL_ERROR: `설치 에러`<br/>- DELETED: `삭제 됨`<br/>- DELETING: `삭제 중`<br/>- DELETE_ERROR: `삭제 에러` |
-| extensions.databases.reservedAction | Enum | 예약 작업<br/>- NONE: `없음`<br/>- INSTALL: `설치 예약 (적용 필요)`<br/>- INSTALL_WITH_CASCADE: `강제 설치 예약 (적용 필요)`<br/>- DELETE: `삭제 예약 (적용 필요)`<br/>- DELETE_WITH_CASCADE: `강제 삭제 예약 (적용 필요)` |
+| extensions.databases.dbInstanceGroupExtensionStatus | Enum | 데이터베이스 확장 설치 상태<br/>- CREATED: `생성 됨`<br/>- INSTALLED: `설치 됨`<br/>- INSTALLING: `설치 중`<br/>- INSTALL_ERROR: `설치 에러`<br/>- DELETED: `삭제됨`<br/>- DELETING: `삭제 중`<br/>- DELETE_ERROR: `삭제 에러` |
+| extensions.databases.reservedAction | Enum | 예약 작업<br/>- NONE: `없음`<br/>- INSTALL: `설치 예약(적용 필요)`<br/>- INSTALL_WITH_CASCADE: `강제 설치 예약(적용 필요)`<br/>- DELETE: `삭제 예약(적용 필요)`<br/>- DELETE_WITH_CASCADE: `강제 삭제 예약(적용 필요)` |
 | extensions.databases.errorReason | String | 에러 원인 |
 | isNeedToApply | Boolean | 적용 필요 여부 |
 
@@ -958,7 +958,7 @@ GET /v1.0/db-instances
 | dbInstances.dbVersion | String | DB 엔진 유형 |
 | dbInstances.dbPort | Number | DB 포트 |
 | dbInstances.dbInstanceType | Enum | DB 인스턴스 역할 타입<br/>- MASTER: `마스터`<br/>- FAILED_MASTER: `장애 마스터`<br/>- CANDIDATE_MASTER: `예비 마스터`<br/>- READ_ONLY_SLAVE: `읽기 복제본` |
-| dbInstances.dbInstanceStatus | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전 (회색)`<br/>- AVAILABLE: `사용 가능 (녹색)`<br/>- STORAGE_FULL: `용량 부족 (적색)`<br/>- FAIL_TO_CREATE: `생성 실패 (적색)`<br/>- FAIL_TO_CONNECT: `연결 실패 (적색)`<br/>- REPLICATION_STOP: `복제 중단 (적색)`<br/>- REPLICATION_DELAY: `복제 지연 (황색)`<br/>- FAILOVER: `장애 조치 완료 (적색)`<br/>- SHUTDOWN: `중지 됨 (회색)`<br/>- DELETED: `삭제됨 (회색)` |
+| dbInstances.dbInstanceStatus | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전(회색)`<br/>- AVAILABLE: `사용 가능(녹색)`<br/>- STORAGE_FULL: `용량 부족(적색)`<br/>- FAIL_TO_CREATE: `생성 실패(적색)`<br/>- FAIL_TO_CONNECT: `연결 실패(적색)`<br/>- REPLICATION_STOP: `복제 중단(적색)`<br/>- REPLICATION_DELAY: `복제 지연(황색)`<br/>- FAILOVER: `장애 조치 완료(적색)`<br/>- SHUTDOWN: `중지됨(회색)`<br/>- DELETED: `삭제됨(회색)` |
 | dbInstances.progressStatus | String | DB 인스턴스의 현재 진행 상태 |
 | dbInstances.createdYmdt | DateTime | 생성 일시 |
 | dbInstances.updatedYmdt | DateTime | 수정 일시 |
@@ -1036,7 +1036,7 @@ POST /v1.0/db-instances
 | dbVersion | String | Y | DB 엔진 유형 |
 | dbPort | Number | Y | DB 포트<br/>- 최솟값: 5432, 최댓값: 45432 |
 | databaseName | String | Y | 데이터베이스명 |
-| dbUserName | String | Y | DB 사용자 계정명 |
+| dbUserName | String | Y | DB 사용자 계정 이름 |
 | dbPassword | String | Y | DB 사용자 계정 암호 |
 | parameterGroupId | UUID | Y | 파라미터 그룹의 식별자 |
 | dbSecurityGroupIds | Array | N | DB 보안 그룹의 식별자 목록 |
@@ -1056,7 +1056,7 @@ POST /v1.0/db-instances
 | backup | Object | Y | 백업 정보 |
 | backup.backupPeriod | Number | Y | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
 | backup.backupRetryCount | Number | N | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
-| backup.backupSchedules | Array | Y | 백업 스케쥴 정보 |
+| backup.backupSchedules | Array | Y | 백업 스케줄 정보 |
 | backup.backupSchedules.backupWndBgnTime | Time | Y | 백업 시작 시각 |
 | backup.backupSchedules.backupWndDuration | Enum | Y | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 
@@ -1175,12 +1175,12 @@ POST /v1.0/db-instances/restore-from-obs
 | backup.backupPeriod | Number | Y | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
 | backup.backupRetryCount | Number | N | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
 | backup.replicationRegion | Enum | N | 백업 복제 리전<br/>- KR1: `한국(판교)`<br/>- KR2: `한국(평촌)` |
-| backup.backupSchedules | Array | Y | 백업 스케쥴 목록 |
+| backup.backupSchedules | Array | Y | 백업 스케줄 목록 |
 | backup.backupSchedules.backupWndBgnTime | Time | Y | 백업 시작 시각 |
 | backup.backupSchedules.backupWndDuration | Enum | Y | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 | restore | Object | Y | 복원 정보 객체 |
 | restore.tenantId | String | Y | 백업이 저장된 오브젝트 스토리지의 테넌트 ID |
-| restore.username | String | Y | NHN Cloud 계정 혹은 IAM 멤버 ID |
+| restore.username | String | Y | NHN Cloud 계정 또는 IAM 계정 ID |
 | restore.password | String | Y | 백업이 저장된 오브젝트 스토리지의 API 비밀번호 |
 | restore.targetContainer | String | Y | 백업이 저장된 오브젝트 스토리지의 컨테이너 |
 | restore.objectPath | String | Y | 컨테이너에 저장된 백업의 경로 |
@@ -1335,7 +1335,7 @@ GET /v1.0/db-instances/{dbInstanceId}
 | dbVersion | String | DB 엔진 유형 |
 | dbPort | Number | DB 포트 |
 | dbInstanceType | Enum | DB 인스턴스 역할 타입<br/>- MASTER: `마스터`<br/>- FAILED_MASTER: `장애 마스터`<br/>- CANDIDATE_MASTER: `예비 마스터`<br/>- READ_ONLY_SLAVE: `읽기 복제본` |
-| dbInstanceStatus | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전 (회색)`<br/>- AVAILABLE: `사용 가능 (녹색)`<br/>- STORAGE_FULL: `용량 부족 (적색)`<br/>- FAIL_TO_CREATE: `생성 실패 (적색)`<br/>- FAIL_TO_CONNECT: `연결 실패 (적색)`<br/>- REPLICATION_STOP: `복제 중단 (적색)`<br/>- REPLICATION_DELAY: `복제 지연 (황색)`<br/>- FAILOVER: `장애 조치 완료 (적색)`<br/>- SHUTDOWN: `중지 됨 (회색)`<br/>- DELETED: `삭제됨 (회색)` |
+| dbInstanceStatus | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전(회색)`<br/>- AVAILABLE: `사용 가능(녹색)`<br/>- STORAGE_FULL: `용량 부족(적색)`<br/>- FAIL_TO_CREATE: `생성 실패(적색)`<br/>- FAIL_TO_CONNECT: `연결 실패(적색)`<br/>- REPLICATION_STOP: `복제 중단(적색)`<br/>- REPLICATION_DELAY: `복제 지연(황색)`<br/>- FAILOVER: `장애 조치 완료(적색)`<br/>- SHUTDOWN: `중지됨(회색)`<br/>- DELETED: `삭제됨(회색)` |
 | progressStatus | String | DB 인스턴스의 현재 진행 상태 |
 | dbFlavorId | UUID | DB 인스턴스 사양의 식별자 |
 | parameterGroupId | UUID | DB 인스턴스에 적용된 파라미터 그룹의 식별자 |
@@ -1567,7 +1567,8 @@ POST /v1.0/db-instances/{dbInstanceId}/backup
 
 ```json
 {
-    "backupName": "backupName-example"
+    "backupName": "backupName-example",
+    "backupMethodType": "FULL"
 }
 ```
 
@@ -1576,6 +1577,7 @@ POST /v1.0/db-instances/{dbInstanceId}/backup
 | 이름 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|
 | backupName | String | Y | 백업을 식별할 수 있는 이름 |
+| backupMethodType | Enum | N | 백업 방식<br/>- FULL<br/>- SNAPSHOT |
 
 #### 응답
 
@@ -1658,7 +1660,7 @@ GET /v1.0/db-instances/{dbInstanceId}/backup-info
 | usePeriodicAutoBackup | Boolean | 예정된 자동 백업 사용 여부 |
 | backupPeriod | Number | 백업 보관 기간(일) |
 | backupRetryCount | Number | 백업 재시도 횟수 |
-| backupSchedules | Array | 백업 스케쥴 목록 |
+| backupSchedules | Array | 백업 스케줄 목록 |
 | backupSchedules.backupWndBgnTime | Time | 백업 시작 시각 |
 | backupSchedules.backupWndDuration | Enum | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 
@@ -1712,7 +1714,7 @@ PUT /v1.0/db-instances/{dbInstanceId}/backup-info
 | usePeriodicAutoBackup | Boolean | N | 예정된 자동 백업 사용 여부 |
 | backupPeriod | Number | N | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
 | backupRetryCount | Number | N | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
-| backupSchedules | Array | N | 백업 스케쥴 목록 |
+| backupSchedules | Array | N | 백업 스케줄 목록 |
 | backupSchedules.backupWndBgnTime | Time | Y | 백업 시작 시각 |
 | backupSchedules.backupWndDuration | Enum | Y | 백업 윈도우<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 
@@ -1780,7 +1782,7 @@ POST /v1.0/db-instances/{dbInstanceId}/backup-to-object-storage
 | 이름 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|
 | tenantId | String | Y | 백업이 저장될 오브젝트 스토리지의 테넌트 ID<br/>- 최소 길이: `32`<br/>- 최대 길이: `32` |
-| username | String | Y | NHN Cloud 계정 혹은 IAM 회원 ID |
+| username | String | Y | NHN Cloud 계정 또는 IAM 계정 ID |
 | password | String | Y | 백업이 저장될 오브젝트 스토리지의 API 비밀번호 |
 | targetContainer | String | Y | 백업이 저장될 오브젝트 스토리지의 컨테이너 |
 | objectPath | String | Y | 컨테이너에 저장될 백업의 경로 |
@@ -2109,7 +2111,7 @@ GET /v1.0/db-instances/{dbInstanceId}/db-users
 | dbUsers | Array | DB 사용자 목록 |
 | dbUsers.dbUserId | UUID | DB 사용자의 식별자 |
 | dbUsers.dbUserName | String | DB 사용자 계정 이름 |
-| dbUsers.authorityType | Enum | DB 사용자 권한 타입<br/>- CUSTOM: `커스텀 권한 권한`<br/>- READ: `READ 권한 (읽기 전용 권한)`<br/>- CRUD: `CRUD 권한 (읽기 권한 포함)`<br/>- DDL: `DDL 권한 (CRUD 권한 포함)` |
+| dbUsers.authorityType | Enum | DB 사용자 권한 타입<br/>- CUSTOM: `커스텀 권한 권한`<br/>- READ: `READ 권한(읽기 전용 권한)`<br/>- CRUD: `CRUD 권한(읽기 권한 포함)`<br/>- DDL: `DDL 권한(CRUD 권한 포함)` |
 | dbUsers.dbUserStatus | Enum | DB 사용자의 현재 상태<br/>- STABLE: `사용 가능`<br/>- CREATING: `생성 중`<br/>- MODIFYING: `수정 중`<br/>- DELETING: `삭제 중`<br/>- DELETED: `삭제됨`<br/>- SYNCING: `동기화 중`<br/>- DELETE_ERROR: `삭제 실패` |
 | dbUsers.createdYmdt | DateTime | 생성 일시 |
 | dbUsers.updatedYmdt | DateTime | 수정 일시 |
@@ -2456,8 +2458,8 @@ GET /v1.0/db-instances/{dbInstanceId}/hba-rules
 | hbaRules.dbUsers.dbUserId | UUID | DB 사용자 ID |
 | hbaRules.dbUsers.dbUserName | String | DB 사용자 이름 |
 | hbaRules.address | String | 접속 주소 |
-| hbaRules.authMethod | Enum | 인증 방식<br/>- TRUST: `트러스트 (패스워드 불필요)`<br/>- REJECT: `접속 차단`<br/>- SCRAM_SHA_256: `패스워드 (SCRAM-SHA-256)` |
-| hbaRules.reservedAction | Enum | 예약된 작업 내용<br/>- NONE: `없음`<br/>- CREATE: `생성 예약 (적용 필요)`<br/>- MODIFY: `수정 예약 (적용 필요)`<br/>- DELETE: `삭제 예약 (적용 필요)` |
+| hbaRules.authMethod | Enum | 인증 방식<br/>- TRUST: `트러스트(패스워드 불필요)`<br/>- REJECT: `접속 차단`<br/>- SCRAM_SHA_256: `패스워드(SCRAM-SHA-256)` |
+| hbaRules.reservedAction | Enum | 예약된 작업 내용<br/>- NONE: `없음`<br/>- CREATE: `생성 예약(적용 필요)`<br/>- MODIFY: `수정 예약(적용 필요)`<br/>- DELETE: `삭제 예약(적용 필요)` |
 | hbaRules.order | Number | 규칙 적용 순서 |
 | hbaRules.applicable | Boolean | 적용 가능 여부 |
 | needToApply | Boolean | 변경사항 적용 필요 여부 |
@@ -2511,7 +2513,7 @@ POST /v1.0/db-instances/{dbInstanceId}/hba-rules
 | databaseIds | Array | N | 데이터베이스의 식별자 목록 |
 | dbUserIds | Array | N | DB 사용자의 식별자 목록 |
 | address | String | Y | 접속 주소 |
-| authMethod | Enum | Y | 인증 방식<br/>- TRUST: `트러스트 (패스워드 불필요)`<br/>- REJECT: `접속 차단`<br/>- SCRAM_SHA_256: `패스워드 (SCRAM-SHA-256)` |
+| authMethod | Enum | Y | 인증 방식<br/>- TRUST: `트러스트(패스워드 불필요)`<br/>- REJECT: `접속 차단`<br/>- SCRAM_SHA_256: `패스워드(SCRAM-SHA-256)` |
 
 #### 응답
 
@@ -2707,7 +2709,7 @@ PUT /v1.0/db-instances/{dbInstanceId}/hba-rules/{hbaRuleId}
 | databaseIds | Array | N | 데이터베이스의 식별자 목록 |
 | dbUserIds | Array | N | DB 사용자의 식별자 목록 |
 | address | String | Y | 접속 주소 |
-| authMethod | Enum | Y | 인증 방식<br/>- TRUST: `트러스트 (패스워드 불필요)`<br/>- REJECT: `접속 차단`<br/>- SCRAM_SHA_256: `패스워드 (SCRAM-SHA-256)` |
+| authMethod | Enum | Y | 인증 방식<br/>- TRUST: `트러스트(패스워드 불필요)`<br/>- REJECT: `접속 차단`<br/>- SCRAM_SHA_256: `패스워드(SCRAM-SHA-256)` |
 
 #### 응답
 
@@ -3535,11 +3537,11 @@ GET /v1.0/db-instances/{dbInstanceId}/restoration-info
 | restorableBackups | Array | 복원 가능한 백업 목록 |
 | restorableBackups.backupId | UUID | 백업의 식별자 |
 | restorableBackups.backupName | String | 백업 이름 |
-| restorableBackups.backupStatus | Enum | 백업 상태<br/>- BACKING_UP: `백업 중 (스피너)`<br/>- VERIFYING: `검증 중 (스피너)`<br/>- COMPLETED: `사용 가능 (녹색 아이콘)`<br/>- DELETING: `삭제 중 (스피너)`<br/>- DELETED: `삭제 됨 (회색 아이콘)`<br/>- ERROR: `에러 (적색 아이콘)` |
+| restorableBackups.backupStatus | Enum | 백업 상태<br/>- BACKING_UP: `백업 중(스피너)`<br/>- VERIFYING: `검증 중(스피너)`<br/>- COMPLETED: `사용 가능(녹색 아이콘)`<br/>- DELETING: `삭제 중(스피너)`<br/>- DELETED: `삭제됨(회색 아이콘)`<br/>- ERROR: `에러(적색 아이콘)` |
 | restorableBackups.dbInstanceId | UUID | 원본 DB 인스턴스의 식별자 |
 | restorableBackups.dbInstanceName | String | 원본 DB 인스턴스의 이름 |
 | restorableBackups.dbVersion | String | DB 엔진 유형 |
-| restorableBackups.backupType | Enum | 백업 유형<br/>- AUTO<br/>- MANUAL |
+| restorableBackups.backupType | Enum | 백업 유형<br/>- AUTO: `자동 백업`<br/>- MANUAL: `수동 백업` |
 | restorableBackups.backupSize | Number | 백업 크기 |
 | restorableBackups.failoverCount | Number | 장애 조치 횟수 |
 | restorableBackups.walFileName | String | WAL 로그 파일 이름 |
@@ -3643,7 +3645,7 @@ POST /v1.0/db-instances/{dbInstanceId}/restore
 | backup.backupPeriod | Number | Y | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
 | backup.backupRetryCount | Number | N | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
 | backup.replicationRegion | Enum | N | 백업 복제 리전<br/>- KR1: `한국(판교)`<br/>- KR2: `한국(평촌)` |
-| backup.backupSchedules | Array | Y | 백업 스케쥴 목록 |
+| backup.backupSchedules | Array | Y | 백업 스케줄 목록 |
 | backup.backupSchedules.backupWndBgnTime | Time | Y | 백업 시작 시각 |
 | backup.backupSchedules.backupWndDuration | Enum | Y | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 | restore | Object | Y | 복원 정보 객체 |
@@ -3824,7 +3826,7 @@ GET /v1.0/db-instances/{dbInstanceId}/storage-info
 |-----|-----|-----|
 | storageType | Enum | 데이터 스토리지 타입 |
 | storageSize | Number | 데이터 스토리지 크기(GB) |
-| storageStatus | Enum | 데이터 스토리지의 현재 상태<br/>- DELETED: `삭제됨`<br/>- PENDING_DELETION: `삭제 유예됨`<br/>- DELETION_RESERVED: `삭제 예약됨 (스냅샷 정리 대기)`<br/>- DETACHED: `해제됨`<br/>- ATTACHED: `할당됨` |
+| storageStatus | Enum | 데이터 스토리지의 현재 상태<br/>- DELETED: `삭제됨`<br/>- PENDING_DELETION: `삭제 유예됨`<br/>- DELETION_RESERVED: `삭제 예약됨(스냅숏 정리 대기)`<br/>- DETACHED: `해제됨`<br/>- ATTACHED: `할당됨` |
 
 ---
 
@@ -3958,10 +3960,10 @@ GET /v1.0/backups
 | backups | Array | 백업 목록 |
 | backups.backupId | UUID | 백업의 식별자 |
 | backups.backupName | String | 백업을 식별할 수 있는 이름 |
-| backups.backupStatus | Enum | 백업의 현재 상태<br/>- BACKING_UP: `백업 중 (스피너)`<br/>- VERIFYING: `검증 중 (스피너)`<br/>- COMPLETED: `사용 가능 (녹색 아이콘)`<br/>- DELETING: `삭제 중 (스피너)`<br/>- DELETED: `삭제 됨 (회색 아이콘)`<br/>- ERROR: `에러 (적색 아이콘)` |
+| backups.backupStatus | Enum | 백업의 현재 상태<br/>- BACKING_UP: `백업 중(스피너)`<br/>- VERIFYING: `검증 중(스피너)`<br/>- COMPLETED: `사용 가능(녹색 아이콘)`<br/>- DELETING: `삭제 중(스피너)`<br/>- DELETED: `삭제됨(회색 아이콘)`<br/>- ERROR: `에러(적색 아이콘)` |
 | backups.dbInstanceId | UUID | 원본 DB 인스턴스의 식별자 |
 | backups.dbVersion | String | DB 엔진 버전 |
-| backups.backupType | Enum | 백업 유형<br/>- AUTO<br/>- MANUAL |
+| backups.backupType | Enum | 백업 유형<br/>- AUTO: `자동 백업`<br/>- MANUAL: `수동 백업` |
 | backups.backupSize | Number | 백업의 크기(Byte) |
 | backups.startYmdt | DateTime | 시작 일시 |
 | backups.createdYmdt | DateTime | 생성 일시 |
@@ -4058,7 +4060,7 @@ POST /v1.0/backups/{backupId}/export
 | 이름 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|
 | tenantId | String | Y | 백업이 저장될 오브젝트 스토리지의 테넌트 ID<br/>- 최소 길이: `32`<br/>- 최대 길이: `32` |
-| username | String | Y | NHN Cloud 계정 혹은 IAM 회원 ID |
+| username | String | Y | NHN Cloud 계정 또는 IAM 계정 ID |
 | password | String | Y | 백업이 저장될 오브젝트 스토리지의 API 비밀번호 |
 | targetContainer | String | Y | 백업이 저장될 오브젝트 스토리지의 컨테이너 |
 | objectPath | String | Y | 컨테이너에 저장될 백업의 경로 |
@@ -4176,7 +4178,7 @@ POST /v1.0/backups/{backupId}/restore
 | backup | Object | Y | 백업 정보 객체 |
 | backup.backupPeriod | Number | Y | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
 | backup.backupRetryCount | Number | N | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
-| backup.backupSchedules | Array | Y | 백업 스케쥴 목록 |
+| backup.backupSchedules | Array | Y | 백업 스케줄 목록 |
 | backup.backupSchedules.backupWndBgnTime | Time | Y | 백업 시작 시간 |
 | backup.backupSchedules.backupWndDuration | Enum | Y | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 
@@ -4268,7 +4270,7 @@ GET /v1.0/db-security-groups
 | dbSecurityGroups.dbSecurityGroupName | String | DB 보안 그룹을 식별할 수 있는 이름 |
 | dbSecurityGroups.dbSecurityGroupStatus | Enum | DB 보안 그룹의 현재 상태<br/>- CREATED: `생성됨`<br/>- DELETED: `삭제됨` |
 | dbSecurityGroups.description | String | DB 보안 그룹에 대한 추가 정보 |
-| dbSecurityGroups.progressStatus | Enum | DB 보안 그룹의 현재 진행 상태<br/>- NONE: `없음`<br/>- CREATING_RULE: `규칙 생성중`<br/>- UPDATING_RULE: `규칙 수정중`<br/>- DELETING_RULE: `규칙 삭제중`<br/>- APPLYING_DEFAULT_RULE: `기본 규칙 적용중` |
+| dbSecurityGroups.progressStatus | Enum | DB 보안 그룹의 현재 진행 상태<br/>- NONE: `없음`<br/>- CREATING_RULE: `규칙 생성 중`<br/>- UPDATING_RULE: `규칙 수정 중`<br/>- DELETING_RULE: `규칙 삭제 중`<br/>- APPLYING_DEFAULT_RULE: `기본 규칙 적용 중` |
 | dbSecurityGroups.createdYmdt | DateTime | 생성 일시 |
 | dbSecurityGroups.updatedYmdt | DateTime | 수정 일시 |
 
@@ -4323,7 +4325,7 @@ POST /v1.0/db-security-groups
 | rules.direction | Enum | Y | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
 | rules.etherType | Enum | Y | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
 | rules.port | Object | Y | 포트 객체 |
-| rules.port.portType | Enum | Y | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
+| rules.port.portType | Enum | Y | 포트 타입<br/>- ALL: `포트 범위 전체(사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
 | rules.port.minPort | Number | N | 최소 포트 범위<br/>- 최솟값: `1` |
 | rules.port.maxPort | Number | N | 최대 포트 범위<br/>- 최댓값: `65535` |
 | rules.cidr | String | Y | CIDR |
@@ -4456,14 +4458,14 @@ GET /v1.0/db-security-groups/{dbSecurityGroupId}
 | dbSecurityGroup.dbSecurityGroupName | String | DB 보안 그룹을 식별할 수 있는 이름 |
 | dbSecurityGroup.dbSecurityGroupStatus | Enum | DB 보안 그룹의 현재 상태<br/>- CREATED: `생성됨`<br/>- DELETED: `삭제됨` |
 | dbSecurityGroup.description | String | DB 보안 그룹에 대한 추가 정보 |
-| dbSecurityGroup.progressStatus | Enum | DB 보안 그룹의 현재 진행 상태<br/>- NONE: `없음`<br/>- CREATING_RULE: `규칙 생성중`<br/>- UPDATING_RULE: `규칙 수정중`<br/>- DELETING_RULE: `규칙 삭제중`<br/>- APPLYING_DEFAULT_RULE: `기본 규칙 적용중` |
+| dbSecurityGroup.progressStatus | Enum | DB 보안 그룹의 현재 진행 상태<br/>- NONE: `없음`<br/>- CREATING_RULE: `규칙 생성 중`<br/>- UPDATING_RULE: `규칙 수정 중`<br/>- DELETING_RULE: `규칙 삭제 중`<br/>- APPLYING_DEFAULT_RULE: `기본 규칙 적용 중` |
 | dbSecurityGroup.rules | Array | DB 보안 그룹 규칙 목록 |
 | dbSecurityGroup.rules.ruleId | UUID | DB 보안 그룹 규칙의 식별자 |
 | dbSecurityGroup.rules.description | String | DB 보안 그룹 규칙에 대한 추가 정보 |
 | dbSecurityGroup.rules.direction | Enum | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
 | dbSecurityGroup.rules.etherType | Enum | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
 | dbSecurityGroup.rules.port | Object | 포트 객체 |
-| dbSecurityGroup.rules.port.portType | Enum | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
+| dbSecurityGroup.rules.port.portType | Enum | 포트 타입<br/>- ALL: `포트 범위 전체(사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
 | dbSecurityGroup.rules.port.minPort | Number | 최소 포트 범위 |
 | dbSecurityGroup.rules.port.maxPort | Number | 최대 포트 범위 |
 | dbSecurityGroup.rules.cidr | String | CIDR |
@@ -4614,7 +4616,7 @@ POST /v1.0/db-security-groups/{dbSecurityGroupId}/rules
 | direction | Enum | Y | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
 | etherType | Enum | Y | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
 | port | Object | Y | 포트 정보 |
-| port.portType | Enum | Y | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
+| port.portType | Enum | Y | 포트 타입<br/>- ALL: `포트 범위 전체(사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
 | port.minPort | Number | N | 최소 포트 범위<br/>- 최솟값: `1` |
 | port.maxPort | Number | N | 최대 포트 범위<br/>- 최댓값: `65535` |
 | cidr | String | Y | CIDR |
@@ -4691,7 +4693,7 @@ PUT /v1.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
 | direction | Enum | Y | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
 | etherType | Enum | Y | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
 | port | Object | Y | 포트 정보 |
-| port.portType | Enum | Y | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
+| port.portType | Enum | Y | 포트 타입<br/>- ALL: `포트 범위 전체(사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
 | port.minPort | Number | N | 최소 포트 범위<br/>- 최솟값: `1` |
 | port.maxPort | Number | N | 최대 포트 범위<br/>- 최댓값: `65535` |
 | cidr | String | Y | CIDR |
@@ -4952,7 +4954,7 @@ GET /v1.0/parameter-groups/{parameterGroupId}
  * ex) 120kB, 100MB
  * 허용된 바이트 단위: B (bytes), kB (kilobytes), MB (megabytes), GB (gigabytes), and TB (terabytes)`<br/>- NUMERIC_WITH_TIME_UNIT: `단위가 있는 숫자
  * ex) 120ms, 100s, 1d
- * 허용된 시간 단위: us (microseconds), ms (milliseconds), s (seconds), min (minutes), h (hours), and d (days)`<br/>- ENUMERATED: `allowed_value에 선언된 값 중 한 개 선택 (콤마(,)로 구분됨)`<br/>- MULTI_ENUMERATED: `allowed_value에 선언된 값 중 여러개 선택 (콤마(,)로 구분됨)` |
+ * 허용된 시간 단위: us (microseconds), ms (milliseconds), s (seconds), min (minutes), h (hours), and d (days)`<br/>- ENUMERATED: `allowed_value에 선언된 값 중 한 개 선택(콤마(,)로 구분됨)`<br/>- MULTI_ENUMERATED: `allowed_value에 선언된 값 중 여러개 선택(콤마(,)로 구분됨)` |
 | parameters.updateType | Enum | 수정 타입<br/>- VARIABLE: `동적, 언제든 수정 가능`<br/>- CONSTANT: `수정 불가능` |
 | parameters.applyType | Enum | 적용 타입<br/>- BOTH: `세션, 파일 모두 적용`<br/>- SESSION: `세션에만 적용`<br/>- FILE: `파일에만 적용` |
 | parameters.expressionAvailable | Boolean | 수식 허용 여부 |
@@ -6107,9 +6109,9 @@ GET /v1.0/events
 | events.eventCode | Enum | 발생한 이벤트의 유형 |
 | events.sourceId | UUID | 이벤트 소스의 식별자 |
 | events.sourceName | String | 이벤트 소스를 식별할 수 있는 이름 |
-| events.messages | Array | 이벤트 메세지 목록 |
+| events.messages | Array | 이벤트 메시지 목록 |
 | events.messages.langCode | Enum | 언어 코드<br/>- KO<br/>- EN<br/>- JA<br/>- ZH |
-| events.messages.message | String | 이벤트 메세지 |
+| events.messages.message | String | 이벤트 메시지 |
 | events.eventYmdt | DateTime | 이벤트 발생 일시 |
 
 ---

--- a/ko/api-guide-v1.0.md
+++ b/ko/api-guide-v1.0.md
@@ -1,22 +1,16 @@
-## Database > RDS for PostgreSQL > API 가이드 > API v1.0 가이드
+## Database > RDS for PostgreSQL > API 가이드
 
 ## RDS for PostgreSQL API 공통 정보
 
-### API 엔드포인트
-
-| 리전        | 엔드포인트                                            |
-|-----------|--------------------------------------------------|
-| 한국(판교) 리전 | https://kr1-rds-postgres.api.nhncloudservice.com |
-
 ### 인증 및 권한
 
-RDS for PostgreSQL은 API 호출 시 인증/인가를 위해 User Access Key 토큰을 사용합니다. User Access Key 토큰은 User Access Key를 기반으로 발급되는 Bearer 타입의 일시적 액세스 토큰입니다. User Access Key 토큰 발급 및 사용에 대한 자세한 내용은 [User Access Key 토큰](/nhncloud/ko/public-api/user-access-key-token)을 참고하세요.
+RDS for PostgreSQL은(는) API 호출 시 인증/인가를 위해 User Access Key 토큰을 사용합니다. User Access Key 토큰은 User Access Key를 기반으로 발급되는 Bearer 타입의 일시적 액세스 토큰입니다. User Access Key 토큰 발급 및 사용에 대한 자세한 내용은 [User Access Key 토큰](/nhncloud/ko/public-api/user-access-key-token)을 참고하세요.
 발급 받은 토큰은 Appkey와 함께 요청 Header에 포함해야 합니다.
 
-| 이름                  | 종류     | 형식     | 필수 | 설명                                               |
-|---------------------|--------|--------|----|--------------------------------------------------|
-| X-TC-APP-KEY        | Header | String | O  | RDS for PostgreSQL 서비스의 Appkey 또는 프로젝트 통합 Appkey |
-| X-NHN-AUTHORIZATION | Header | String | O  | Public API로 발급 받은 Bearer 유형 토큰                   |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| X-TC-APP-KEY | Header | String | O | RDS for PostgreSQL 서비스의 Appkey 또는 프로젝트 통합 Appkey |
+| X-NHN-AUTHORIZATION | Header | String | O | Public API로 발급 받은 Bearer 유형 토큰 |
 
 또한 프로젝트 권한에 따라 호출할 수 있는 API가 제한됩니다. `RDS for PostgreSQL ADMIN`, `RDS for PostgreSQL VIEWER` 역할에는 아래처럼 기본 권한이 부여돼 있고 프로젝트 내 역할 그룹 관리 메뉴에서 필요한 권한만 부여할 수 있습니다.
 
@@ -25,19 +19,18 @@ RDS for PostgreSQL은 API 호출 시 인증/인가를 위해 User Access Key 토
     * DB 인스턴스를 생성, 수정, 삭제하거나, DB 인스턴스를 대상으로 하는 어떠한 기능도 사용할 수 없습니다.
     * 단, 알림 그룹과 사용자 그룹 관련된 기능은 사용할 수 있습니다.
 
-API 요청 시 인증에 실패하거나 권한이 없으면 다음과 같은 오류가 발생합니다.
+API 요청 시 인증에 실패하거나 권한이 없을 경우 다음과 같은 오류가 발생합니다.
 
-| resultCode | resultMessage | 설명          |
-|------------|---------------|-------------|
-| 80401      | Unauthorized  | 인증에 실패했습니다. |
-| 80403      | Forbidden     | 권한이 없습니다.   |
+| resultCode | resultMessage | 설명 |
+|------------|---------------|-----|
+| 80401 | Unauthorized | 인증에 실패했습니다. |
+| 80403 | Forbidden | 권한이 없습니다. |
 
 ### 응답 공통 정보
 
-모든 API 요청에 `200 OK`로 응답합니다. 자세한 응답 결과는 응답 본문의 헤더를 참고합니다.
+모든 API 요청에 '200 OK'로 응답합니다. 자세한 응답 결과는 응답 본문의 헤더를 참고합니다.
 
 #### 응답 본문
-
 ```json
 {
     "header": {
@@ -49,39 +42,34 @@ API 요청 시 인증에 실패하거나 권한이 없으면 다음과 같은 �
 ```
 
 #### 필드
+| 이름 | 형식 | 설명 |
+|-----|-----|-----|
+| resultCode | Number | 결과 코드<br/>- 성공: `0`<br/>- 실패: `0`이 아닌 값 |
+| resultMessage | String | 결과 메시지 |
+| isSuccessful | Boolean | 성공 여부 |
+### API 엔드포인트
 
-| 이름            | 자료형     | 설명                    |
-|---------------|---------|-----------------------|
-| resultCode    | Number  | 결과 코드(성공: 0, 그 외: 실패) |
-| resultMessage | String  | 결과 메시지                |
-| successful    | Boolean | 성공 여부                 |
+| 리전 | 엔드포인트 |
+|------|----------|
+| 한국(판교) 리전 | https://kr1-rds-postgres.api.nhncloudservice.com |
+| 한국(평촌) 리전 | https://kr2-rds-postgres.api.nhncloudservice.com |
 
-## DB 버전
+## DB 보안 그룹
 
-| DB 버전             | 생성 가능 여부 |
-|-------------------|----------|
-| POSTGRESQL_V14_6  |          |
-| POSTGRESQL_V14_15 |          |
-| POSTGRESQL_V14_17 | O        |
-| POSTGRESQL_V14_19 | O        |
-| POSTGRESQL_V17_2  |          |
-| POSTGRESQL_V17_4  | O        |
-| POSTGRESQL_V17_6  | O        |
+### DB 보안 그룹 진행 상태
 
-* ENUM 유형의 dbVersion 필드에 대해 해당 값을 사용할 수 있습니다.
-* 버전에 따라 생성이 불가능하거나, 복원이 불가능한 경우가 있을 수 있습니다.
+| 상태              | 설명           |
+|-----------------|--------------|
+| `NONE`          | 진행 중인 작업이 없음 |
+| `CREATING_RULE` | 규칙 정책 생성 중   |
+| `UPDATING_RULE` | 규칙 정책 수정 중   |
+| `DELETING_RULE` | 규칙 정책 삭제 중   |
 
-### DB 버전 목록 보기
+### DB 보안 그룹 목록 보기
 
 ```http
-GET /v1.0/db-versions
+GET /v1.0/db-security-groups
 ```
-
-#### 필요 권한
-
-| 권한명                             | 설명          |
-|---------------------------------|-------------|
-| RDSforPostgreSQL:DbVersion.List | DB 버전 목록 보기 |
 
 #### 요청
 
@@ -89,14 +77,19 @@ GET /v1.0/db-versions
 
 #### 응답
 
-| 이름                           | 종류   | 형식      | 설명                    |
-|------------------------------|------|---------|-----------------------|
-| dbVersions                   | Body | Array   | DB 버전 목록              |
-| dbVersions.dbVersion         | Body | String  | DB 버전                 |
-| dbVersions.dbVersionName     | Body | String  | DB 버전명                |
-| dbVersions.restorableFromObs | Body | Boolean | 오브젝트 스토리지로부터 복원 가능 여부 |
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| dbSecurityGroups | Body | Array | DB 보안 그룹 목록 |
+| dbSecurityGroups.dbSecurityGroupId | Body | String | DB 보안 그룹의 식별자 |
+| dbSecurityGroups.dbSecurityGroupName | Body | String | DB 보안 그룹을 식별할 수 있는 이름 |
+| dbSecurityGroups.dbSecurityGroupStatus | Body | Enum | DB 보안 그룹의 현재 상태<br/>- CREATED: `생성됨`<br/>- DELETED: `삭제됨` |
+| dbSecurityGroups.description | Body | String | DB 보안 그룹에 대한 추가 정보 |
+| dbSecurityGroups.progressStatus | Body | Enum | DB 보안 그룹의 현재 진행 상태<br/>- NONE: `없음`<br/>- CREATING_RULE: `규칙 생성중`<br/>- UPDATING_RULE: `규칙 수정중`<br/>- DELETING_RULE: `규칙 삭제중`<br/>- APPLYING_DEFAULT_RULE: `기본 규칙 적용중` |
+| dbSecurityGroups.createdYmdt | Body | DateTime | 생성 일시 |
+| dbSecurityGroups.updatedYmdt | Body | DateTime | 수정 일시 |
 
 <details><summary>예시</summary>
+<p>
 
 ```json
 {
@@ -105,93 +98,67 @@ GET /v1.0/db-versions
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "dbVersions": [
+    "dbSecurityGroups": [
         {
-            "dbVersion": "POSTGRESQL_V17_6",
-            "dbVersionName": "PostgreSQL V17.6",
-            "restorableFromObs": true
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
+
+</p>
 </details>
 
-## DB 인스턴스 사양
+---
 
-### DB 인스턴스 사양 목록 보기
+### DB 보안 그룹 생성하기
 
 ```http
-GET /v1.0/db-flavors
+POST /v1.0/db-security-groups
 ```
-
-#### 필요 권한
-
-| 권한명                            | 설명               |
-|--------------------------------|------------------|
-| RDSforPostgreSQL:DbFlavor.List | DB 인스턴스 사양 목록 보기 |
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
-
-#### 응답
-
-| 이름                     | 종류   | 형식     | 설명              |
-|------------------------|------|--------|-----------------|
-| dbFlavors              | Body | Array  | DB 인스턴스 사양 목록   |
-| dbFlavors.dbFlavorId   | Body | UUID   | DB 인스턴스 사양의 식별자 |
-| dbFlavors.dbFlavorName | Body | String | DB 인스턴스 사양 이름   |
-| dbFlavors.ram          | Body | Number | 메모리 용량(MB)      |
-| dbFlavors.vcpus        | Body | Number | CPU 코어 수        |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupName | Body | String | O | DB 보안 그룹을 식별할 수 있는 이름 |
+| description | Body | String | X | DB 보안 그룹에 대한 추가 정보 |
+| rules | Body | Array | O | DB 보안 그룹 규칙 정보 |
+| rules.direction | Body | Enum | O | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
+| rules.etherType | Body | Enum | O | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
+| rules.port | Body | Object | O | 포트 객체 |
+| rules.port.portType | Body | Enum | O | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
+| rules.port.minPort | Body | Number | X | 최소 포트 범위<br/>- 최솟값: `1` |
+| rules.port.maxPort | Body | Number | X | 최대 포트 범위<br/>- 최댓값: `65535` |
+| rules.cidr | Body | String | O | CIDR |
+| rules.description | Body | String | X | 보안 그룹 규칙에 대한 추가 정보 |
 
 <details><summary>예시</summary>
+<p>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbFlavors": [
+    "dbSecurityGroupName": "dbSecurityGroupName-example",
+    "description": "description-example",
+    "rules": [
         {
-            "dbFlavorId": "50be6d9c-02d6-4594-a2d4-12010eb65ec0",
-            "dbFlavorName": "m2.c1m2",
-            "ram": 2048,
-            "vcpus": 1
+            "description": "description-example"
         }
     ]
 }
 ```
+
+</p>
 </details>
-
-## 프로젝트 정보
-
-### 리전 목록 보기
-
-```http
-GET /v1.0/project/regions
-```
-
-#### 필요 권한
-
-| 권한명                          | 설명         |
-|------------------------------|------------|
-| RDSforPostgreSQL:Project.Get | 프로젝트 정보 조회 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름                 | 종류   | 형식      | 설명                           |
-|--------------------|------|---------|------------------------------|
-| regions            | Body | Array   | 리전 목록                        |
-| regions.regionCode | Body | Enum    | 리전 코드<br/>- `KR1`: 한국(판교) 리전 |
-| regions.isEnabled  | Body | Boolean | 리전의 활성화 여부                   |
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| dbSecurityGroupId | Body | String | DB 보안 그룹의 식별자 |
 
 <details><summary>예시</summary>
+<p>
 
 ```json
 {
@@ -200,613 +167,356 @@ GET /v1.0/project/regions
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "regions": [
-        {
-            "regionCode": "KR1",
-            "isEnabled": true
-        }
-    ]
+    "dbSecurityGroupId": "dbSecurityGroupId-example"
 }
 ```
+
+</p>
 </details>
 
-### 프로젝트 멤버 목록 보기
+---
+
+### DB 보안 그룹 삭제하기
 
 ```http
-GET /v1.0/project/members
+DELETE /v1.0/db-security-groups/{dbSecurityGroupId}
 ```
-
-#### 필요 권한
-
-| 권한명                          | 설명         |
-|------------------------------|------------|
-| RDSforPostgreSQL:Project.Get | 프로젝트 정보 조회 |
 
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-#### 응답
-
-| 이름                   | 종류   | 형식     | 설명              |
-|----------------------|------|--------|-----------------|
-| members              | Body | Array  | 프로젝트 멤버 목록      |
-| members.memberId     | Body | UUID   | 프로젝트 멤버의 식별자    |
-| members.memberName   | Body | String | 프로젝트 멤버의 이름     |
-| members.emailAddress | Body | String | 프로젝트 멤버의 이메일 주소 |
-| members.phoneNumber  | Body | String | 프로젝트 멤버의 전화번호   |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "members": [
-        {
-            "memberId": "1b1d3627-507a-49ea-8cb7-c86dfa9caa58",
-            "memberName": "홍길동",
-            "emailAddress": "gildong.hong@nhn.com",
-            "phoneNumber": "+821012345678"
-        }
-    ]
-}
-```
-</details>
-
-## 네트워크
-
-### 서브넷 목록 보기
-
-```http
-GET /v1.0/network/subnets
-```
-
-#### 필요 권한
-
-| 권한명                           | 설명        |
-|-------------------------------|-----------|
-| RDSforPostgreSQL:Network.List | 서브넷 목록 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-#### 응답
-
-| 이름                       | 종류   | 형식      | 설명               |
-|--------------------------|------|---------|------------------|
-| subnets                  | Body | Array   | 서브넷 목록           |
-| subnets.subnetId         | Body | UUID    | 서브넷의 식별자         |
-| subnets.subnetName       | Body | String  | 서브넷을 식별할 수 있는 이름 |
-| subnets.subnetCidr       | Body | String  | 서브넷의 CIDR        |
-| subnets.usingGateway     | Body | Boolean | 게이트웨이 사용 여부      |
-| subnets.availableIpCount | Body | Number  | 사용 가능한 IP 수      |
-
-<details>
-<summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "subnets": [
-        {
-            "subnetId": "1b2a9b23-0725-4b92-8c78-35db66b8ad9f",
-            "subnetName": "Default Network",
-            "subnetCidr": "192.168.0.0/24",
-            "usingGateway": true,
-            "availableIpCount": 240
-        }
-    ]
-}
-```
-</details>
-
-## 스토리지
-
-### 스토리지 유형 목록 보기
-
-```http
-GET /v1.0/storage-types
-```
-
-#### 필요 권한
-
-| 권한명                           | 설명            |
-|-------------------------------|---------------|
-| RDSforPostgreSQL:Storage.List | 스토리지 유형 목록 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-#### 응답
-
-| 이름           | 종류   | 형식    | 설명         |
-|--------------|------|-------|------------|
-| storageTypes | Body | Array | 스토리지 유형 목록 |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "storageTypes": [
-        "General SSD",
-        "General HDD"
-    ]
-}
-```
-</details>
-
-## 작업 정보
-
-### 작업 정보 상세 보기
-
-```http
-GET /v1.0/jobs/{jobId}
-```
-
-#### 필요 권한
-
-| 권한명                      | 설명          |
-|--------------------------|-------------|
-| RDSforPostgreSQL:Job.Get | 작업 정보 상세 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름    | 종류  | 형식   | 필수 | 설명      |
-|-------|-----|------|----|---------|
-| jobId | URL | UUID | O  | 작업의 식별자 |
-
-#### 응답
-
-| 이름                             | 종류   | 형식       | 설명                                                                                                                                                                                                                                                                                                                                                                                                              |
-|--------------------------------|------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| jobId                          | Body | UUID     | 작업의 식별자                                                                                                                                                                                                                                                                                                                                                                                                         |
-| jobStatus                      | Body | Enum     | 작업의 현재 상태<br/>- `PREPARING`: 작업이 준비 중인 경우<br/>- `READY`: 작업이 준비 완료된 경우<br/>- `RUNNING`: 작업이 진행 중인 경우<br/>- `COMPLETED`: 작업이 완료된 경우<br/>- `REGISTERED`: 작업이 등록된 경우<br/>- `WAIT_TO_REGISTER`: 작업 등록 대기 중인 경우<br/>- `INTERRUPTED`: 작업 진행 중 인터럽트가 발생한 경우<br/>- `CANCELED`: 작업이 취소된 경우<br/>- `FAILED`: 작업이 실패한 경우<br/>- `ERROR`: 작업 진행 중 오류가 발생한 경우<br/>- `DELETED`: 작업이 삭제된 경우<br/>- `FAIL_TO_READY`: 작업 준비에 실패한 경우 |
-| resourceRelations              | Body | Array    | 연관 리소스 목록                                                                                                                                                                                                                                                                                                                                                                                                       |
-| resourceRelations.resourceType | Body | Enum     | 연관 리소스 유형<br/>- `DB_INSTANCE`: DB 인스턴스<br/>- `DB_INSTANCE_GROUP`: DB 인스턴스 그룹<br/>- `DB_SECURITY_GROUP`: DB 보안 그룹<br/>- `PARAMETER_GROUP`: 파라미터 그룹<br/>- `BACKUP`: 백업<br/>- `TENANT`: 테넌트                                                                                                                                                                                                                        |
-| resourceRelations.resourceId   | Body | UUID     | 연관 리소스의 식별자                                                                                                                                                                                                                                                                                                                                                                                                     |
-| createdYmdt                    | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                                                                                                                                                                                                                                               |
-| updatedYmdt                    | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                                                                                                                                                                                                                                               |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c",
-    "jobStatus": "RUNNING",
-    "resourceRelations": [
-        {
-            "resourceType": "DB_INSTANCE",
-            "resourceId": "56b39dcf-65eb-47ec-9d4f-09f160ba2266"
-        }
-    ],
-    "createdYmdt": "2023-02-22T20:47:12+09:00",
-    "updatedYmdt": "2023-02-22T20:49:46+09:00"
-}
-```
-</details>
-
-## DB 인스턴스 그룹
-
-### DB 인스턴스 그룹 목록 보기
-
-```http
-GET /v1.0/db-instance-groups
-```
-
-#### 필요 권한
-
-| 권한명                                   | 설명               |
-|---------------------------------------|------------------|
-| RDSforPostgreSQL:DbInstanceGroup.List | DB 인스턴스 그룹 목록 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-#### 응답
-
-| 이름                                     | 종류   | 형식       | 설명                                                          |
-|----------------------------------------|------|----------|-------------------------------------------------------------|
-| dbInstanceGroups                       | Body | Array    | DB 인스턴스 그룹 목록                                               |
-| dbInstanceGroups.dbInstanceGroupId     | Body | UUID     | DB 인스턴스 그룹의 식별자                                             |
-| dbInstanceGroups.dbInstanceGroupStatus | Body | Enum     | DB 인스턴스 그룹의 현재 상태<br/>- `CREATED`: 생성됨<br/>- `DELETED`: 삭제됨 |
-| dbInstanceGroups.replicationType       | Body | Enum     | DB 인스턴스 그룹의 복제 형태<br/>- `STANDALONE`: 단일                    |
-| dbInstanceGroups.createdYmdt           | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                           |
-| dbInstanceGroups.updatedYmdt           | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                           |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceGroups": [
-        {
-            "dbInstanceGroupId": "05de0746-89fd-49c8-94f9-9c5b1df97009",
-            "dbInstanceGroupStatus": "CREATED",
-            "replicationType": "STANDALONE",
-            "createdYmdt": "2023-02-13T17:35:20+09:00",
-            "updatedYmdt": "2023-02-13T17:35:20+09:00"
-        }
-    ]
-}
-```
-</details>
-
-
-### DB 인스턴스 그룹 상세 보기
-
-```http
-GET /v1.0/db-instance-groups/{dbInstanceGroupId}
-```
-
-#### 필요 권한
-
-| 권한명                                  | 설명               |
-|--------------------------------------|------------------|
-| RDSforPostgreSQL:DbInstanceGroup.Get | DB 인스턴스 그룹 상세 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름                | 종류  | 형식   | 필수 | 설명              |
-|-------------------|-----|------|----|-----------------|
-| dbInstanceGroupId | URL | UUID | O  | DB 인스턴스 그룹의 식별자 |
-
-#### 응답
-
-| 이름                           | 종류   | 형식       | 설명                                                                                                                                    |
-|------------------------------|------|----------|---------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceGroupId            | Body | UUID     | DB 인스턴스 그룹의 식별자                                                                                                                       |
-| dbInstanceGroupStatus        | Body | Enum     | DB 인스턴스 그룹의 현재 상태<br/>- `CREATED`: 생성됨<br/>- `DELETED`: 삭제됨                                                                           |
-| replicationType              | Body | Enum     | DB 인스턴스 그룹의 복제 형태<br/>- `STANDALONE`: 단일<br/>- `HIGH_AVAILABILITY`: 고가용성                                                              |
-| dbInstances                  | Body | Array    | DB 인스턴스 그룹에 속한 DB 인스턴스 목록                                                                                                             |
-| dbInstances.dbInstanceId     | Body | UUID     | DB 인스턴스의 식별자                                                                                                                          |
-| dbInstances.dbInstanceType   | Body | Enum     | DB 인스턴스의 역할 타입<br/>- `MASTER`: 마스터<br/>- `FAILED_MASTER`: 장애 조치된 마스터<br/>- `CANDIDATE_MASTER`: 예비 마스터<br/>- `READ_ONLY_SLAVE`: 읽기 복제본 |
-| dbInstances.dbInstanceStatus | Body | Enum     | DB 인스턴스의 현재 상태                                                                                                                        |
-| createdYmdt                  | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-| updatedYmdt                  | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceGroupId": "36617a8e-0df8-4b16-b6ea-6306019e95da",
-    "dbInstanceGroupStatus": "CREATED",
-    "replicationType": "STANDALONE",
-    "dbInstances": [
-        {
-            "dbInstanceId": "6d2db0ef-fe9b-4ed4-97b1-d97fcb4cf1b8",
-            "dbInstanceType": "MASTER",
-            "dbInstanceStatus": "AVAILABLE"
-        }
-    ],
-    "createdYmdt": "2023-03-03T17:38:14+09:00",
-    "updatedYmdt": "2023-03-03T17:38:14+09:00"
-}
-```
-</details>
-
-## DB 인스턴스 그룹 > 확장 관리
-
-### 확장 목록 보기
-
-```http
-GET /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions
-```
-
-#### 필요 권한
-
-| 권한명                                            | 설명       |
-|------------------------------------------------|----------|
-| RDSforPostgreSQL:DbInstanceGroupExtension.List | 확장 목록 조회 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름                | 종류  | 형식   | 필수 | 설명              |
-|-------------------|-----|------|----|-----------------|
-| dbInstanceGroupId | URL | UUID | O  | DB 인스턴스 그룹의 식별자 |
-
-#### 응답
-
-| 이름                                                  | 종류   | 형식      | 설명                                                                                                                                                                                              |
-|-----------------------------------------------------|------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| extensions                                          | Body | Array   | 확장 목록                                                                                                                                                                                           |
-| extensions.extensionId                              | Body | UUID    | 확장의 식별자                                                                                                                                                                                         |
-| extensions.extensionName                            | Body | String  | 확장 이름                                                                                                                                                                                           |
-| extensions.extensionStatus                          | Body | ENUM    | 확장 상태<br/>- `AVAILABLE`: 사용 가능<br/>- `NEED_TO_APPLY`: 적용 필요<br/>- `APPLYING`: 적용 중                                                                                                               |
-| extensions.databases                                | Body | Array   | 확장이 설치된 데이터베이스 정보                                                                                                                                                                               |
-| extensions.databases.dbInstanceGroupExtensionId     | Body | UUID    | DB 인스턴스 그룹 내 확장의 식별자                                                                                                                                                                            |
-| extensions.databases.dbInstanceGroupExtensionStatus | Body | ENUM    | DB 인스턴스 그룹 내 확장 상태<br/>- `CREATED`: 생성됨<br/>- `INSTALLED`: 설치됨<br/>- `INSTALLING`: 설치 중<br/>- `INSTALL_ERROR`: 설치 오류<br/>- `DELETED`: 삭제됨<br/>- `DELETING`: 삭제 중<br/>- `DELETE_ERROR`: 삭제 오류 |
-| extensions.databases.databaseId                     | Body | UUID    | 데이터베이스의 식별자                                                                                                                                                                                     |
-| extensions.databases.databaseName                   | Body | String  | 데이터베이스 이름                                                                                                                                                                                       |
-| extensions.databases.reservedAction                 | Body | ENUM    | 예약 작업<br/>- `NONE`: 없음<br/>- `INSTALL`: 설치 예약(적용 필요)<br/>- `INSTALL_WITH_CASCADE`: 강제 설치 예약(적용 필요)<br/>- `DELETE`: 삭제 예약(적용 필요)<br/>- `DELETE_WITH_CASCADE`: 강제 삭제 예약(적용 필요)                |
-| extensions.databases.errorReason                    | Body | String  | 오류 원인                                                                                                                                                                                           |
-| isNeedToApply                                       | Body | Boolean | 변경 사항 적용 필요 여부                                                                                                                                                                                  |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "extensions": [
-        {
-            "extensionId": "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4",
-            "extensionName": "address_standardizer",
-            "extensionStatus": "AVAILABLE",
-            "databases": [
-                {
-                    "dbInstanceGroupExtensionId": "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4",
-                    "databaseId": "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4",
-                    "databaseName": "database-1",
-                    "dbInstanceGroupExtensionStatus": "INSTALLED",
-                    "reservedAction": "NONE",
-                    "errorReason": null
-                }
-            ]
-        }
-    ],
-    "isNeedToApply": true
-}
-```
-</details>
-
-
-### 확장 설치
-
-```http
-POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{extensionId}
-```
-
-#### 필요 권한
-
-| 권한명                                               | 설명    |
-|---------------------------------------------------|-------|
-| RDSforPostgreSQL:DbInstanceGroupExtension.Install | 확장 설치 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름                | 종류   | 형식      | 필수 | 설명                |
-|-------------------|------|---------|----|-------------------|
-| dbInstanceGroupId | URL  | UUID    | O  | DB 인스턴스 그룹의 식별자   |
-| extensionId       | URL  | UUID    | O  | 확장의 식별자           |
-| databaseId        | Body | UUID    | O  | 설치 대상 데이터베이스의 식별자 |
-| schemaName        | Body | String  | O  | 설치 대상 스키마 이름      |
-| withCascade       | Body | Boolean | X  | 의존 정보 강제 설치 여부    |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
 
 #### 응답
 
 이 API는 응답 본문을 반환하지 않습니다.
 
-<details><summary>예시</summary>
+---
 
-```json
-{
-  "header": {
-    "resultCode": 0,
-    "resultMessage": "SUCCESS",
-    "isSuccessful": true
-  }
-}
-```
-</details>
-
-
-### 확장 삭제(취소)
+### DB 보안 그룹 상세 보기
 
 ```http
-DELETE /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{dbInstanceGroupExtensionId}
+GET /v1.0/db-security-groups/{dbSecurityGroupId}
 ```
-
-#### 필요 권한
-
-| 권한명                                              | 설명        |
-|--------------------------------------------------|-----------|
-| RDSforPostgreSQL:DbInstanceGroupExtension.Delete | 확장 삭제(취소) |
 
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름                         | 종류    | 형식      | 필수 | 설명                   |
-|----------------------------|-------|---------|----|----------------------|
-| dbInstanceGroupId          | URL   | UUID    | O  | DB 인스턴스 그룹의 식별자      |
-| dbInstanceGroupExtensionId | URL   | UUID    | O  | DB 인스턴스 그룹 내 확장의 식별자 |
-| withCascade                | Query | Boolean | O  | 의존 정보 강제 삭제 여부       |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| dbSecurityGroup | Body | Object | DB 보안 그룹 |
+| dbSecurityGroup.dbSecurityGroupId | Body | String | DB 보안 그룹의 식별자 |
+| dbSecurityGroup.dbSecurityGroupName | Body | String | DB 보안 그룹을 식별할 수 있는 이름 |
+| dbSecurityGroup.dbSecurityGroupStatus | Body | Enum | DB 보안 그룹의 현재 상태<br/>- CREATED: `생성됨`<br/>- DELETED: `삭제됨` |
+| dbSecurityGroup.description | Body | String | DB 보안 그룹에 대한 추가 정보 |
+| dbSecurityGroup.progressStatus | Body | Enum | DB 보안 그룹의 현재 진행 상태<br/>- NONE: `없음`<br/>- CREATING_RULE: `규칙 생성중`<br/>- UPDATING_RULE: `규칙 수정중`<br/>- DELETING_RULE: `규칙 삭제중`<br/>- APPLYING_DEFAULT_RULE: `기본 규칙 적용중` |
+| dbSecurityGroup.rules | Body | Array | DB 보안 그룹 규칙 목록 |
+| dbSecurityGroup.rules.ruleId | Body | String | DB 보안 그룹 규칙의 식별자 |
+| dbSecurityGroup.rules.description | Body | String | DB 보안 그룹 규칙에 대한 추가 정보 |
+| dbSecurityGroup.rules.direction | Body | Enum | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
+| dbSecurityGroup.rules.etherType | Body | Enum | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
+| dbSecurityGroup.rules.port | Body | Object | 포트 객체 |
+| dbSecurityGroup.rules.port.portType | Body | Enum | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
+| dbSecurityGroup.rules.port.minPort | Body | Number | 최소 포트 범위 |
+| dbSecurityGroup.rules.port.maxPort | Body | Number | 최대 포트 범위 |
+| dbSecurityGroup.rules.cidr | Body | String | CIDR |
+| dbSecurityGroup.rules.createdYmdt | Body | DateTime | 생성 일시 |
+| dbSecurityGroup.rules.updatedYmdt | Body | DateTime | 수정 일시 |
+| dbSecurityGroup.createdYmdt | Body | DateTime | 생성 일시 |
+| dbSecurityGroup.updatedYmdt | Body | DateTime | 수정 일시 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "dbSecurityGroup": {
+        "dbSecurityGroupId": "dbSecurityGroupId-example",
+        "dbSecurityGroupName": "dbSecurityGroupName-example",
+        "dbSecurityGroupStatus": "CREATED",
+        "description": "description-example",
+        "progressStatus": "NONE",
+        "rules": [
+            {
+                "updatedYmdt": "2023-12-31T15:00:00+09:00"
+            }
+        ],
+        "createdYmdt": "2023-12-31T15:00:00+09:00",
+        "updatedYmdt": "2023-12-31T15:00:00+09:00"
+    }
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 보안 그룹 수정하기
+
+```http
+PUT /v1.0/db-security-groups/{dbSecurityGroupId}
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+| dbSecurityGroupName | Body | String | O | DB 보안 그룹을 식별할 수 있는 이름 |
+| description | Body | String | X | DB 보안 그룹에 대한 추가 정보 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "dbSecurityGroupName": "dbSecurityGroupName-example",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
 
 #### 응답
 
 이 API는 응답 본문을 반환하지 않습니다.
 
-<details><summary>예시</summary>
+---
 
-```json
-{
-  "header": {
-    "resultCode": 0,
-    "resultMessage": "SUCCESS",
-    "isSuccessful": true
-  }
-}
-```
-</details>
-
-
-### 확장 변경 사항 적용
+### DB 보안 그룹 규칙 삭제하기
 
 ```http
-POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/apply
+DELETE /v1.0/db-security-groups/{dbSecurityGroupId}/rules
 ```
-
-#### 필요 권한
-
-| 권한명                                             | 설명         |
-|-------------------------------------------------|------------|
-| RDSforPostgreSQL:DbInstanceGroupExtension.Apply | 확장 변경 사항 적용 |
 
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름                         | 종류    | 형식      | 필수 | 설명                   |
-|----------------------------|-------|---------|----|----------------------|
-| dbInstanceGroupId          | URL   | UUID    | O  | DB 인스턴스 그룹의 식별자      |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+| ruleIds | Query | String | O | DB 보안 그룹 규칙 ID 리스트 |
 
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | 요청한 작업의 식별자 |
 
 <details><summary>예시</summary>
+<p>
 
 ```json
 {
-  "header": {
-    "resultCode": 0,
-    "resultMessage": "SUCCESS",
-    "isSuccessful": true
-  },
-  "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
+---
 
-### 확장 동기화
+### DB 보안 그룹 규칙 생성하기
 
 ```http
-POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/sync
+POST /v1.0/db-security-groups/{dbSecurityGroupId}/rules
 ```
-
-#### 필요 권한
-
-| 권한명                                            | 설명     |
-|------------------------------------------------|--------|
-| RDSforPostgreSQL:DbInstanceGroupExtension.Sync | 확장 동기화 |
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름                         | 종류    | 형식      | 필수 | 설명                   |
-|----------------------------|-------|---------|----|----------------------|
-| dbInstanceGroupId          | URL   | UUID    | O  | DB 인스턴스 그룹의 식별자      |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+| direction | Body | Enum | O | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
+| etherType | Body | Enum | O | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
+| port | Body | Object | O | 포트 정보 |
+| port.portType | Body | Enum | O | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
+| port.minPort | Body | Number | X | 최소 포트 범위<br/>- 최솟값: `1` |
+| port.maxPort | Body | Number | X | 최대 포트 범위<br/>- 최댓값: `65535` |
+| cidr | Body | String | O | CIDR |
+| description | Body | String | X | DB 보안 그룹 규칙에 대한 추가 정보 |
 
 <details><summary>예시</summary>
+<p>
 
 ```json
 {
-  "header": {
-    "resultCode": 0,
-    "resultMessage": "SUCCESS",
-    "isSuccessful": true
-  },
-  "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "direction": "INGRESS",
+    "etherType": "IPV4",
+    "port": {
+        "portType": "ALL",
+        "minPort": 1,
+        "maxPort": 1
+    },
+    "cidr": "cidr-example",
+    "description": "description-example"
 }
 ```
+
+</p>
 </details>
 
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 보안 그룹 규칙 수정하기
+
+```http
+PUT /v1.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+| ruleId | URL | UUID | O |  |
+| direction | Body | Enum | O | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
+| etherType | Body | Enum | O | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
+| port | Body | Object | O | 포트 정보 |
+| port.portType | Body | Enum | O | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
+| port.minPort | Body | Number | X | 최소 포트 범위<br/>- 최솟값: `1` |
+| port.maxPort | Body | Number | X | 최대 포트 범위<br/>- 최댓값: `65535` |
+| cidr | Body | String | O | CIDR |
+| description | Body | String | X | DB 보안 그룹 규칙에 대한 추가 정보 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "direction": "INGRESS",
+    "etherType": "IPV4",
+    "port": {
+        "portType": "ALL",
+        "minPort": 1,
+        "maxPort": 1
+    },
+    "cidr": "cidr-example",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
 
 ## DB 인스턴스
 
 ### DB 인스턴스 상태
 
-| 상태                  | 설명                          |
-|---------------------|-----------------------------|
-| `AVAILABLE`         | DB 인스턴스가 사용 가능한 경우          |
-| `BEFORE_CREATE`     | DB 인스턴스 생성 전인 경우            |
-| `STORAGE_FULL`      | DB 인스턴스의 용량이 부족한 경우         |
-| `FAIL_TO_CREATE`    | DB 인스턴스 생성에 실패한 경우          |
-| `FAIL_TO_CONNECT`   | DB 인스턴스 연결에 실패한 경우          |
-| `REPLICATION_STOP`  | DB 인스턴스의 복제가 중단된 경우         |
-| `REPLICATION_DELAY` | DB 인스턴스의 복제가 지연 중인 경우       |
-| `FAILOVER`          | 고가용성 DB 인스턴스의 장애 조치가 완료된 경우 |
-| `SHUTDOWN`          | DB 인스턴스가 중지된 경우             |
-| `DELETED`           | DB 인스턴스가 삭제된 경우             |
+| 상태                  | 설명                           |
+|---------------------|------------------------------|
+| `AVAILABLE`         | DB 인스턴스가 사용 가능한 경우           |
+| `BEFORE_CREATE`     | DB 인스턴스가 생성 전인 경우            |
+| `STORAGE_FULL`      | DB 인스턴스의 용량이 부족한 경우          |
+| `FAIL_TO_CREATE`    | DB 인스턴스 생성에 실패한 경우           |
+| `FAIL_TO_CONNECT`   | DB 인스턴스 연결에 실패한 경우           |
+| `REPLICATION_STOP`  | DB 인스턴스의 복제가 중단된 경우          |
+| `FAILOVER`          | DB 인스턴스가 고가용성 장애 조치된 경우      |
+| `SHUTDOWN`          | DB 인스턴스가 중지된 경우              |
+| `DELETED`           | DB 인스턴스가 삭제된 경우              |
 
 ### DB 인스턴스 진행 상태
 
-| 상태                              | 설명             |
-|---------------------------------|----------------|
-| `APPLYING_DB_INSTANCE_HBA_RULE` | 접근 제어 규칙 적용 중  |
-| `APPLYING_PARAMETER_GROUP`      | 파라미터 그룹 적용 중   |
-| `APPLYING_EXTENSION`            | 확장 적용 중        |
-| `BACKING_UP`                    | 백업 중           |
-| `CANCELING`                     | 취소 중           |
-| `CREATING`                      | 생성 중           |
-| `CREATING_DATABASE`             | 데이터베이스 생성 중	   |
-| `CREATING_USER`                 | 사용자 생성 중	      |
-| `DELETING`                      | 삭제 중           |
-| `DELETING_DATABASE`             | 데이터베이스 삭제 중    |
-| `DELETING_USER`                 | 사용자 삭제 중       |
-| `EXPORTING_BACKUP`              | 백업을 내보내는 중     |
-| `FAILING_OVER`                  | 장애 조치 중        |
-| `MIGRATING`                     | 마이그레이션 중       |
-| `MODIFYING`                     | 수정 중           |
-| `OCCUPIED`                      | 점유 중           |
-| `PREPARING`                     | 준비 중           |
-| `PROMOTING`                     | 승격 중           |
-| `PROMOTING_FORCIBLY`            | 강제 승격 중        |
-| `REBUILDING`                    | 재구축 중          |
-| `REPAIRING`                     | 복구 중           |
-| `REPLICATING`                   | 복제 중           |
-| `RESTARTING`                    | 재시작 중          |
-| `RESTARTING_FORCIBLY`           | 강제 재시작 중       |
-| `RESTORING`                     | 복원 중           |
-| `STARTING`                      | 시작 중           |
-| `STOPPING`                      | 정지 중           |
-| `SYNCING_DATABASE`              | 데이터베이스 동기화 중   |
-| `SYNCING_USER`                  | 사용자 동기화 중	     |
-| `SYNCING_EXTENSION`             | 확장 동기화 중	      |
-| `UPDATING_USER`                 | 사용자 수정 중	      |
-| `UPDATING_DATABASE`             | 데이터베이스 수정 중	   |
-| `WAIT_MANUAL_CONTROL`           | 수동 장애 조치 대기 중	 |
+| 상태                         | 설명           |
+|----------------------------|--------------|
+| `APPLYING_PARAMETER_GROUP` | 파라미터 그룹 적용 중 |
+| `BACKING_UP`               | 백업 중         |
+| `CANCELING`                | 취소 중         |
+| `CREATING`                 | 생성 중         |
+| `CREATING_SCHEMA`          | DB 스키마 생성 중  |
+| `CREATING_USER`            | 사용자 생성 중     |
+| `DELETING`                 | 삭제 중         |
+| `DELETING_SCHEMA`          | DB 스키마 삭제 중  |
+| `DELETING_USER`            | 사용자 삭제 중     |
+| `EXPORTING_BACKUP`         | 백업을 내보내는 중   |
+| `FAILING_OVER`             | 장애 조치 중      |
+| `MIGRATING`                | 마이그레이션 중     |
+| `MODIFYING`                | 수정 중         |
+| `PREPARING`                | 준비 중         |
+| `PROMOTING`                | 승격 중         |
+| `REBUILDING`               | 재구축 중        |
+| `REPAIRING`                | 복구 중         |
+| `REPLICATING`              | 복제 중         |
+| `RESTARTING`               | 재시작 중        |
+| `RESTARTING_FORCIBLY`      | 강제 재시작 중     |
+| `RESTORING`                | 복원 중         |
+| `STARTING`                 | 시작 중         |
+| `STOPPING`                 | 정지 중         |
+| `SYNCING_SCHEMA`           | DB 스키마 동기화 중 |
+| `SYNCING_USER`             | 사용자 동기화 중    |
+| `UPDATING_USER`            | 사용자 수정 중     |
 
 ### DB 인스턴스 목록 보기
 
@@ -814,34 +524,29 @@ POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/sync
 GET /v1.0/db-instances
 ```
 
-#### 필요 권한
-
-| 권한명                              | 설명            |
-|----------------------------------|---------------|
-| RDSforPostgreSQL:DbInstance.List | DB 인스턴스 목록 보기 |
-
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름                            | 종류   | 형식       | 설명                                                                                                                                    |
-|-------------------------------|------|----------|---------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstances                   | Body | Array    | DB 인스턴스 목록                                                                                                                            |
-| dbInstances.dbInstanceId      | Body | UUID     | DB 인스턴스의 식별자                                                                                                                          |
-| dbInstances.dbInstanceGroupId | Body | UUID     | DB 인스턴스 그룹의 식별자                                                                                                                       |
-| dbInstances.dbInstanceName    | Body | String   | DB 인스턴스를 식별할 수 있는 이름                                                                                                                  |
-| dbInstances.description       | Body | String   | DB 인스턴스에 대한 추가 정보                                                                                                                     |
-| dbInstances.dbVersion         | Body | Enum     | DB 버전 정보                                                                                                                              |
-| dbInstances.dbPort            | Body | Number   | DB 포트                                                                                                                                 |
-| dbInstances.dbInstanceType    | Body | Enum     | DB 인스턴스의 역할 타입<br/>- `MASTER`: 마스터<br/>- `FAILED_MASTER`: 장애 조치된 마스터<br/>- `CANDIDATE_MASTER`: 예비 마스터<br/>- `READ_ONLY_SLAVE`: 읽기 복제본 |
-| dbInstances.dbInstanceStatus  | Body | Enum     | DB 인스턴스의 현재 상태                                                                                                                        |
-| dbInstances.progressStatus    | Body | Enum     | DB 인스턴스의 현재 진행 상태                                                                                                                     |
-| dbInstances.createdYmdt       | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-| dbInstances.updatedYmdt       | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| dbInstances | Body | Array | DB 인스턴스 정보 |
+| dbInstances.dbInstanceId | Body | String | DB 인스턴스의 식별자 |
+| dbInstances.dbInstanceGroupId | Body | String | DB 인스턴스 그룹의 식별자 |
+| dbInstances.dbInstanceName | Body | String | DB 인스턴스를 식별할 수 있는 이름 |
+| dbInstances.description | Body | String | DB 인스턴스에 대한 추가 정보 |
+| dbInstances.dbVersion | Body | Enum | DB 엔진 유형 |
+| dbInstances.dbPort | Body | Number | DB 포트 |
+| dbInstances.dbInstanceType | Body | Enum | DB 인스턴스 역할 타입<br/>- MASTER: `마스터`<br/>- FAILED_MASTER: `장애 마스터`<br/>- CANDIDATE_MASTER: `예비 마스터`<br/>- READ_ONLY_SLAVE: `읽기 복제본` |
+| dbInstances.dbInstanceStatus | Body | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전 (회색)`<br/>- AVAILABLE: `사용 가능 (녹색)`<br/>- STORAGE_FULL: `용량 부족 (적색)`<br/>- FAIL_TO_CREATE: `생성 실패 (적색)`<br/>- FAIL_TO_CONNECT: `연결 실패 (적색)`<br/>- REPLICATION_STOP: `복제 중단 (적색)`<br/>- REPLICATION_DELAY: `복제 지연 (황색)`<br/>- FAILOVER: `장애 조치 완료 (적색)`<br/>- SHUTDOWN: `중지 됨 (회색)`<br/>- DELETED: `삭제됨 (회색)` |
+| dbInstances.progressStatus | Body | String | DB 인스턴스의 현재 진행 상태 |
+| dbInstances.createdYmdt | Body | DateTime | 생성 일시 |
+| dbInstances.updatedYmdt | Body | DateTime | 수정 일시 |
 
 <details><summary>예시</summary>
+<p>
 
 ```json
 {
@@ -852,98 +557,16 @@ GET /v1.0/db-instances
     },
     "dbInstances": [
         {
-            "dbInstanceId": "d067593b-1acc-4ccc-9e8a-cc72d6d79ec3",
-            "dbInstanceGroupId": "51c7d080-ff36-4025-84b1-9d9d0b4fe9e0",
-            "dbInstanceName": "db-instance",
-            "description": null,
-            "dbVersion": "POSTGRESQL_V17_6",
-            "dbPort": 15432,
-            "dbInstanceType": "MASTER",
-            "dbInstanceStatus": "AVAILABLE",
-            "progressStatus": "NONE",
-            "createdYmdt": "2023-01-23T12:03:13+09:00",
-            "updatedYmdt": "2023-02-02T17:20:17+09:00"
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
+
+</p>
 </details>
 
-
-### DB 인스턴스 상세 보기
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}
-```
-
-#### 필요 권한
-
-| 권한명                             | 설명            |
-|---------------------------------|---------------|
-| RDSforPostgreSQL:DbInstance.Get | DB 인스턴스 상세 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름                        | 종류   | 형식       | 설명                                                                                                                                    |
-|---------------------------|------|----------|---------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId              | Body | UUID     | DB 인스턴스의 식별자                                                                                                                          |
-| dbInstanceGroupId         | Body | UUID     | DB 인스턴스 그룹의 식별자                                                                                                                       |
-| dbInstanceName            | Body | String   | DB 인스턴스를 식별할 수 있는 이름                                                                                                                  |
-| description               | Body | String   | DB 인스턴스에 대한 추가 정보                                                                                                                     |
-| dbVersion                 | Body | Enum     | DB 버전 정보                                                                                                                              |
-| dbPort                    | Body | Number   | DB 포트                                                                                                                                 |
-| dbInstanceType            | Body | Enum     | DB 인스턴스의 역할 타입<br/>- `MASTER`: 마스터<br/>- `FAILED_MASTER`: 장애 조치된 마스터<br/>- `CANDIDATE_MASTER`: 예비 마스터<br/>- `READ_ONLY_SLAVE`: 읽기 복제본 |
-| dbInstanceStatus          | Body | Enum     | DB 인스턴스의 현재 상태                                                                                                                        |
-| progressStatus            | Body | Enum     | DB 인스턴스의 현재 작업 진행 상태                                                                                                                  |
-| dbFlavorId                | Body | UUID     | DB 인스턴스 사양의 식별자                                                                                                                       |
-| parameterGroupId          | Body | UUID     | DB 인스턴스에 적용된 파라미터 그룹의 식별자                                                                                                             |
-| dbSecurityGroupIds        | Body | Array    | DB 인스턴스에 적용된 DB 보안 그룹의 식별자 목록                                                                                                         |
-| notificationGroupIds      | Body | Array    | DB 인스턴스에 적용된 알림 그룹의 식별자 목록                                                                                                            |
-| useDeletionProtection     | Body | Boolean  | DB 인스턴스 삭제 보호 여부                                                                                                                      |
-| needToApplyParameterGroup | Body | Boolean  | 최신 파라미터 그룹 적용 필요 여부                                                                                                                   |
-| needMigration             | Body | Boolean  | 마이그레이션 필요 여부                                                                                                                          |
-| osVersion                 | Body | String   | 운영체제 버전                                                                                                                               |
-| createdYmdt               | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-| updatedYmdt               | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceId": "d067593b-1acc-4ccc-9e8a-cc72d6d79ec3",
-    "dbInstanceGroupId": "51c7d080-ff36-4025-84b1-9d9d0b4fe9e0",
-    "dbInstanceName": "db-instance",
-    "description": null,
-    "dbVersion": "POSTGRESQL_V17_6",
-    "dbPort": 15432,
-    "dbInstanceType": "MASTER",
-    "dbInstanceStatus": "AVAILABLE",
-    "progressStatus": "NONE",
-    "dbFlavorId": "e9ed4ef6-78d7-46fa-ace9-32481e97f3b7",
-    "parameterGroupId": "b03e8b13-de27-4d04-a488-ff5689589372",
-    "dbSecurityGroupIds": ["01908c35-d2c9-4852-baf0-17f06ec42c03"],
-    "notificationGroupIds": ["83a62a33-ddbf-4a04-8653-e54463d5b1ac"],
-    "useDeletionProtection": false,
-    "needToApplyParameterGroup": false,
-    "needMigration": false,
-    "createdYmdt": "2022-11-23T12:03:13+09:00",
-    "updatedYmdt": "2022-12-02T17:20:17+09:00"
-}
-```
-</details>
+---
 
 ### DB 인스턴스 생성하기
 
@@ -951,91 +574,95 @@ GET /v1.0/db-instances/{dbInstanceId}
 POST /v1.0/db-instances
 ```
 
-#### 필요 권한
-
-| 권한명                                | 설명           |
-|------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Create | DB 인스턴스 생성하기 |
-
 #### 요청
 
-| 이름                                       | 종류   | 형식      | 필수 | 설명                                                                                                                                                                                                                   |
-|------------------------------------------|------|---------|----|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceName                           | Body | String  | O  | DB 인스턴스를 식별할 수 있는 이름                                                                                                                                                                                                 |
-| description                              | Body | String  | X  | DB 인스턴스에 대한 추가 정보                                                                                                                                                                                                    |
-| dbFlavorId                               | Body | UUID    | O  | DB 인스턴스 사양의 식별자                                                                                                                                                                                                      |
-| dbVersion                                | Body | Enum    | O  | DB 버전 정보                                                                                                                                                                                                             |
-| dbPort                                   | Body | Number  | O  | DB 포트<br/>- 최솟값: `5432`<br/>- 최댓값: `45432`                                                                                                                                                                           |
-| databaseName                             | Body | String  | O  | DB 엔진 내 신규 생성할 데이터베이스명                                                                                                                                                                                               |
-| dbUserName                               | Body | String  | O  | DB 엔진 내 신규 생성할 사용자 계정명                                                                                                                                                                                               |
-| dbPassword                               | Body | String  | O  | DB 엔진 내 신규 생성할 사용자 계정 암호<br/>- 최소 길이: `4`<br/>- 최대 길이: `16`                                                                                                                                                          |
-| parameterGroupId                         | Body | UUID    | O  | 파라미터 그룹의 식별자                                                                                                                                                                                                         |
-| dbSecurityGroupIds                       | Body | Array   | X  | DB 보안 그룹의 식별자 목록                                                                                                                                                                                                     |
-| useDeletionProtection                    | Body | Boolean | X  | 삭제 보호 여부<br/>- 기본값: `false`                                                                                                                                                                                          |
-| useDefaultNotification                   | Body | Boolean | X  | 기본 알림 사용 여부<br/>- 기본값: `false`                                                                                                                                                                                       |
-| useHighAvailability                      | Body | Boolean | X  | 고가용성 사용 여부                                                                                                                                                                                                           |
-| pingInterval                             | Body | Number  | X  | 고가용성 사용 시 Ping 간격(초)<br/>- 최솟값: `1`<br/>- 최댓값: `600`                                                                                                                                                                 |
-| failoverReplWaitingTime                  | Body | Number  | X  | 고가용성 사용 시 장애 조치 대기 시간<br/>- 최솟값: `-1`<br/>- -1로 설정 시, 복제 지연 해소까지 계속해서 대기합니다.                                                                                                                                         |                                                                                                                                                                                                                      | userGroupIds                             | Body | Array   | X  | 기본 알림 수신용 사용자 그룹의 식별자 목록                                                                                                                                                                                             |
-| network                                  | Body | Object  | O  | 네트워크 정보 객체                                                                                                                                                                                                           |
-| network.subnetId                         | Body | UUID    | O  | 서브넷의 식별자                                                                                                                                                                                                             |
-| network.usePublicAccess                  | Body | Boolean | X  | 외부 접속 가능  여부<br/>- 기본값: `false`                                                                                                                                                                                      |
-| network.availabilityZone                 | Body | Enum    | X  | DB 인스턴스를 생성할 가용성 영역<br/>- 예시: `kr-pub-a`<br/>- 기본값: `임의의 가용성 영역`                                                                                                                                                     |
-| storage                                  | Body | Object  | O  | 스토리지 정보 객체                                                                                                                                                                                                           |    
-| storage.storageType                      | Body | Enum    | O  | 데이터 스토리지 유형<br/>- 예시: `General SSD`                                                                                                                                                                                  |
-| storage.storageSize                      | Body | Number  | O  | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20`<br/>- 최댓값: `2048`                                                                                                                                                                    |
-| backup                                   | Body | Object  | O  | 백업 정보 객체                                                                                                                                                                                                             |
-| backup.backupPeriod                      | Body | Number  | O  | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730`                                                                                                                                                                          |
-| backup.backupRetryCount                  | Body | Number  | X  | 백업 재시도 횟수<br/>- 기본값: `0`<br/>- 최솟값: `0`<br/>- 최댓값: `10`                                                                                                                                                              |
-| backup.backupSchedules                   | Body | Array   | X  | 백업 스케줄 목록                                                                                                                                                                                                            |
-| backup.backupSchedules.backupWndBgnTime  | Body | String  | O  | 백업 시작 시간<br/>- 예시: `00:00:00`                                                                                                                                                                                        |
-| backup.backupSchedules.backupWndDuration | Body | Enum    | O  | 백업 윈도우<br/>백업 시작 시간부터 설정된 기간 안에 자동 백업이 실행됩니다.<br/>- `HALF_AN_HOUR`: 30분<br/>- `ONE_HOUR`: 1시간<br/>- `ONE_HOUR_AND_HALF`: 1시간 30분<br/>- `TWO_HOURS`: 2시간<br/>- `TWO_HOURS_AND_HALF`: 2시간 30분<br/>- `THREE_HOURS`: 3시간 |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceName | Body | String | O | DB 인스턴스를 식별할 수 있는 이름 |
+| dbInstanceCandidateName | Body | String | X | DB 인스턴스를 식별할 수 있는 예비 마스터 이름 |
+| description | Body | String | X | DB 인스턴스에 대한 추가 정보 |
+| dbFlavorId | Body | UUID | O | DB 인스턴스 사양의 식별자 |
+| dbVersion | Body | Enum | O | DB 엔진 유형 |
+| dbPort | Body | Number | O | DB 포트<br/>- 최솟값: 5432, 최댓값: 45432 |
+| databaseName | Body | String | O | 데이터베이스명 |
+| dbUserName | Body | String | O | DB 사용자 계정명 |
+| dbPassword | Body | String | O | DB 사용자 계정 암호 |
+| parameterGroupId | Body | UUID | O | 파라미터 그룹의 식별자 |
+| dbSecurityGroupIds | Body | Array | X | DB 보안 그룹의 식별자 목록 |
+| userGroupIds | Body | Array | X | 사용자 그룹의 식별자 목록 |
+| useHighAvailability | Body | Boolean | X | 고가용성 사용 여부<br/>- 기본값: `false` |
+| useDefaultNotification | Body | Boolean | X | 기본 알림 사용 여부<br/>- 기본값: `false` |
+| useDeletionProtection | Body | Boolean | X | 삭제 보호 여부<br/>- 기본값: `false` |
+| pingInterval | Body | Number | X | Ping 간격(초)<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
+| failoverReplWaitingTime | Body | Number | X | 장애조치 복제 지연 대기 시간(초)<br/>- 최솟값: `-1` |
+| network | Body | Object | O | 네트워크 정보 |
+| network.subnetId | Body | UUID | O | 서브넷의 식별자 |
+| network.usePublicAccess | Body | Boolean | X | 외부 접속 가능 여부<br/>- 기본값: `false` |
+| network.availabilityZone | Body | Enum | X | DB 인스턴스를 생성할 가용성 영역 |
+| storage | Body | Object | O | 스토리지 정보 |
+| storage.storageType | Body | Enum | O | 스토리지 타입 |
+| storage.storageSize | Body | Number | O | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20` |
+| backup | Body | Object | O | 백업 정보 |
+| backup.backupPeriod | Body | Number | O | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
+| backup.backupRetryCount | Body | Number | X | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
+| backup.backupSchedules | Body | Array | O | 백업 스케쥴 정보 |
+| backup.backupSchedules.backupWndBgnTime | Body | String | O | 백업 시작 시각 |
+| backup.backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 
 <details><summary>예시</summary>
+<p>
 
 ```json
 {
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbVersion": "POSTGRESQL_V17_6",
-    "dbPort": 15432,
-    "databaseName": "database",
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
+    "dbInstanceName": "dbInstanceName-example",
+    "dbInstanceCandidateName": "dbInstanceCandidateName-example",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbVersion": "ENUM_VALUE",
+    "dbPort": 1,
+    "databaseName": "databaseName-example",
+    "dbUserName": "dbUserName-example",
+    "dbPassword": "dbPassword-example",
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
     "userGroupIds": [],
+    "useHighAvailability": false,
+    "useDefaultNotification": false,
+    "useDeletionProtection": false,
+    "pingInterval": 1,
+    "failoverReplWaitingTime": 1,
     "network": {
-        "subnetId": "e721a9dd-dad0-4cf0-a53b-dd654ebfc683",
-        "availabilityZone": "kr-pub-a"
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
+        "availabilityZone": "ENUM_VALUE"
     },
     "storage": {
-        "storageType": "General SSD",
+        "storageType": "ENUM_VALUE",
         "storageSize": 20
     },
     "backup": {
-        "backupPeriod": 1,
+        "backupPeriod": 0,
+        "backupRetryCount": 0,
         "backupSchedules": [
             {
-                "backupWndBgnTime": "00:00:00",
-                "backupWndDuration": "ONE_HOUR_AND_HALF",
-                "backupRetryExpireTime": "01:30:00"
+                "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
     }
 }
 ```
+
+</p>
 </details>
 
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | 요청한 작업의 식별자 |
 
 <details><summary>예시</summary>
+<p>
 
 ```json
 {
@@ -1044,142 +671,121 @@ POST /v1.0/db-instances
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-### DB 인스턴스 수정하기
+---
+
+### DB 인스턴스 오브젝트 스토리지에 있는 백업으로 복원
 
 ```http
-PUT /v1.0/db-instances/{dbInstanceId}
+POST /v1.0/db-instances/restore-from-obs
 ```
-
-#### 필요 권한
-
-| 권한명                                | 설명           |
-|------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Modify | DB 인스턴스 수정하기 |
 
 #### 요청
 
-| 이름                 | 종류   | 형식      | 필수 | 설명                                                                        |
-|--------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId       | URL  | UUID    | O  | DB 인스턴스의 식별자                                                              |
-| dbInstanceName     | Body | String  | X  | DB 인스턴스를 식별할 수 있는 이름                                                      |
-| description        | Body | String  | X  | DB 인스턴스에 대한 추가 정보                                                         |
-| dbPort             | Body | Number  | X  | DB 포트<br/>- 최솟값: `5432`<br/>- 최댓값: `45432`                                |
-| dbFlavorId         | Body | UUID    | X  | DB 인스턴스 사양의 식별자                                                           |
-| parameterGroupId   | Body | UUID    | X  | 파라미터 그룹의 식별자                                                              |
-| dbSecurityGroupIds | Body | Array   | X  | DB 보안 그룹의 식별자 목록                                                          |
-| executeBackup      | Body | Boolean | X  | 현재 시점 백업 진행 여부<br/>- 기본값: `false`                                         |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceName | Body | String | X | DB 인스턴스를 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| dbInstanceCandidateName | Body | String | X | DB 인스턴스를 식별할 수 있는 예비 마스터 이름 |
+| description | Body | String | X | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbFlavorId | Body | UUID | O | DB 인스턴스 사양의 식별자 |
+| dbPort | Body | Number | X | DB 포트<br/>- 최솟값: 5432, 최댓값: 45432 |
+| dbVersion | Body | Enum | O | DB 엔진 유형 |
+| useHighAvailability | Body | Boolean | X | 고가용성 사용 여부<br/>- 기본값: `false` |
+| imageId | Body | UUID | X | 이미지의 식별자 |
+| pingInterval | Body | Number | X | 고가용성 사용 시 Ping 간격(초)<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
+| failoverReplWaitingTime | Body | Number | X | 장애조치 복제 지연 대기 시간(초)<br/>- 최솟값: `-1` |
+| storage | Body | Object | O | 스토리지 정보 객체 |
+| storage.storageType | Body | Enum | O | 스토리지 타입 |
+| storage.storageSize | Body | Number | O | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20` |
+| network | Body | Object | O | 네트워크 정보 객체 |
+| network.subnetId | Body | UUID | O | 서브넷의 식별자 |
+| network.usePublicAccess | Body | Boolean | X | 외부 접속 가능 여부<br/>- 기본값: `false` |
+| network.availabilityZone | Body | Enum | X | DB 인스턴스를 생성할 가용성 영역 |
+| backup | Body | Object | O | 백업 정보 객체 |
+| backup.backupPeriod | Body | Number | O | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
+| backup.backupRetryCount | Body | Number | X | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
+| backup.replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)`<br/>- KR2: `한국(평촌)` |
+| backup.backupSchedules | Body | Array | O | 백업 스케쥴 목록 |
+| backup.backupSchedules.backupWndBgnTime | Body | String | O | 백업 시작 시각 |
+| backup.backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
+| restore | Body | Object | O | 복원 정보 객체 |
+| restore.tenantId | Body | String | O | 백업이 저장된 오브젝트 스토리지의 테넌트 ID |
+| restore.username | Body | String | O | NHN Cloud 계정 혹은 IAM 멤버 ID |
+| restore.password | Body | String | O | 백업이 저장된 오브젝트 스토리지의 API 비밀번호 |
+| restore.targetContainer | Body | String | O | 백업이 저장된 오브젝트 스토리지의 컨테이너 |
+| restore.objectPath | Body | String | O | 컨테이너에 저장된 백업의 경로 |
+| useDefaultNotification | Body | Boolean | X | 기본 알림 사용 여부<br/>- 기본값: `false` |
+| parameterGroupId | Body | UUID | O | 파라미터 그룹의 식별자 |
+| dbSecurityGroupIds | Body | Array | X | DB 보안 그룹의 식별자 목록 |
+| userGroupIds | Body | Array | X | 사용자 그룹의 식별자 목록 |
+| useDeletionProtection | Body | Boolean | X | 삭제 보호 여부<br/>- 기본값: `false` |
 
 <details><summary>예시</summary>
+<p>
 
 ```json
 {
-    "dbInstanceName": "db-instance2",
-    "description": "description2",
-    "dbPort": 25432,
-    "dbSecurityGroupIds": [],
-    "executeBackup": true
-}
-```
-</details>
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-
-### 고가용성 정보 조회
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}/high-availability
-```
-
-#### 필요 권한
-
-| 권한명                                   | 설명         |
-|---------------------------------------|------------|
-| RDSforPostgreSQL:HighAvailability.Get | 고가용성 정보 조회 |
-
-#### 요청
-
-| 이름                  | 종류   | 형식      | 필수 | 설명                                                   |
-|---------------------|------|---------|----|------------------------------------------------------|
-| dbInstanceId        | URL  | UUID    | O  | DB 인스턴스의 식별자                                         |
-
-#### 응답
-
-| 이름                      | 종류   | 형식      | 설명                                                                                                                                                                                                                                                                                                                             |
-|-------------------------|------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| haStatus                | Body | Boolean | 고가용성 상태<br/>- `CREATED`: 생성됨<br/>- `STABLE`: 정상<br/>- `DISABLE_REPLICATION_DELAY`: 복제 지연으로 인한 장애 조치 정지<br/>- `PAUSING`: 일시 중지 중<br/>- `PAUSED`: 일시 중지<br/>- `PAUSED_DUE_TO_TASK`: 작업으로 인한 일시 중지<br/>- `FAILOVER_STARTED`: 장애 조치 시작<br/>- `FAILOVER_FAILED`: 장애 조치 실패<br/>- `FAILOVER_COMPLETED`: 장애 조치 완료<br/>- `DELETED`: 삭제됨 |
-| pingInterval            | Body | Number  | 고가용성 사용 시 Ping 간격(초)<br/>- 최솟값: `1`<br/>- 최댓값: `600`                                                                                                                                                                                                                                                                           |
-| failoverReplWaitingTime | Body | Number  | 고가용성 사용 시 장애 조치 대기 시간<br/>- 최솟값: `-1`<br/>- -1로 설정 시, 복제 지연 해소까지 계속해서 대기합니다.                                                                                                                                                                                                                                                   |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "useHighAvailability": true,
-    "haStatus": "STABLE",
+    "dbInstanceName": "dbInstanceName",
+    "dbInstanceCandidateName": "dbInstanceCandidateName-example",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "dbVersion": "ENUM_VALUE",
+    "useHighAvailability": false,
+    "imageId": "550e8400-e29b-41d4-a716-446655440000",
     "pingInterval": 3,
-    "failoverReplWaitingTime": 60
+    "failoverReplWaitingTime": 60,
+    "storage": {
+        "storageType": "ENUM_VALUE",
+        "storageSize": 20
+    },
+    "network": {
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
+        "availabilityZone": "ENUM_VALUE"
+    },
+    "backup": {
+        "backupPeriod": 0,
+        "backupRetryCount": 0,
+        "replicationRegion": "KR1",
+        "backupSchedules": [
+            {
+                "backupWndDuration": "HALF_AN_HOUR"
+            }
+        ]
+    },
+    "restore": {
+        "tenantId": "tenantId-example",
+        "username": "username-example",
+        "password": "password-example",
+        "targetContainer": "targetContainer-example",
+        "objectPath": "objectPath-example"
+    },
+    "useDefaultNotification": false,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useDeletionProtection": false
 }
 ```
+
+</p>
 </details>
-
-
-### 고가용성 수정하기
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/high-availability
-```
-
-#### 필요 권한
-
-| 권한명                                      | 설명        |
-|------------------------------------------|-----------|
-| RDSforPostgreSQL:HighAvailability.Modify | 고가용성 수정하기 |
-
-#### 요청
-
-| 이름                      | 종류   | 형식      | 필수 | 설명                                                                           |
-|-------------------------|------|---------|----|------------------------------------------------------------------------------|
-| dbInstanceId            | URL  | UUID    | O  | DB 인스턴스의 식별자                                                                 |
-| useHighAvailability     | Body | Boolean | O  | 고가용성 사용 여부                                                                   |
-| pingInterval            | Body | Number  | X  | 고가용성 사용 시 Ping 간격(초)<br/>- 최솟값: `1`<br/>- 최댓값: `600`                         |
-| failoverReplWaitingTime | Body | Number  | X  | 고가용성 사용 시 장애 조치 대기 시간<br/>- 최솟값: `-1`<br/>- -1로 설정 시, 복제 지연 해소까지 계속해서 대기합니다. |
 
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | 요청한 작업의 식별자 |
 
 <details><summary>예시</summary>
+<p>
 
 ```json
 {
@@ -1188,842 +794,14 @@ PUT /v1.0/db-instances/{dbInstanceId}/high-availability
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-### 고가용성 다시 시작하기
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/high-availability/resume
-```
-
-#### 필요 권한
-
-| 권한명                                      | 설명           |
-|------------------------------------------|--------------|
-| RDSforPostgreSQL:HighAvailability.Resume | 고가용성 다시 시작하기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-
-### 고가용성 일시 중지하기
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/high-availability/pause
-```
-
-#### 필요 권한
-
-| 권한명                                     | 설명           |
-|-----------------------------------------|--------------|
-| RDSforPostgreSQL:HighAvailability.Pause | 고가용성 일시 중지하기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-
-### 고가용성 복구하기
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/high-availability/repair
-```
-
-#### 필요 권한
-
-| 권한명                                      | 설명        |
-|------------------------------------------|-----------|
-| RDSforPostgreSQL:HighAvailability.Repair | 고가용성 복구하기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-
-### 고가용성 분리하기
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/high-availability/split
-```
-
-#### 필요 권한
-
-| 권한명                                     | 설명        |
-|-----------------------------------------|-----------|
-| RDSforPostgreSQL:HighAvailability.Split | 고가용성 분리하기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-
-### DB 인스턴스 스토리지 정보 조회
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}/storage-info
-```
-
-#### 필요 권한
-
-| 권한명                             | 설명            |
-|---------------------------------|---------------|
-| RDSforPostgreSQL:DbInstance.Get | DB 인스턴스 상세 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름               | 종류   | 형식      | 설명                                                                                   |
-|------------------|------|---------|--------------------------------------------------------------------------------------|
-| storageType      | Body | Enum    | 데이터 스토리지 유형                                                                          |
-| storageSize      | Body | Number  | 데이터 스토리지 크기(GB)                                                                      |
-| storageStatus    | Body | Enum    | 데이터 스토리지의 현재 상태<br/>- `DETACHED`: 부착되지 않음<br/>- `ATTACHED`: 부착됨<br/>- `DELETED`: 삭제됨 |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "storageType": "General SSD",
-    "storageSize": 20,
-    "storageStatus": "ATTACHED"
-}
-```
-</details>
-
-
-### DB 인스턴스 스토리지 정보 수정하기
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/storage-info
-```
-
-#### 필요 권한
-
-| 권한명                                | 설명           |
-|------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Modify | DB 인스턴스 수정하기 |
-
-#### 요청
-
-| 이름                | 종류   | 형식      | 필수 | 설명                                                                        |
-|-------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID    | O  | DB 인스턴스의 식별자                                                              |
-| storageSize       | Body | Number  | O  | 데이터 스토리지 크기(GB)<br/>- 최솟값: 현재값<br/>- 최댓값: `2048`                          |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### DB 인스턴스 네트워크 정보 조회
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}/network-info
-```
-
-#### 필요 권한
-
-| 권한명                             | 설명            |
-|---------------------------------|---------------|
-| RDSforPostgreSQL:DbInstance.Get | DB 인스턴스 상세 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름                      | 종류   | 형식      | 설명                                                                                                                                      |
-|-------------------------|------|---------|-----------------------------------------------------------------------------------------------------------------------------------------|
-| availabilityZone        | Body | Enum    | DB 인스턴스를 생성할 가용성 영역                                                                                                                     |
-| subnet                  | Body | Object  | 서브넷 객체                                                                                                                                  |
-| subnet.subnetId         | Body | UUID    | 서브넷의 식별자                                                                                                                                |
-| subnet.subnetName       | Body | UUID    | 서브넷을 식별할 수 있는 이름                                                                                                                        |
-| subnet.subnetCidr       | Body | UUID    | 서브넷의 CIDR                                                                                                                               |
-| subnet.publicAccessible | Body | Boolean | 외부 접속 가능 여부                                                                                                                             |
-| endPoints               | Body | Array   | 접속 정보 목록                                                                                                                                |
-| endPoints.domain        | Body | String  | 도메인                                                                                                                                     |
-| endPoints.ipAddress     | Body | String  | IP 주소                                                                                                                                   |
-| endPoints.endPointType  | Body | Enum    | 접속 정보 유형<br>-`EXTERNAL`: 외부 접속 도메인<br>-`INTERNAL`: 내부 접속 도메인<br>-`PUBLIC`: (Deprecated) 외부 접속 도메인<br>-`PRIVATE`: (Deprecated) 내부 접속 도메인 |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "availabilityZone": "kr-pub-a",
-    "subnet": {
-        "subnetId": "bd453789-34ae-416c-9f78-05b9e43a46be",
-        "subnetName": "Default Network",
-        "subnetCidr": "192.168.0.0/16",
-        "publicAccessible": true
-    },
-    "endPoints": [
-        {
-            "domain": "ea548a78-d85f-43b4-8ddf-c88d999b9905.internal.kr1.postgres.rds.nhncloudservice.com",
-            "ipAddress": "192.168.0.2",
-            "endPointType": "INTERNAL"
-        }
-    ]
-}
-```
-</details>
-
-### DB 인스턴스 네트워크 정보 수정하기
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/network-info
-```
-
-#### 필요 권한
-
-| 권한명                                | 설명           |
-|------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Modify | DB 인스턴스 수정하기 |
-
-#### 요청
-
-| 이름              | 종류   | 형식      | 필수 | 설명           |
-|-----------------|------|---------|----|--------------|
-| dbInstanceId    | URL  | UUID    | O  | DB 인스턴스의 식별자 |
-| usePublicAccess | Body | Boolean | O  | 외부 접속 가능 여부  |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### DB 인스턴스 백업 정보 조회
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}/backup-info
-```
-
-#### 필요 권한
-
-| 권한명                             | 설명            |
-|---------------------------------|---------------|
-| RDSforPostgreSQL:DbInstance.Get | DB 인스턴스 상세 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름                                    | 종류   | 형식     | 설명                                                                                                                                                                                                                   |
-|---------------------------------------|------|--------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| backupPeriod                          | Body | Number | 백업 보관 기간(일)                                                                                                                                                                                                          |
-| backupRetryCount                      | Body | Number | 백업 재시도 횟수                                                                                                                                                                                                            |
-| backupSchedules                       | Body | Array  | 백업 스케줄 목록                                                                                                                                                                                                            |
-| backupSchedules.backupWndBgnTime      | Body | String | 백업 시작 시간                                                                                                                                                                                                             |
-| backupSchedules.backupWndDuration     | Body | Enum   | 백업 윈도우<br/>백업 시작 시간부터 설정된 기간 안에 자동 백업이 실행됩니다.<br/>- `HALF_AN_HOUR`: 30분<br/>- `ONE_HOUR`: 1시간<br/>- `ONE_HOUR_AND_HALF`: 1시간 30분<br/>- `TWO_HOURS`: 2시간<br/>- `TWO_HOURS_AND_HALF`: 2시간 30분<br/>- `THREE_HOURS`: 3시간 |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "backupPeriod": 1,
-    "backupRetryCount": 0,
-    "backupSchedules": [
-        {
-            "backupWndBgnTime": "00:00:00",
-            "backupWndDuration": "ONE_HOUR_AND_HALF",
-            "backupRetryExpireTime": "01:30:00"
-        }
-    ]
-}
-```
-</details>
-
-### DB 인스턴스 백업 정보 수정하기
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/backup-info
-```
-
-#### 필요 권한
-
-| 권한명                                | 설명           |
-|------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Modify | DB 인스턴스 수정하기 |
-
-#### 요청
-
-| 이름                                    | 종류   | 형식     | 필수 | 설명                                                                                                                                                                                                                   |
-|---------------------------------------|------|--------|----|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                          | URL  | UUID   | O  | DB 인스턴스의 식별자                                                                                                                                                                                                         |
-| backupPeriod                          | Body | Number | X  | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730`                                                                                                                                                                          |
-| backupRetryCount                      | Body | Number | X  | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10`                                                                                                                                                                             |
-| backupSchedules                       | Body | Array  | X  | 백업 스케줄 목록                                                                                                                                                                                                            |
-| backupSchedules.backupWndBgnTime      | Body | String | O  | 백업 시작 시간<br/>- 예시: `00:00:00`                                                                                                                                                                                        |
-| backupSchedules.backupWndDuration     | Body | Enum   | O  | 백업 윈도우<br/>백업 시작 시간부터 설정된 기간 안에 자동 백업이 실행됩니다.<br/>- `HALF_AN_HOUR`: 30분<br/>- `ONE_HOUR`: 1시간<br/>- `ONE_HOUR_AND_HALF`: 1시간 30분<br/>- `TWO_HOURS`: 2시간<br/>- `TWO_HOURS_AND_HALF`: 2시간 30분<br/>- `THREE_HOURS`: 3시간 |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "backupPeriod": 5,
-    "backupSchedules": [
-        {
-            "backupWndBgnTime": "01:00:00",
-            "backupWndDuration": "TWO_HOURS",
-            "backupRetryExpireTime": "03:00:00"
-        }
-    ]
-}
-```
-</details>
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### DB 인스턴스 복원 정보 조회
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}/restoration-info
-```
-
-#### 필요 권한
-
-| 권한명                             | 설명            |
-|---------------------------------|---------------|
-| RDSforPostgreSQL:DbInstance.Get | DB 인스턴스 상세 보기 |
-
-#### 요청
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름                                      | 종류   | 형식       | 설명                                                                                                                                                    |
-|-----------------------------------------|------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
-| oldestRestorableYmdt                    | Body | DateTime | 가장 오래된 복원 가능한 시간                                                                                                                                      |
-| latestRestorableYmdt                    | Body | DateTime | 가장 최신의 복원 가능한 시간                                                                                                                                      |
-| restorableBackups                       | Body | Array    | 복원 가능한 백업 목록                                                                                                                                          |
-| restorableBackups.backup                | Body | Object   | 백업 정보 객체                                                                                                                                              |
-| restorableBackups.backup.backupId       | Body | UUID     | 백업의 식별자                                                                                                                                               |
-| restorableBackups.backup.backupName     | Body | String   | 백업 이름                                                                                                                                                 |
-| restorableBackups.backup.backupSize     | Body | Number   | 백업 크기                                                                                                                                                 |
-| restorableBackups.backup.backupType     | Body | Enum     | 백업 유형<br/>- `AUTO`: 자동<br/>- `MANUAL`: 수동                                                                                                             |
-| restorableBackups.backup.backupStatus   | Body | Enum     | 백업 상태<br/>- `BACKING_UP`: 백업 중인 경우<br/>- `COMPLETED`: 백업이 완료된 경우<br/>- `DELETING`: 백업이 삭제 중인 경우<br/>- `DELETED`: 백업이 삭제된 경우<br/>- `ERROR`: 오류가 발생한 경우 |
-| restorableBackups.backup.dbInstanceId   | Body | UUID     | 원본 DB 인스턴스의 식별자                                                                                                                                       |
-| restorableBackups.backup.dbInstanceName | Body | String   | 원본 DB 인스턴스의 이름                                                                                                                                        |
-| restorableBackups.backup.dbVersion      | Body | String   | DB 버전 정보                                                                                                                                              |
-| restorableBackups.backup.failoverCount  | Body | Number   | 장애 조치 횟수                                                                                                                                              |
-| restorableBackups.backup.walFileName    | Body | String   | WAL 로그 파일 이름                                                                                                                                          |
-| restorableBackups.backup.createdYmdt    | Body | DateTime | 백업 생성 일시                                                                                                                                              |
-| restorableBackups.backup.updatedYmdt    | Body | DateTime | 백업 갱신 일시                                                                                                                                              |
-| restorableBackups.backup.startYmdt      | Body | DateTime | 백업 시작 일시                                                                                                                                              |
-| restorableBackups.backup.completedYmdt  | Body | DateTime | 백업 완료 일시                                                                                                                                              |
-
-<details><summary>예시</summary>
-
-```json
-{
-	"header": {
-		"resultCode": 0,
-		"resultMessage": "SUCCESS",
-		"isSuccessful": true
-	},
-    "oldestRestorableYmdt": "2023-07-09T16:33:33+09:00",
-	"latestRestorableYmdt": "2023-07-10T15:44:44+09:00",
-	"restorableBackups": [
-		{
-			"backup": {
-				"backupId": "145d889a-fe08-474f-8f58-bde576ff96a9",
-				"backupName": "example-backup-name",
-				"backupStatus": "COMPLETED",
-				"dbInstanceId": "dba1be25-9429-4589-9716-7fb6daad7cb9",
-				"dbInstanceName": "original-db-instance-name",
-				"dbVersion": "POSTGRESQL_V17_6",
-				"backupType": "MANUAL",
-				"backupSize": 8299904,
-				"walFileName": "000000010000000000000005",
-				"createdYmdt": "2023-07-10T15:44:44+09:00",
-				"updatedYmdt": "2023-07-10T15:46:07+09:00"
-			}
-		}
-	]
-}
-```
-</details>
-
-### DB 인스턴스 복원하기
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/restore
-```
-
-#### 필요 권한
-
-| 권한명                                 | 설명           |
-|-------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Restore | DB 인스턴스 복원하기 |
-
-#### 공통 요청
-
-| 이름                                       | 종류   | 형식      | 필수 | 설명                                                                                                                                                                                                                                                  |
-|------------------------------------------|------|---------|----|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                             | URL  | UUID    | O  | DB 인스턴스의 식별자                                                                                                                                                                                                                                        |
-| restore                                  | Body | Object  | O  | 복원 정보 객체                                                                                                                                                                                                                                            |
-| restore.restoreType                      | Body | Enum    | O  | 복원 타입 종류<br/>- `TIMESTAMP`: 복원 가능한 시간 이내의 시간을 이용한 시점 복원 타입<br/>- `BACKUP`: 기존에 생성한 백업을 이용한 복원 타입                                                                                                                                                    |
-| dbInstanceName                           | Body | String  | O  | DB 인스턴스를 식별할 수 있는 이름                                                                                                                                                                                                                                |
-| description                              | Body | String  | X  | DB 인스턴스에 대한 추가 정보                                                                                                                                                                                                                                   |
-| dbFlavorId                               | Body | UUID    | O  | DB 인스턴스 사양의 식별자                                                                                                                                                                                                                                     |
-| dbPort                                   | Body | Number  | O  | DB 포트<br/>- 최솟값: `3306`<br/>- 최댓값: `43306`                                                                                                                                                                                                          |
-| parameterGroupId                         | Body | UUID    | O  | 파라미터 그룹의 식별자                                                                                                                                                                                                                                        |
-| dbSecurityGroupIds                       | Body | Array   | X  | DB 보안 그룹의 식별자 목록                                                                                                                                                                                                                                    |
-| userGroupIds                             | Body | Array   | X  | 사용자 그룹의 식별자 목록                                                                                                                                                                                                                                      |
-| useDefaultNotification                   | Body | Boolean | X  | 기본 알림 사용 여부<br/>- 기본값: `false`                                                                                                                                                                                                                      |
-| useDeletionProtection                    | Body | Boolean | X  | 삭제 보호 여부<br>기본값: `false`                                                                                                                                                                                                                            |                                                                                                                                                                                                                                                                                                                                                                                                                                        |
-| useHighAvailability                      | Body | Boolean | X  | 고가용성 사용 여부<br/>- 기본값: `false`                                                                                                                                                                                                                       |
-| pingInterval                             | Body | Number  | X  | 고가용성 사용 시 Ping 간격(초)<br/>- 기본값: `3`최솟값: `1`<br/>- 최댓값: `600`                                                                                                                                                                                        |
-| failoverReplWaitingTime                  | Body | Number  | X  | 고가용성 사용 시 장애 조치 대기 시간<br/>- 최솟값: `-1`<br/>- -1로 설정 시, 복제 지연 해소까지 계속해서 대기합니다.                                                                                                                                                                        |                                                                                                                                                                                                                      | userGroupIds                             | Body | Array   | X  | 기본 알림 수신용 사용자 그룹의 식별자 목록                                                                                                                                                                                             |
-| network                                  | Body | Object  | O  | 네트워크 정보 객체                                                                                                                                                                                                                                          |
-| network.subnetId                         | Body | UUID    | O  | 서브넷의 식별자                                                                                                                                                                                                                                            |
-| network.usePublicAccess                  | Body | Boolean | X  | 외부 접속 가능 여부<br/>- 기본값: `false`</li></ul>                                                                                                                                                                                                            |
-| network.availabilityZone                 | Body | Enum    | X  | DB 인스턴스를 생성할 가용성 영역<br/>- 예시: `kr-pub-a`<br/>- 기본값: `임의의 가용성 영역`                                                                                                                                                                                    |
-| storage                                  | Body | Object  | O  | 스토리지 정보 객체                                                                                                                                                                                                                                          |
-| storage.storageType                      | Body | Enum    | O  | 데이터 스토리지 타입<br/>- 예시: `General SSD`                                                                                                                                                                                                                 |
-| storage.storageSize                      | Body | Number  | O  | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20`<br/>- 최댓값: `2048`                                                                                                                                                                                                   |
-| backup                                   | Body | Object  | O  | 백업 정보 객체                                                                                                                                                                                                                                            |
-| backup.backupPeriod                      | Body | Number  | O  | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730`                                                                                                                                                                                                         |
-| backup.backupRetryCount                  | Body | Number  | X  | 백업 재시도 횟수<br/>- 기본값: `0`<br/>- 최솟값: `0`<br/>- 최댓값: `10`                                                                                                                                                                                             |
-| backup.backupSchedules                   | Body | Array   | O  | 백업 스케줄 목록                                                                                                                                                                                                                                           |
-| backup.backupSchedules.backupWndBgnTime  | Body | String  | X  | 백업 시작 시각<br/>- 예시: `00:00:00`<br/>- 기본값: 원본 DB 인스턴스 값                                                                                                                                                                                               |
-| backup.backupSchedules.backupWndDuration | Body | Enum    | X  | 백업 Duration<br/>백업 시작 시각부터 Duration 안에 자동 백업이 실행됩니다.<br/>- `HALF_AN_HOUR`: 30분<br/>- `ONE_HOUR`: 1시간<br/>- `ONE_HOUR_AND_HALF`: 1시간 30분<br/>- `TWO_HOURS`: 2시간<br/>- `TWO_HOURS_AND_HALF`: 2시간 30분<br/>- `THREE_HOURS`: 3시간<br/>- 기본값: 원본 DB 인스턴스 값 |
-
-#### Timestamp를 이용한 시점 복원 시 요청(restoreType이 `TIMESTAMP`인 경우)
-
-| 이름                  | 종류   | 형식       | 필수 | 설명                                                                                              |
-|---------------------|------|----------|----|-------------------------------------------------------------------------------------------------|
-| restore.restoreYmdt | Body | DateTime | O  | DB 인스턴스 복원 시간.(YYYY-MM-DDThh:mm:ss.SSSTZD)<br>복원 정보 조회로 조회한 가장 최신의 복원 가능한 시간 이전에 대해서만 복원이 가능하다. |
-
-<details><summary>예시</summary>
-
-```json
-{
-  "dbInstanceName": "db-instance",
-  "description": "description",
-  "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-  "dbPort": 10000,
-  "dbUserName": "db-user",
-  "dbPassword": "password",
-  "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-  "dbSecurityGroupIds": [
-    "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-  ],
-  "userGroupIds": [],
-  "network": {
-    "subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36"
-  },
-  "storage": {
-    "storageType": "General SSD",
-    "storageSize": 20
-  },
-  "restore": {
-    "restoreType": "TIMESTAMP",
-    "restoreYmdt": "2023-07-10T15:44:44+09:00"
-  },
-  "backup": {
-    "backupPeriod": 1,
-    "backupSchedules": [
-      {
-        "backupWndBgnTime": "00:00:00",
-        "backupWndDuration": "ONE_HOUR_AND_HALF"
-      }
-    ]
-  }
-}
-```
-</details>
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-
-### DB 인스턴스 삭제 보호 설정 변경하기
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/deletion-protection
-```
-
-#### 필요 권한
-
-| 권한명                                | 설명           |
-|------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Modify | DB 인스턴스 수정하기 |
-
-#### 요청
-
-| 이름                    | 종류   | 형식      | 필수 | 설명           |
-|-----------------------|------|---------|----|--------------|
-| dbInstanceId          | URL  | UUID    | O  | DB 인스턴스의 식별자 |
-| useDeletionProtection | Body | Boolean | O  | 삭제 보호 여부     |
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
-
-
-### DB 인스턴스 유지보수 정보 조회
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}/maintenance-info
-```
-
-#### 필요 권한
-
-| 권한명                             | 설명            |
-|---------------------------------|---------------|
-| RDSforPostgreSQL:DbInstance.Get | DB 인스턴스 상세 보기 |
-
-#### 요청
-
-| 이름                    | 종류   | 형식      | 필수 | 설명           |
-|-----------------------|------|---------|----|--------------|
-| dbInstanceId          | URL  | UUID    | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름                    | 종류   | 형식      | 설명                                                                                                                   |
-|-----------------------|------|---------|----------------------------------------------------------------------------------------------------------------------|
-| allowAutoMaintenance  | Body | Boolean | 자동 유지보수 허용 여부                                                                                                        |
-| useAutoStorageCleanup | Body | Boolean | 자동 스토리지 정리 사용 여부                                                                                                     |
-| maintWndBgnTime       | Body | String  | 자동 유지보수 시작 시간 <br/>- 예시: `00:00:00`                                                                                  |
-| maintWndDuration      | Body | ENUM    | 유지보수 윈도우 <br/> 예시: `HALF_AN_HOUR`, `ONE_HOUR`, `ONE_HOUR_AND_HALF`, `TWO_HOURS`, `TWO_HOURS_AND_HALF`, `THREE_HOURS` |
-| logRetentionPeriod    | Body | Number  | 로그 보관 기간(일)                                                                                                         |
-
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "allowAutoMaintenance": true,
-    "useAutoStorageCleanup": true,
-    "maintWndBgnTime": "00:00:00",
-    "maintWndDuration": "HALF_AN_HOUR",
-    "logRetentionPeriod": 7
-}
-```
-</details>
-
-
-### DB 인스턴스 유지보수 정보 수정
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/maintenance-info
-```
-
-#### 필요 권한
-
-| 권한명                                | 설명           |
-|------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Modify | DB 인스턴스 수정하기 |
-
-#### 요청
-
-| 이름                    | 종류   | 형식      | 필수 | 설명                                                                                                                   |
-|-----------------------|------|---------|----|----------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId          | URL  | UUID    | O  | DB 인스턴스의 식별자                                                                                                         |
-| allowAutoMaintenance  | Body | Boolean | X  | 자동 유지보수 허용 여부                                                                                                        |
-| useAutoStorageCleanup | Body | Boolean | X  | 자동 스토리지 정리 사용 여부                                                                                                     |
-| maintWndBgnTime       | Body | String  | X  | 자동 유지보수 시작 시간 <br/>- 예시: `00:00:00`                                                                                  |
-| maintWndDuration      | Body | ENUM    | X  | 유지보수 윈도우 <br/> 예시: `HALF_AN_HOUR`, `ONE_HOUR`, `ONE_HOUR_AND_HALF`, `TWO_HOURS`, `TWO_HOURS_AND_HALF`, `THREE_HOURS` |
-| logRetentionPeriod    | Body | Number  | X  | 로그 보관 기간(일)                                                                                                         |
-
-<details><summary>예시</summary>
-
-```json
-{
-  "allowAutoMaintenance": true,
-  "useAutoStorageCleanup": true,
-  "logRetentionPeriod": 7
-}
-```
-</details>
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-
-```json
-{
-  "header": {
-    "resultCode": 0,
-    "resultMessage": "SUCCESS",
-    "isSuccessful": true
-  },
-  "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-
-### 현 DB 인스턴스에서 선택 가능한 DB 버전 조회
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}/available-db-versions
-```
-
-#### 필요 권한
-
-| 권한명                                | 설명           |
-|------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Get | DB 인스턴스 상세 보기 |
-
-#### 요청
-
-| 이름                    | 종류   | 형식      | 필수 | 설명           |
-|-----------------------|------|---------|----|--------------|
-| dbInstanceId          | URL  | UUID    | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름                           | 종류   | 형식      | 설명                    |
-|------------------------------|------|---------|-----------------------|
-| dbVersions                   | Body | Array   | DB 버전 목록              |
-| dbVersions.dbVersion         | Body | String  | DB 버전                 |
-| dbVersions.dbVersionName     | Body | String  | DB 버전명                |
-| dbVersions.restorableFromObs | Body | Boolean | 오브젝트 스토리지로부터 복원 가능 여부 |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbVersions": [
-        {
-            "dbVersion": "POSTGRESQL_V17_6",
-            "dbVersionName": "PostgreSQL V17.6",
-            "restorableFromObs": true
-        }
-    ]
-}
-```
-</details>
-
+---
 
 ### DB 인스턴스 삭제하기
 
@@ -2031,27 +809,79 @@ GET /v1.0/db-instances/{dbInstanceId}/available-db-versions
 DELETE /v1.0/db-instances/{dbInstanceId}
 ```
 
-#### 필요 권한
+#### 요청
 
-| 권한명                                | 설명           |
-|------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Delete | DB 인스턴스 삭제하기 |
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 인스턴스 상세 보기
+
+```http
+GET /v1.0/db-instances/{dbInstanceId}
+```
 
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
 
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceId | Body | String | DB 인스턴스의 식별자 |
+| dbInstanceGroupId | Body | String | DB 인스턴스 그룹의 식별자 |
+| dbInstanceName | Body | String | DB 인스턴스를 식별할 수 있는 이름 |
+| description | Body | String | DB 인스턴스에 대한 추가 정보 |
+| dbVersion | Body | Enum | DB 엔진 유형 |
+| dbPort | Body | Number | DB 포트 |
+| dbInstanceType | Body | Enum | DB 인스턴스 역할 타입<br/>- MASTER: `마스터`<br/>- FAILED_MASTER: `장애 마스터`<br/>- CANDIDATE_MASTER: `예비 마스터`<br/>- READ_ONLY_SLAVE: `읽기 복제본` |
+| dbInstanceStatus | Body | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전 (회색)`<br/>- AVAILABLE: `사용 가능 (녹색)`<br/>- STORAGE_FULL: `용량 부족 (적색)`<br/>- FAIL_TO_CREATE: `생성 실패 (적색)`<br/>- FAIL_TO_CONNECT: `연결 실패 (적색)`<br/>- REPLICATION_STOP: `복제 중단 (적색)`<br/>- REPLICATION_DELAY: `복제 지연 (황색)`<br/>- FAILOVER: `장애 조치 완료 (적색)`<br/>- SHUTDOWN: `중지 됨 (회색)`<br/>- DELETED: `삭제됨 (회색)` |
+| progressStatus | Body | String | DB 인스턴스의 현재 진행 상태 |
+| dbFlavorId | Body | String | DB 인스턴스 사양의 식별자 |
+| parameterGroupId | Body | String | DB 인스턴스에 적용된 파라미터 그룹의 식별자 |
+| dbSecurityGroupIds | Body | Array | DB 인스턴스에 적용된 DB 보안 그룹의 식별자 목록 |
+| notificationGroupIds | Body | Array | DB 인스턴스에 적용된 알림 그룹의 식별자 목록 |
+| useDeletionProtection | Body | Boolean | DB 인스턴스 삭제 보호 여부 |
+| needToApplyParameterGroup | Body | Boolean | 최신 파라미터 그룹 적용 필요 여부 |
+| needMigration | Body | Boolean | 마이그레이션 필요 여부 |
+| osVersion | Body | String | 운영체제 버전 |
+| createdYmdt | Body | DateTime | 생성 일시 |
+| updatedYmdt | Body | DateTime | 수정 일시 |
 
 <details><summary>예시</summary>
+<p>
 
 ```json
 {
@@ -2060,47 +890,88 @@ DELETE /v1.0/db-instances/{dbInstanceId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "dbInstanceId": "dbInstanceId-example",
+    "dbInstanceGroupId": "dbInstanceGroupId-example",
+    "dbInstanceName": "dbInstanceName-example",
+    "description": "description-example",
+    "dbVersion": "ENUM_VALUE",
+    "dbPort": 1,
+    "dbInstanceType": "MASTER",
+    "dbInstanceStatus": "BEFORE_CREATE",
+    "progressStatus": "progressStatus-example",
+    "dbFlavorId": "dbFlavorId-example",
+    "parameterGroupId": "parameterGroupId-example",
+    "dbSecurityGroupIds": [],
+    "notificationGroupIds": [],
+    "useDeletionProtection": false,
+    "needToApplyParameterGroup": false,
+    "needMigration": false,
+    "osVersion": "osVersion-example",
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
+
+</p>
 </details>
 
-### DB 인스턴스 재시작하기
+---
+
+### DB 인스턴스 수정하기
 
 ```http
-POST /v1.0/db-instances/{dbInstanceId}/restart
+PUT /v1.0/db-instances/{dbInstanceId}
 ```
-
-#### 필요 권한
-
-| 권한명                                 | 설명            |
-|-------------------------------------|---------------|
-| RDSforPostgreSQL:DbInstance.Restart | DB 인스턴스 재시작하기 |
 
 #### 요청
 
-| 이름                | 종류   | 형식      | 필수 | 설명                                                                        |
-|-------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID    | O  | DB 인스턴스의 식별자                                                              |
-| useOnlineFailover | Body | Boolean | X  | 장애 조치를 이용한 재시작 여부<br/>고가용성을 사용 중인 DB 인스턴스에서만 사용 가능합니다.<br/>- 기본값: `false` |
-| executeBackup     | Body | Boolean | X  | 현재 시점 백업 진행 여부<br/>- 기본값: `false`                                         |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceName | Body | String | X | DB 인스턴스를 식별할 수 있는 이름 |
+| dbInstanceCandidateName | Body | String | X | DB 인스턴스를 식별할 수 있는 예비 마스터 이름 |
+| description | Body | String | X | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbPort | Body | Number | X | DB 포트<br/>- 최솟값: 5432, 최댓값: 45432 |
+| dbFlavorId | Body | UUID | X | DB 인스턴스 사양의 식별자 |
+| parameterGroupId | Body | UUID | X | 파라미터 그룹의 식별자 |
+| dbVersion | Body | Enum | X | DB 엔진 버전 코드 |
+| dbSecurityGroupIds | Body | Array | X | DB 보안 그룹의 식별자 목록 |
+| executeBackup | Body | Boolean | X | 현재 시점 백업 진행 여부<br/>- 기본값: `false` |
+| useOnlineFailover | Body | Boolean | X | 장애 조치를 이용한 재시작 여부<br/>- 기본값: `false` |
+| waitReplicationDelay | Body | Boolean | X | 복제 지연 해소 대기<br/>- 기본값: `false` |
+| useReadOnly | Body | Boolean | X | 쓰기 부하 차단<br/>- 기본값: `false` |
 
 <details><summary>예시</summary>
+<p>
 
 ```json
 {
-    "executeBackup": true
+    "dbInstanceName": "dbInstanceName-example",
+    "dbInstanceCandidateName": "dbInstanceCandidateName-example",
+    "description": "description-example",
+    "dbPort": 1,
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbVersion": "ENUM_VALUE",
+    "dbSecurityGroupIds": [],
+    "executeBackup": false,
+    "useOnlineFailover": false,
+    "waitReplicationDelay": false,
+    "useReadOnly": false
 }
 ```
+
+</p>
 </details>
 
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | 요청한 작업의 식별자 |
 
 <details><summary>예시</summary>
+<p>
 
 ```json
 {
@@ -2109,230 +980,14 @@ POST /v1.0/db-instances/{dbInstanceId}/restart
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-### DB 인스턴스 강제 재시작하기
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/force-restart
-```
-
-#### 필요 권한
-
-| 권한명                                      | 설명               |
-|------------------------------------------|------------------|
-| RDSforPostgreSQL:DbInstance.ForceRestart | DB 인스턴스 강제 재시작하기 |
-
-#### 요청
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
-
-
-### DB 인스턴스 시작하기
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/start
-```
-
-#### 필요 권한
-
-| 권한명                               | 설명           |
-|-----------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Start | DB 인스턴스 시작하기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### DB 인스턴스 정지하기
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/stop
-```
-
-#### 필요 권한
-
-| 권한명                              | 설명           |
-|----------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Stop | DB 인스턴스 정지하기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### DB 인스턴스 백업하기
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/backup
-```
-
-#### 필요 권한
-
-| 권한명                                | 설명           |
-|------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Backup | DB 인스턴스 백업하기 |
-
-#### 요청
-
-| 이름           | 종류   | 형식     | 필수 | 설명              |
-|--------------|------|--------|----|-----------------|
-| dbInstanceId | URL  | UUID   | O  | DB 인스턴스의 식별자    |
-| backupName   | Body | String | O  | 백업을 식별할 수 있는 이름 |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "backupName": "backup"
-}
-```
-</details>
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### DB 인스턴스 백업 후 내보내기
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/backup-to-object-storage
-```
-
-#### 필요 권한
-
-| 권한명                                               | 설명                         |
-|---------------------------------------------------|----------------------------|
-| RDSforPostgreSQL:DbInstance.BackupToObjectStorage | 백업 후 백업 파일 오브젝트 스토리지로 내보내기 |
-
-#### 요청
-
-| 이름              | 종류   | 형식     | 필수 | 설명                          |
-|-----------------|------|--------|----|-----------------------------|
-| dbInstanceId    | URL  | UUID   | O  | DB 인스턴스의 식별자                |
-| tenantId        | Body | String | O  | 백업이 저장될 오브젝트 스토리지의 테넌트 ID   |
-| username        | Body | String | O  | NHN Cloud 계정 또는 IAM 계정 ID   |
-| password        | Body | String | O  | 백업이 저장될 오브젝트 스토리지의 API 비밀번호 |
-| targetContainer | Body | String | O  | 백업이 저장될 오브젝트 스토리지의 컨테이너     |
-| objectPath      | Body | String | O  | 컨테이너에 저장될 백업의 경로            |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "tenantId": "399631c404744dbbb18ce4fa2dc71a5a",
-    "username": "gildong.hong@nhn.com",
-    "password": "password",
-    "targetContainer": "/container",
-    "objectPath": "/backups/backup_file"
-}
-```
-</details>
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
+---
 
 ### DB 인스턴스 최신 파라미터 그룹 적용하기
 
@@ -2340,35 +995,22 @@ POST /v1.0/db-instances/{dbInstanceId}/backup-to-object-storage
 POST /v1.0/db-instances/{dbInstanceId}/apply-recent-parameter-group
 ```
 
-#### 필요 권한
-
-| 권한명                                | 설명           |
-|------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Modify | DB 인스턴스 수정하기 |
-
 #### 요청
 
-| 이름                | 종류   | 형식      | 필수 | 설명                                                                        |
-|-------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID    | O  | DB 인스턴스의 식별자                                                              |
-| executeBackup     | Body | Boolean | X  | 현재 시점 백업 진행 여부<br/>- 기본값: `false`                                         |
+이 API는 요청 본문을 요구하지 않습니다.
 
-<details><summary>예시</summary>
-
-```json
-{
-  "executeBackup": true
-}
-```
-</details>
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
 
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | 요청한 작업의 식별자 |
 
 <details><summary>예시</summary>
+<p>
 
 ```json
 {
@@ -2377,108 +1019,41 @@ POST /v1.0/db-instances/{dbInstanceId}/apply-recent-parameter-group
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-### DB 인스턴스 복제하기
+---
+
+### 현 DB 인스턴스에서 선택 가능한 DB 버전 조회
 
 ```http
-POST /v1.0/db-instances/{dbInstanceId}/replicate
+GET /v1.0/db-instances/{dbInstanceId}/available-db-versions
 ```
-
-#### 필요 권한
-
-| 권한명                                   | 설명           |
-|---------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Replicate | DB 인스턴스 복제하기 |
-
-#### 요청
-
-| 이름                                           | 종류   | 형식      | 필수 | 설명                                                                                                                                                                                                                                                  |
-|----------------------------------------------|------|---------|----|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                                 | URL  | UUID    | O  | DB 인스턴스의 식별자                                                                                                                                                                                                                                        |
-| dbInstanceName                               | Body | String  | O  | DB 인스턴스를 식별할 수 있는 이름                                                                                                                                                                                                                                |
-| description                                  | Body | String  | X  | DB 인스턴스에 대한 추가 정보                                                                                                                                                                                                                                   |
-| dbFlavorId                                   | Body | UUID    | X  | DB 인스턴스 사양의 식별자<br/>- 기본값: 원본 DB 인스턴스 값                                                                                                                                                                                                             |
-| dbPort                                       | Body | Number  | X  | DB 포트<br/>- 기본값: 원본 DB 인스턴스 값<br/>- 최솟값: `5432`<br/>- 최댓값: `45432`                                                                                                                                                                                  |
-| parameterGroupId                             | Body | UUID    | X  | 파라미터 그룹의 식별자<br/>- 기본값: 원본 DB 인스턴스 값                                                                                                                                                                                                                |
-| dbSecurityGroupIds                           | Body | Array   | X  | DB 보안 그룹의 식별자 목록<br/>- 기본값: 원본 DB 인스턴스 값                                                                                                                                                                                                            |
-| userGroupIds                                 | Body | Array   | X  | 사용자 그룹의 식별자 목록                                                                                                                                                                                                                                      |
-| useDefaultNotification                       | Body | Boolean | X  | 기본 알림 사용 여부<br/>- 기본값: `false`                                                                                                                                                                                                                      |
-| useDeletionProtection                        | Body | Boolean | X  | 삭제 보호 여부<br/>- 기본값: `false`                                                                                                                                                                                                                         |
-| network                                      | Body | Object  | X  | 네트워크 정보 객체                                                                                                                                                                                                                                          |
-| network.usePublicAccess                      | Body | Boolean | X  | 외부 접속 가능 여부<br/>- 기본값: `false`                                                                                                                                                                                                                      |
-| network.availabilityZone                     | Body | Enum    | X  | DB 인스턴스를 생성할 가용성 영역<br/>- 예시: `kr-pub-a`<br/>- 기본값: `임의의 가용성 영역`                                                                                                                                                                                    |  
-| storage                                      | Body | Object  | X  | 스토리지 정보 객체                                                                                                                                                                                                                                          |    
-| storage.storageType                          | Body | Enum    | X  | 데이터 스토리지 유형<br>- 예시: `General SSD`                                                                                                                                                                                                                  |
-| storage.storageSize                          | Body | Number  | X  | 데이터 스토리지 크기(GB)<br/>- 기본값: 원본 DB 인스턴스 값<br/>- 최솟값: `20`<br/>- 최댓값: `2048`                                                                                                                                                                           |
-| backup                                       | Body | Object  | X  | 백업 정보 객체                                                                                                                                                                                                                                            |
-| backup.backupPeriod                          | Body | Number  | X  | 백업 보관 기간(일)<br/>- 기본값: 원본 DB 인스턴스 값<br/>- 최솟값: `0`<br/>- 최댓값: `730`                                                                                                                                                                                 |
-| backup.backupRetryCount                      | Body | Number  | X  | 백업 재시도 횟수<br/>- 기본값: 원본 DB 인스턴스 값<br/>- 최솟값: `0`<br/>- 최댓값: `10`                                                                                                                                                                                    |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "dbInstanceName": "db-instance-replicate",
-    "description": "description",
-    "dbPort": 15432,
-    "storage": {
-        "storageSize": 100
-    }
-}
-```
-</details>
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### DB 인스턴스 승격하기
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/promote
-```
-
-#### 필요 권한
-
-| 권한명                                 | 설명           |
-|-------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Promote | DB 인스턴스 승격하기 |
 
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
 
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| availableDbVersions | Body | Array | DB 버전 정보 |
+| availableDbVersions.dbVersionCode | Body | Enum | DB 버전 코드<br/>- MYSQL_V5633<br/>- MYSQL_V5715<br/>- MYSQL_V5719<br/>- MYSQL_V5726<br/>- MYSQL_V5731<br/>- MYSQL_V5733<br/>- MYSQL_V5737<br/>- MYSQL_V8018<br/>- MYSQL_V8023<br/>- MYSQL_V8028<br/>- MYSQL_V8032<br/>- MYSQL_V8033<br/>- MYSQL_V8034<br/>- MYSQL_V8035<br/>- MYSQL_V8036<br/>- MYSQL_V8040<br/>- MYSQL_V8041<br/>- MYSQL_V8042<br/>- MYSQL_V8043<br/>- MYSQL_V8044<br/>- MYSQL_V8045<br/>- MYSQL_V8405<br/>- MYSQL_V8406<br/>- MYSQL_V8407<br/>- MYSQL_V8408<br/>- MARIADB_V10330<br/>- MARIADB_V10611<br/>- MARIADB_V10612<br/>- MARIADB_V10616<br/>- MARIADB_V10622<br/>- MARIADB_V10625<br/>- MARIADB_V101107<br/>- MARIADB_V101108<br/>- MARIADB_V101113<br/>- MARIADB_V101116<br/>- MARIADB_V11407<br/>- MARIADB_V11410<br/>- MARIADB_V11806<br/>- POSTGRESQL_V14_6<br/>- POSTGRESQL_V14_15<br/>- POSTGRESQL_V14_17<br/>- POSTGRESQL_V14_19<br/>- POSTGRESQL_V17_2<br/>- POSTGRESQL_V17_4<br/>- POSTGRESQL_V17_6 |
+| availableDbVersions.dbMajorVersionCode | Body | Enum | DB 메이저 버전 코드<br/>- MYSQL_V56<br/>- MYSQL_V57<br/>- MYSQL_V80<br/>- MYSQL_V84<br/>- MARIADB_V103<br/>- MARIADB_V106<br/>- MARIADB_V1011<br/>- MARIADB_V114<br/>- MARIADB_V118<br/>- POSTGRES_V14<br/>- POSTGRES_V17 |
+| availableDbVersions.name | Body | String | DB 버전명 |
+| availableDbVersions.canCreate | Body | Boolean | 신규 생성 가능 여부 |
 
 <details><summary>예시</summary>
+<p>
 
 ```json
 {
@@ -2487,13 +1062,243 @@ POST /v1.0/db-instances/{dbInstanceId}/promote
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "availableDbVersions": [
+        {
+            "canCreate": false
+        }
+    ]
 }
 ```
+
+</p>
 </details>
 
+---
 
-## DB 인스턴스 > 데이터베이스
+### DB 인스턴스 백업하기
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/backup
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| backupName | Body | String | O | 백업을 식별할 수 있는 이름 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "backupName": "backupName-example"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 인스턴스 백업 정보 조회
+
+```http
+GET /v1.0/db-instances/{dbInstanceId}/backup-info
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| allowAutoBackup | Body | Boolean | 자동 백업 허용 여부 |
+| usePeriodicAutoBackup | Body | Boolean | 예정된 자동 백업 사용 여부 |
+| backupPeriod | Body | Number | 백업 보관 기간(일) |
+| backupRetryCount | Body | Number | 백업 재시도 횟수 |
+| backupSchedules | Body | Array | 백업 스케쥴 목록 |
+| backupSchedules.backupWndBgnTime | Body | String | 백업 시작 시각 |
+| backupSchedules.backupWndDuration | Body | Enum | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "allowAutoBackup": false,
+    "usePeriodicAutoBackup": false,
+    "backupPeriod": 1,
+    "backupRetryCount": 1,
+    "backupSchedules": [
+        {
+            "backupWndDuration": "HALF_AN_HOUR"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 인스턴스 백업 정보 수정하기
+
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/backup-info
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| allowAutoBackup | Body | Boolean | X | 자동 백업 허용 여부 |
+| usePeriodicAutoBackup | Body | Boolean | X | 예정된 자동 백업 사용 여부 |
+| backupPeriod | Body | Number | X | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
+| backupRetryCount | Body | Number | X | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
+| backupSchedules | Body | Array | X | 백업 스케쥴 목록 |
+| backupSchedules.backupWndBgnTime | Body | String | O | 백업 시작 시각 |
+| backupSchedules.backupWndDuration | Body | Enum | O | 백업 윈도우<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "allowAutoBackup": false,
+    "usePeriodicAutoBackup": false,
+    "backupPeriod": 0,
+    "backupRetryCount": 0,
+    "backupSchedules": [
+        {
+            "backupWndDuration": "HALF_AN_HOUR"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 인스턴스 오브젝트 스토리지로 백업
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/backup-to-object-storage
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| tenantId | Body | String | O | 백업이 저장될 오브젝트 스토리지의 테넌트 ID<br/>- 최소 길이: `32`<br/>- 최대 길이: `32` |
+| username | Body | String | O | NHN Cloud 계정 혹은 IAM 회원 ID |
+| password | Body | String | O | 백업이 저장될 오브젝트 스토리지의 API 비밀번호 |
+| targetContainer | Body | String | O | 백업이 저장될 오브젝트 스토리지의 컨테이너 |
+| objectPath | Body | String | O | 컨테이너에 저장될 백업의 경로 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "tenantId": "tenantId-example",
+    "username": "username-example",
+    "password": "password-example",
+    "targetContainer": "targetContainer-example",
+    "objectPath": "objectPath-example"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
 
 ### 데이터베이스 목록 보기
 
@@ -2501,34 +1306,29 @@ POST /v1.0/db-instances/{dbInstanceId}/promote
 GET /v1.0/db-instances/{dbInstanceId}/databases
 ```
 
-#### 필요 권한
-
-| 권한명                                      | 설명                     |
-|------------------------------------------|------------------------|
-| RDSforPostgreSQL:DbInstanceDatabase.List | DB 인스턴스 내 데이터베이스 목록 보기 |
-
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
 
 #### 응답
 
-| 이름                           | 종류   | 형식       | 설명                                                                                                                                                  |
-|------------------------------|------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| databases                    | Body | Array    | 데이터베이스 목록                                                                                                                                           |
-| databases.databaseId         | Body | UUID     | 데이터베이스의 식별자                                                                                                                                         |
-| databases.databaseName       | Body | String   | 데이터베이스 이름                                                                                                                                           |
-| databases.databaseStatus     | Body | Enum     | 데이터베이스의 현재 상태<br/>- `STABLE`: 생성됨<br/>- `CREATING`: 생성 중<br/>- `MODIFYING`: 수정 중<br/>- `SYNCING`: 동기화 중<br/>- `DELETING`: 삭제 중<br/>- `DELETED`: 삭제됨 |
-| databases.createdYmdt        | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                   |
-| databases.updatedYmdt        | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                   |
-| databases.schemas            | Body | Array    | 데이터베이스 내 스키마 목록                                                                                                                                     |
-| databases.schemas.schemaName | Body | String   | 스키마 이름                                                                                                                                              |
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| databases | Body | Array | 데이터베이스 정보 |
+| databases.databaseId | Body | String | 데이터베이스의 식별자 |
+| databases.databaseName | Body | String | 데이터베이스 이름 |
+| databases.databaseStatus | Body | Enum | 데이터베이스의 현재 상태<br/>- STABLE: `사용 가능`<br/>- CREATING: `생성 중`<br/>- MODIFYING: `수정 중`<br/>- DELETING: `삭제 중`<br/>- DELETED: `삭제됨`<br/>- SYNCING: `동기화 중` |
+| databases.createdYmdt | Body | DateTime | 생성 일시 |
+| databases.updatedYmdt | Body | DateTime | 수정 일시 |
+| databases.schemas | Body | Array | 스키마 정보 |
+| databases.schemas.schemaName | Body | String | 스키마 이름 |
 
 <details><summary>예시</summary>
+<p>
 
 ```json
 {
@@ -2539,21 +1339,18 @@ GET /v1.0/db-instances/{dbInstanceId}/databases
     },
     "databases": [
         {
-            "databaseId": "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4",
-            "databaseName": "database",
-            "databaseStatus": "STABLE",
-            "createdYmdt": "2023-03-20T13:37:45+09:00",
-            "updatedYmdt": "2023-03-20T13:37:45+09:00",
-            "schemas": [
-                {
-                    "schemaName": "rds"
-                }
-            ]
+            "schemas": {
+                "schemaName": "schemaName-example"
+            }
         }
     ]
 }
 ```
+
+</p>
 </details>
+
+---
 
 ### 데이터베이스 생성하기
 
@@ -2561,35 +1358,33 @@ GET /v1.0/db-instances/{dbInstanceId}/databases
 POST /v1.0/db-instances/{dbInstanceId}/databases
 ```
 
-#### 필요 권한
-
-| 권한명                                        | 설명                    |
-|--------------------------------------------|-----------------------|
-| RDSforPostgreSQL:DbInstanceDatabase.Create | DB 인스턴스 내 데이터베이스 생성하기 |
-
 #### 요청
 
-| 이름           | 종류   | 형식     | 필수 | 설명           |
-|--------------|------|--------|----|--------------|
-| dbInstanceId | URL  | UUID   | O  | DB 인스턴스의 식별자 |
-| databaseName | Body | String | O  | 데이터베이스 이름    |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| databaseName | Body | String | O | 데이터베이스 이름 |
 
 <details><summary>예시</summary>
+<p>
 
 ```json
 {
-    "databaseName": "database"
+    "databaseName": "databaseName-example"
 }
 ```
+
+</p>
 </details>
 
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | 요청한 작업의 식별자 |
 
 <details><summary>예시</summary>
+<p>
 
 ```json
 {
@@ -2598,60 +1393,14 @@ POST /v1.0/db-instances/{dbInstanceId}/databases
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-### 데이터베이스 수정하기
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/databases/{databaseId}
-```
-
-#### 필요 권한
-
-| 권한명                                        | 설명                    |
-|--------------------------------------------|-----------------------|
-| RDSforPostgreSQL:DbInstanceDatabase.Modify | DB 인스턴스 내 데이터베이스 수정하기 |
-
-#### 요청
-
-| 이름                       | 종류   | 형식      | 필수 | 설명                                                                                          |
-|--------------------------|------|---------|----|---------------------------------------------------------------------------------------------|
-| dbInstanceId             | URL  | UUID    | O  | DB 인스턴스의 식별자                                                                                |
-| databaseId               | URL  | UUID    | O  | 데이터베이스의 식별자                                                                                 |
-| databaseName             | Body | String  | O  | 데이터베이스 이름                                                                                   |
-| applyHbaRulesImmediately | Body | Boolean | X  | 연관된 접근 제어 규칙 즉시 적용 여부<br/>- 데이터베이스 이름 변경 시 이전 데이터베이스 이름으로 설정된 접근 제어 규칙이 있으면 변경된 이름으로 반영합니다. |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "databaseName": "database-1"
-}
-```
-</details>
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
+---
 
 ### 데이터베이스 삭제하기
 
@@ -2659,28 +1408,23 @@ PUT /v1.0/db-instances/{dbInstanceId}/databases/{databaseId}
 DELETE /v1.0/db-instances/{dbInstanceId}/databases/{databaseId}
 ```
 
-#### 필요 권한
-
-| 권한명                                        | 설명                    |
-|--------------------------------------------|-----------------------|
-| RDSforPostgreSQL:DbInstanceDatabase.Delete | DB 인스턴스 내 데이터베이스 삭제하기 |
-
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-| databaseId   | URL | UUID | O  | 데이터베이스의 식별자  |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| databaseId | URL | UUID | O | 데이터베이스의 식별자 |
 
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | 요청한 작업의 식별자 |
 
 <details><summary>예시</summary>
+<p>
 
 ```json
 {
@@ -2689,12 +1433,67 @@ DELETE /v1.0/db-instances/{dbInstanceId}/databases/{databaseId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-## DB 인스턴스 > 사용자
+---
+
+### 데이터베이스 수정하기
+
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/databases/{databaseId}
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| databaseId | URL | UUID | O | 데이터베이스의 식별자 |
+| applyHbaRulesImmediately | Body | Boolean | X | 연관된 접근 제어 규칙 즉시 적용 여부<br/>- 기본값: `false` |
+| databaseName | Body | String | O | 데이터베이스 이름 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "applyHbaRulesImmediately": false,
+    "databaseName": "databaseName-example"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
 
 ### 사용자 목록 보기
 
@@ -2702,33 +1501,28 @@ DELETE /v1.0/db-instances/{dbInstanceId}/databases/{databaseId}
 GET /v1.0/db-instances/{dbInstanceId}/db-users
 ```
 
-#### 필요 권한
-
-| 권한명                                  | 설명                  |
-|--------------------------------------|---------------------|
-| RDSforPostgreSQL:DbInstanceUser.List | DB 인스턴스 내 사용자 목록 보기 |
-
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
 
 #### 응답
 
-| 이름                    | 종류   | 형식       | 설명                                                                                                                                                  |
-|-----------------------|------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbUsers               | Body | Array    | DB 사용자 목록                                                                                                                                           |
-| dbUsers.dbUserId      | Body | UUID     | DB 사용자의 식별자                                                                                                                                         |
-| dbUsers.dbUserName    | Body | String   | DB 사용자 계정 이름                                                                                                                                        |
-| dbUsers.authorityType | Body | Enum     | DB 사용자 권한 유형<br/>- `CRUD`: DML 쿼리 수행 가능한 권한<br/>- `DDL`: DDL 쿼리 수행 가능한 권한                                                                           |
-| dbUsers.dbUserStatus  | Body | Enum     | DB 사용자의 현재 상태<br/>- `STABLE`: 생성됨<br/>- `CREATING`: 생성 중<br/>- `MODIFYING`: 수정 중<br/>- `SYNCING`: 동기화 중<br/>- `DELETING`: 삭제 중<br/>- `DELETED`: 삭제됨 |
-| dbUsers.createdYmdt   | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                   |
-| dbUsers.updatedYmdt   | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                   |
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| dbUsers | Body | Array | DB 사용자 목록 |
+| dbUsers.dbUserId | Body | String | DB 사용자의 식별자 |
+| dbUsers.dbUserName | Body | String | DB 사용자 계정 이름 |
+| dbUsers.authorityType | Body | Enum | DB 사용자 권한 타입<br/>- CUSTOM: `커스텀 권한 권한`<br/>- READ: `READ 권한 (읽기 전용 권한)`<br/>- CRUD: `CRUD 권한 (읽기 권한 포함)`<br/>- DDL: `DDL 권한 (CRUD 권한 포함)` |
+| dbUsers.dbUserStatus | Body | Enum | DB 사용자의 현재 상태<br/>- STABLE: `사용 가능`<br/>- CREATING: `생성 중`<br/>- MODIFYING: `수정 중`<br/>- DELETING: `삭제 중`<br/>- DELETED: `삭제됨`<br/>- SYNCING: `동기화 중` |
+| dbUsers.createdYmdt | Body | DateTime | 생성 일시 |
+| dbUsers.updatedYmdt | Body | DateTime | 수정 일시 |
 
 <details><summary>예시</summary>
+<p>
 
 ```json
 {
@@ -2737,17 +1531,18 @@ GET /v1.0/db-instances/{dbInstanceId}/db-users
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "databases": [
+    "dbUsers": [
         {
-            "databaseId": "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4",
-            "databaseName": "database",
-            "databaseStatus": "STABLE",
-            "createdYmdt": "2023-03-20T13:37:45+09:00"
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
+
+</p>
 </details>
+
+---
 
 ### 사용자 생성하기
 
@@ -2755,41 +1550,41 @@ GET /v1.0/db-instances/{dbInstanceId}/db-users
 POST /v1.0/db-instances/{dbInstanceId}/db-users
 ```
 
-#### 필요 권한
-
-| 권한명                                    | 설명                 |
-|----------------------------------------|--------------------|
-| RDSforPostgreSQL:DbInstanceUser.Create | DB 인스턴스 내 사용자 생성하기 |
-
 #### 요청
 
-| 이름                    | 종류   | 형식      | 필수 | 설명                                                                        |
-|-----------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId          | URL  | UUID    | O  | DB 인스턴스의 식별자                                                              |
-| dbUserName            | Body | String  | O  | DB 사용자 계정 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `20`                           |
-| dbPassword            | Body | String  | O  | DB 사용자 계정 암호<br/>- 최소 길이: `1`<br/>- 최대 길이: `100`                          |
-| authorityType         | Body | Enum    | O  | DB 사용자 권한 유형<br/>- `CRUD`: DML 쿼리 수행 가능한 권한<br/>- `DDL`: DDL 쿼리 수행 가능한 권한 |
-| createDefaultHbaRules | Body | Boolean | X  | 기본 접근 제어 규칙 생성 여부                                                         |
-| address               | Body | String  | X  | 기본 접근 제어 규칙 생성 시 사용할 접속 주소                                                |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbUserName | Body | String | O | DB 사용자 계정 이름 |
+| dbPassword | Body | String | O | DB 사용자 계정 암호 |
+| authorityType | Body | Enum | O | DB 사용자 권한 타입<br/>- CUSTOM: `사용자 정의 권한`<br/>- READ: `읽기 권한`<br/>- CRUD: `CRUD 권한`<br/>- DDL: `DDL 권한` |
+| createDefaultHbaRules | Body | Boolean | X | 기본 접근 제어 규칙 생성 여부<br/>- 기본값: `false` |
+| address | Body | String | X | 접속 주소 |
 
 <details><summary>예시</summary>
+<p>
 
 ```json
 {
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "authorityType": "CRUD"
+    "dbUserName": "dbUserName-example",
+    "dbPassword": "dbPassword-example",
+    "authorityType": "CUSTOM",
+    "createDefaultHbaRules": false,
+    "address": "address-example"
 }
 ```
+
+</p>
 </details>
 
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | 요청한 작업의 식별자 |
 
 <details><summary>예시</summary>
+<p>
 
 ```json
 {
@@ -2798,63 +1593,14 @@ POST /v1.0/db-instances/{dbInstanceId}/db-users
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-### 사용자 수정하기
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
-```
-
-#### 필요 권한
-
-| 권한명                                    | 설명                 |
-|----------------------------------------|--------------------|
-| RDSforPostgreSQL:DbInstanceUser.Modify | DB 인스턴스 내 사용자 수정하기 |
-
-#### 요청
-
-| 이름                       | 종류   | 형식      | 필수 | 설명                                                                                          |
-|--------------------------|------|---------|----|---------------------------------------------------------------------------------------------|
-| dbInstanceId             | URL  | UUID    | O  | DB 인스턴스의 식별자                                                                                |
-| dbUserId                 | URL  | UUID    | O  | DB 사용자의 식별자                                                                                 |
-| dbUserName               | Body | String  | X  | DB 사용자 계정 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `20`                                             |
-| dbPassword               | Body | String  | X  | DB 사용자 계정 암호<br/>- 최소 길이: `1`<br/>- 최대 길이: `100`                                            |
-| authorityType            | Body | Enum    | X  | DB 사용자 권한 유형<br/>- `CRUD`: DML 쿼리 수행 가능한 권한<br/>- `DDL`: DDL 쿼리 수행 가능한 권한                   |
-| applyHbaRulesImmediately | Body | Boolean | X  | 연관된 접근 제어 규칙 즉시 적용 여부<br/>- 사용자 계정 이름 변경 시 이전 사용자 계정 이름으로 설정된 접근 제어 규칙이 있으면 변경된 이름으로 반영합니다. |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "dbUserName": "db-user-1",
-    "dbPassword": "new-password"
-}
-```
-</details>
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
+---
 
 ### 사용자 삭제하기
 
@@ -2862,28 +1608,23 @@ PUT /v1.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
 DELETE /v1.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
 ```
 
-#### 필요 권한
-
-| 권한명                                    | 설명                 |
-|----------------------------------------|--------------------|
-| RDSforPostgreSQL:DbInstanceUser.Delete | DB 인스턴스 내 사용자 삭제하기 |
-
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-| dbUserId     | URL | UUID | O  | DB 사용자의 식별자  |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbUserId | URL | UUID | O | 사용자의 식별자 |
 
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | 요청한 작업의 식별자 |
 
 <details><summary>예시</summary>
+<p>
 
 ```json
 {
@@ -2892,12 +1633,122 @@ DELETE /v1.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-## DB 인스턴스 > 접근 제어
+---
+
+### 사용자 수정하기
+
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbUserId | URL | UUID | O | 사용자의 식별자 |
+| dbUserName | Body | String | X | DB 사용자 계정 이름 |
+| dbPassword | Body | String | X | DB 사용자 계정 암호 |
+| authorityType | Body | Enum | X | DB 사용자 권한<br/>- CUSTOM: `사용자 정의 권한`<br/>- READ: `읽기 권한`<br/>- CRUD: `CRUD 권한`<br/>- DDL: `DDL 권한` |
+| applyHbaRulesImmediately | Body | Boolean | X | 접근 제어 변경 사항 즉시 적용 여부<br/>- 기본값: `false` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "dbUserName": "dbUserName-example",
+    "dbPassword": "dbPassword-example",
+    "authorityType": "CUSTOM",
+    "applyHbaRulesImmediately": false
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 인스턴스 삭제 보호 설정 변경하기
+
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/deletion-protection
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| useDeletionProtection | Body | Boolean | O | 삭제 보호 여부 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "useDeletionProtection": false
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### DB 인스턴스 강제 재시작하기
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/force-restart
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
 
 ### 접근 제어 규칙 목록 보기
 
@@ -2905,43 +1756,38 @@ DELETE /v1.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
 GET /v1.0/db-instances/{dbInstanceId}/hba-rules
 ```
 
-#### 필요 권한
-
-| 권한명                                 | 설명                       |
-|-------------------------------------|--------------------------|
-| RDSforPostgreSQL:DbInstanceHba.List | DB 인스턴스 내 접근 제어 규칙 목록 보기 |
-
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
 
 #### 응답
 
-| 이름                              | 종류   | 형식      | 설명                                                                                                                                                   |
-|---------------------------------|------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------|
-| hbaRules                        | Body | Array   | 접근 제어 규칙 목록                                                                                                                                          |
-| hbaRules.hbaRuleId              | Body | UUID    | 접근 제어 규칙의 식별자                                                                                                                                        |
-| hbaRules.hbaRuleStatus          | Body | Enum    | 접근 제어 규칙의 현재 상태<br/>- `CREATED`: 생성됨<br/>- `APPLIED`: 적용됨<br/>- `CREATING`: 생성 중<br/>- `MODIFYING`: 수정 중<br/>- `DELETING`: 삭제 중<br/>- `DELETED`: 삭제됨 |
-| hbaRules.databaseApplyType      | Body | String  | 데이터베이스 규칙 적용 방식<br/>- `ENTIRE`: 전체<br/>- `USER_CUSTOM`: 사용자 지정                                                                                       |
-| hbaRules.dbUserApplyType        | Body | Enum    | DB 사용자 규칙 적용 방식<br/>- `ENTIRE`: 전체<br/>- `USER_CUSTOM`: 사용자 지정                                                                                       |
-| hbaRules.databases              | Body | Array   | 사용자 지정 데이터베이스 목록                                                                                                                                     |
-| hbaRules.databases.databaseId   | Body | UUID    | 사용자 지정 데이터베이스의 식별자                                                                                                                                   |
-| hbaRules.databases.databaseName | Body | String  | 사용자 지정 데이터베이스 이름                                                                                                                                     |
-| hbaRules.dbUsers                | Body | Array   | 사용자 지정 DB 사용자 목록                                                                                                                                     |
-| hbaRules.dbUsers.dbUserId       | Body | UUID    | 사용자 지정 DB 사용자의 식별자                                                                                                                                   |
-| hbaRules.dbUsers.dbUserName     | Body | String  | 사용자 지정 DB 사용자 계정 이름                                                                                                                                  |
-| hbaRules.address                | Body | String  | 접속 주소                                                                                                                                                |
-| hbaRules.authMethod             | Body | Enum    | 인증 방식<br/>- `TRUST`: 트러스트(패스워드 불필요)<br/>- `REJECT`: 접속 차단<br/>- `SCRAM_SHA_256`: 패스워드(SCRAM-SHA-256)                                                 |
-| hbaRules.reservedAction         | Body | Enum    | 예악 작업<br/>- `NONE`: 없음<br/>- `CREATE`: 생성 예약(적용 필요)<br/>- `MODIFY`: 수정 예약(적용 필요)<br/>- `DELETE`: 삭제 예약(적용 필요)                                        |
-| hbaRules.order                  | Body | Number  | 적용 순서                                                                                                                                                |
-| hbaRules.applicable             | Body | Boolean | 적용 가능 여부<br/>- 적용 불가 상태의 규칙은 무시됨                                                                                                                     |
-| needToApply                     | Body | Boolean | 변경 사항 적용 필요 여부                                                                                                                                       |
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| hbaRules | Body | Array | 접근 제어 규칙 정보 |
+| hbaRules.hbaRuleId | Body | String | 접근 제어 규칙의 식별자 |
+| hbaRules.hbaRuleStatus | Body | Enum | 접근 제어 규칙의 현재 상태<br/>- CREATED: `생성됨`<br/>- APPLIED: `적용됨`<br/>- CREATING: `생성 중`<br/>- MODIFYING: `수정 중`<br/>- DELETING: `삭제 중`<br/>- DELETED: `삭제됨` |
+| hbaRules.databaseApplyType | Body | Enum | DB 데이터베이스 적용 타입<br/>- ENTIRE: `전체`<br/>- USER_CUSTOM: `사용자 지정` |
+| hbaRules.dbUserApplyTypeCode | Body | Enum | DB 사용자 적용 타입<br/>- ENTIRE: `전체`<br/>- USER_CUSTOM: `사용자 지정` |
+| hbaRules.databases | Body | Array | 사용자 지정 데이터베이스 리스트 |
+| hbaRules.databases.databaseId | Body | String | 데이터베이스 ID |
+| hbaRules.databases.databaseName | Body | String | 데이터베이스 이름 |
+| hbaRules.dbUsers | Body | Array | 사용자 지정 DB 사용자 리스트 |
+| hbaRules.dbUsers.dbUserId | Body | String | DB 사용자 ID |
+| hbaRules.dbUsers.dbUserName | Body | String | DB 사용자 이름 |
+| hbaRules.address | Body | String | 접속 주소 |
+| hbaRules.authMethod | Body | Enum | 인증 방식<br/>- TRUST: `트러스트 (패스워드 불필요)`<br/>- REJECT: `접속 차단`<br/>- SCRAM_SHA_256: `패스워드 (SCRAM-SHA-256)` |
+| hbaRules.reservedAction | Body | Enum | 예약된 작업 내용<br/>- NONE: `없음`<br/>- CREATE: `생성 예약 (적용 필요)`<br/>- MODIFY: `수정 예약 (적용 필요)`<br/>- DELETE: `삭제 예약 (적용 필요)` |
+| hbaRules.order | Body | Number | 규칙 적용 순서 |
+| hbaRules.applicable | Body | Boolean | 적용 가능 여부 |
+| needToApply | Body | Boolean | 변경사항 적용 필요 여부 |
 
 <details><summary>예시</summary>
+<p>
 
 ```json
 {
@@ -2952,75 +1798,63 @@ GET /v1.0/db-instances/{dbInstanceId}/hba-rules
     },
     "hbaRules": [
         {
-            "hbaRuleId": "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4",
-            "hbaRuleStatus": "APPLIED",
-            "databaseApplyType": "USER_CUSTOM",
-            "dbUserApplyType": "ENTIRE",
-            "databases": [
-                {
-                    "databaseId": "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4",
-                    "databaseName": "database"
-                }
-            ],
-            "dbUsers": [],
-            "address": "0.0.0.0/0",
-            "authMethod": "TRUST",
-            "reservedAction": "NONE",
-            "order": 0,
-            "applicable": true
+            "applicable": false
         }
-    ]
+    ],
+    "needToApply": false
 }
 ```
+
+</p>
 </details>
 
-### 접근 제어 규칙 추가하기
+---
+
+### DB 인스턴스 접근제어 규칙 추가
 
 ```http
 POST /v1.0/db-instances/{dbInstanceId}/hba-rules
 ```
 
-#### 필요 권한
-
-| 권한명                                   | 설명                      |
-|---------------------------------------|-------------------------|
-| RDSforPostgreSQL:DbInstanceHba.Create | DB 인스턴스 내 접근 제어 규칙 추가하기 |
-
 #### 요청
 
-| 이름                | 종류   | 형식     | 필수 | 설명                                                                                                   |
-|-------------------|------|--------|----|------------------------------------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID   | O  | DB 인스턴스의 식별자                                                                                         |
-| databaseApplyType | Body | String | O  | 데이터베이스 규칙 적용 방식<br/>- `ENTIRE`: 전체<br/>- `USER_CUSTOM`: 사용자 지정                                       |
-| dbUserApplyType   | Body | Enum   | O  | DB 사용자 규칙 적용 방식<br/>- `ENTIRE`: 전체<br/>- `USER_CUSTOM`: 사용자 지정                                       |
-| databaseIds       | Body | Array  | X  | 사용자 지정 데이터베이스의 식별자 목록                                                                                |
-| dbUserIds         | Body | Array  | X  | 사용자 지정 DB 사용자의 식별자 목록                                                                                |
-| address           | Body | String | O  | 접속 주소<br/>- CIDR 형식, 호스트명 또는 도메인 형식으로 입력                                                             |
-| authMethod        | Body | Enum   | O  | 인증 방식<br/>- `TRUST`: 트러스트(패스워드 불필요)<br/>- `REJECT`: 접속 차단<br/>- `SCRAM_SHA_256`: 패스워드(SCRAM-SHA-256) |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| connectionTypeCode | Body | Enum | X | 접근 제어 레코드 타입<br/>- HOST: `TCP/IP로 접속 시 유효`<br/>- HOST_NO_SSL: `SSL 암호화를 사용하지 않는 접속 시에만 유효` |
+| databaseApplyType | Body | Enum | O | Database 적용 타입<br/>- ENTIRE: `전체`<br/>- USER_CUSTOM: `사용자 지정` |
+| dbUserApplyType | Body | Enum | O | DB 사용자 적용 타입<br/>- ENTIRE: `전체`<br/>- USER_CUSTOM: `사용자 지정` |
+| databaseIds | Body | Array | X | 데이터베이스의 식별자 목록 |
+| dbUserIds | Body | Array | X | DB 사용자의 식별자 목록 |
+| address | Body | String | O | 접속 주소 |
+| authMethod | Body | Enum | O | 인증 방식<br/>- TRUST: `트러스트 (패스워드 불필요)`<br/>- REJECT: `접속 차단`<br/>- SCRAM_SHA_256: `패스워드 (SCRAM-SHA-256)` |
 
 <details><summary>예시</summary>
+<p>
 
 ```json
 {
+    "connectionTypeCode": "HOST",
     "databaseApplyType": "ENTIRE",
-    "dbUserApplyType": "USER_CUSTOM",
-    "databaseIds": [], 
-    "dbUserIds": [
-        "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4"
-    ],
-    "address": "0.0.0.0/0",
+    "dbUserApplyType": "ENTIRE",
+    "databaseIds": [],
+    "dbUserIds": [],
+    "address": "address-example",
     "authMethod": "TRUST"
 }
 ```
+
+</p>
 </details>
 
 #### 응답
 
-| 이름        | 종류   | 형식   | 설명            |
-|-----------|------|------|---------------|
-| hbaRuleId | Body | UUID | 접근 제어 규칙의 식별자 |
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| hbaRuleId | Body | String | 접근 제어 규칙 ID |
 
 <details><summary>예시</summary>
+<p>
 
 ```json
 {
@@ -3029,179 +1863,37 @@ POST /v1.0/db-instances/{dbInstanceId}/hba-rules
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "hbaRuleId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "hbaRuleId": "hbaRuleId-example"
 }
 ```
+
+</p>
 </details>
 
-### 접근 제어 규칙 수정하기
+---
 
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/hba-rules/{hbaRuleId}
-```
-
-#### 필요 권한
-
-| 권한명                                   | 설명                      |
-|---------------------------------------|-------------------------|
-| RDSforPostgreSQL:DbInstanceHba.Modify | DB 인스턴스 내 접근 제어 규칙 수정하기 |
-
-#### 요청
-
-| 이름                | 종류   | 형식     | 필수 | 설명                                                                                                   |
-|-------------------|------|--------|----|------------------------------------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID   | O  | DB 인스턴스의 식별자                                                                                         |
-| hbaRuleId         | URL  | UUID   | O  | 접근 제어 규칙의 식별자                                                                                        |
-| databaseApplyType | Body | String | O  | 데이터베이스 규칙 적용 방식<br/>- `ENTIRE`: 전체<br/>- `USER_CUSTOM`: 사용자 지정                                       |
-| dbUserApplyType   | Body | Enum   | O  | DB 사용자 규칙 적용 방식<br/>- `ENTIRE`: 전체<br/>- `USER_CUSTOM`: 사용자 지정                                       |
-| databaseIds       | Body | Array  | X  | 사용자 지정 데이터베이스의 식별자 목록                                                                                |
-| dbUserIds         | Body | Array  | X  | 사용자 지정 DB 사용자의 식별자 목록                                                                                |
-| address           | Body | String | O  | 접속 주소<br/>- CIDR 형식, 호스트명 또는 도메인 형식으로 입력                                                             |
-| authMethod        | Body | Enum   | O  | 인증 방식<br/>- `TRUST`: 트러스트(패스워드 불필요)<br/>- `REJECT`: 접속 차단<br/>- `SCRAM_SHA_256`: 패스워드(SCRAM-SHA-256) |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "databaseApplyType": "ENTIRE",
-    "dbUserApplyType": "ENTIRE",
-    "databaseIds": [], 
-    "dbUserIds": [],
-    "address": "0.0.0.0/0",
-    "authMethod": "REJECT"
-}
-```
-</details>
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
-
-### 접근 제어 규칙 삭제하기
-
-```http
-DELETE /v1.0/db-instances/{dbInstanceId}/hba-rules/{hbaRuleId}
-```
-
-#### 필요 권한
-
-| 권한명                                   | 설명                      |
-|---------------------------------------|-------------------------|
-| RDSforPostgreSQL:DbInstanceHba.Delete | DB 인스턴스 내 접근 제어 규칙 삭제하기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명            |
-|--------------|-----|------|----|---------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자  |
-| hbaRuleId    | URL | UUID | O  | 접근 제어 규칙의 식별자 |
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
-
-### 접근 제어 규칙 순서 조정
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/hba-rules/orders
-```
-
-#### 필요 권한
-
-| 권한명                                   | 설명                      |
-|---------------------------------------|-------------------------|
-| RDSforPostgreSQL:DbInstanceHba.Modify | DB 인스턴스 내 접근 제어 규칙 수정하기 |
-
-#### 요청
-
-| 이름           | 종류  | 형식   | 필수 | 설명                                  |
-|--------------|-----|------|----|-------------------------------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자                        |
-| hbaRuleIds   | URL | Body | O  | 접근 제어 규칙의 식별자 목록<br/>- 요청한 순서대로 조정됨 |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "hbaRuleIds": [
-        "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4"
-    ]
-}
-```
-</details>
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
-
-### 접근제어 규칙 적용하기
+### DB 인스턴스 접근제어 규칙 적용
 
 ```http
 POST /v1.0/db-instances/{dbInstanceId}/hba-rules/apply
 ```
 
-#### 필요 권한
-
-| 권한명                                   | 설명           |
-|---------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Modify    | DB 인스턴스 수정하기 |
-
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
 
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | 요청한 작업의 식별자 |
 
 <details><summary>예시</summary>
+<p>
 
 ```json
 {
@@ -3210,55 +1902,1751 @@ POST /v1.0/db-instances/{dbInstanceId}/hba-rules/apply
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-## 백업
+---
 
-### 백업 목록 조회
+### DB 인스턴스 접근제어 규칙 순서 조정
 
 ```http
-GET /v1.0/backups
+PUT /v1.0/db-instances/{dbInstanceId}/hba-rules/orders
 ```
 
-#### 필요 권한
+#### 요청
 
-| 권한명                          | 설명       |
-|------------------------------|----------|
-| RDSforPostgreSQL:Backup.List | 백업 목록 조회 |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| hbaRuleIds | Body | Array | O | 정렬된 접속제어 규칙 ID 리스트 (요청받은 순서대로 저장) |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "hbaRuleIds": []
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### DB 인스턴스 접근제어 설정 삭제
+
+```http
+DELETE /v1.0/db-instances/{dbInstanceId}/hba-rules/{hbaRuleId}
+```
 
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름           | 종류    | 형식     | 필수 | 설명                                                         |
-|--------------|-------|--------|----|------------------------------------------------------------|
-| page         | Query | Number | O  | 조회할 목록의 페이지<br/>- 최솟값: `1`                                 |
-| size         | Query | Number | O  | 조회할 목록의 페이지 크기<br/>- 최솟값: `1`<br/>- 최댓값: `100`             |
-| backupType   | Query | Enum   | X  | 백업 유형<br/>- `AUTO`: 자동<br/>- `MANUAL`:  수동<br/>- 기본값: `전체` |
-| dbInstanceId | Query | UUID   | X  | 원본 DB 인스턴스의 식별자                                            |
-| dbVersion    | Query | Enum   | X  | DB 버전 정보                                                   |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| hbaRuleId | URL | UUID | O | 접근제어 규칙의 식별자 |
 
 #### 응답
 
-| 이름                   | 종류   | 형식       | 설명                                                                                                                                                        |
-|----------------------|------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| totalCounts          | Body | Number   | 전체 백업 목록 수                                                                                                                                                |
-| backups              | Body | Array    | 백업 목록                                                                                                                                                     |
-| backups.backupId     | Body | UUID     | 백업의 식별자                                                                                                                                                   |
-| backups.backupName   | Body | String   | 백업을 식별할 수 있는 이름                                                                                                                                           |
-| backups.backupStatus | Body | Enum     | 백업의 현재 상태<br/>- `BACKING_UP`: 백업 중인 경우<br/>- `COMPLETED`: 백업이 완료된 경우<br/>- `DELETING`: 백업이 삭제 중인 경우<br/>- `DELETED`: 백업이 삭제된 경우<br/>- `ERROR`: 오류가 발생한 경우 |
-| backups.dbInstanceId | Body | UUID     | 원본 DB 인스턴스의 식별자                                                                                                                                           |
-| backups.dbVersion    | Body | Enum     | DB 버전 정보                                                                                                                                                  |
-| backups.backupType   | Body | Enum     | 백업 유형<br/>- `AUTO`: 자동<br/>- `MANUAL`:  수동                                                                                                                |
-| backups.backupSize   | Body | Number   | 백업의 크기<br/>- 단위: `바이트`                                                                                                                                    |
-| createdYmdt          | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                         |
-| updatedYmdt          | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                         |
-| completedYmdt        | Body | DateTime | 완료 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                         |
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### DB 인스턴스 접근제어 규칙 수정
+
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/hba-rules/{hbaRuleId}
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| hbaRuleId | URL | UUID | O | 접근제어 규칙의 식별자 |
+| connectionTypeCode | Body | Enum | X | 접근 제어 레코드 타입<br/>- HOST: `TCP/IP로 접속 시 유효`<br/>- HOST_NO_SSL: `SSL 암호화를 사용하지 않는 접속 시에만 유효` |
+| databaseApplyType | Body | Enum | O | Database 적용 타입<br/>- ENTIRE: `전체`<br/>- USER_CUSTOM: `사용자 지정` |
+| dbUserApplyType | Body | Enum | O | DB 사용자 적용 타입<br/>- ENTIRE: `전체`<br/>- USER_CUSTOM: `사용자 지정` |
+| databaseIds | Body | Array | X | 데이터베이스의 식별자 목록 |
+| dbUserIds | Body | Array | X | DB 사용자의 식별자 목록 |
+| address | Body | String | O | 접속 주소 |
+| authMethod | Body | Enum | O | 인증 방식<br/>- TRUST: `트러스트 (패스워드 불필요)`<br/>- REJECT: `접속 차단`<br/>- SCRAM_SHA_256: `패스워드 (SCRAM-SHA-256)` |
 
 <details><summary>예시</summary>
+<p>
+
+```json
+{
+    "connectionTypeCode": "HOST",
+    "databaseApplyType": "ENTIRE",
+    "dbUserApplyType": "ENTIRE",
+    "databaseIds": [],
+    "dbUserIds": [],
+    "address": "address-example",
+    "authMethod": "TRUST"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### 고가용성 정보 조회
+
+```http
+GET /v1.0/db-instances/{dbInstanceId}/high-availability
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| haStatus | Body | Enum | 고가용성 상태<br/>- CREATED: `생성됨`<br/>- STABLE: `정상`<br/>- PAUSING: `일시 중지 중`<br/>- DISABLE: `정지`<br/>- DISABLE_MASTER_IN_REPLICATION: `마스터 비정상 복제 감지로 인한 고가용성 중단`<br/>- DISABLE_MHA_PROCESS: `고가용성 프로세스 중단`<br/>- DISABLE_REPLICATION_STOP: `복제 중단으로 인한 고가용성 중단`<br/>- DISABLE_REPLICATION_DELAY: `복제 지연으로 인한 고가용성 중단`<br/>- FAILOVER_STARTED: `장애 조치 시작`<br/>- FAILOVER_FAILED: `장애 조치 실패`<br/>- FAILOVER_COMPLETED: `장애 조치 완료`<br/>- DELETED: `삭제됨`<br/>- PAUSED: `일시 중지`<br/>- PAUSED_DUE_TO_TASK: `작업으로 인한 일시 중지`<br/>- MASTER_FAILURE_DETECTION: `마스터 장애 감지` |
+| pingInterval | Body | Number | Ping 간격(초) |
+| failoverReplWaitingTime | Body | Number | 장애조치 복제 지연 대기 시간(초) |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "haStatus": "CREATED",
+    "pingInterval": 1,
+    "failoverReplWaitingTime": 1
+}
+```
+
+</p>
+</details>
+
+---
+
+### 고가용성 수정하기
+
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/high-availability
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| useHighAvailability | Body | Boolean | O | 고가용성 사용 여부 |
+| pingInterval | Body | Number | X | Ping 간격(초)<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
+| failoverReplWaitingTime | Body | Number | X | 장애조치 복제 지연 대기 시간(초)<br/>- 최솟값: `-1` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "useHighAvailability": false,
+    "pingInterval": 1,
+    "failoverReplWaitingTime": 1
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 고가용성 일시 중지하기
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/high-availability/pause
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 고가용성 복구하기
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/high-availability/repair
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 고가용성 다시 시작하기
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/high-availability/resume
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 고가용성 분리하기
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/high-availability/split
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 인스턴스 유지보수 정보 조회
+
+```http
+GET /v1.0/db-instances/{dbInstanceId}/maintenance-info
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| allowAutoMaintenance | Body | Boolean | 자동 유지보수 허용 여부 |
+| useAutoStorageCleanup | Body | Boolean | 자동 스토리지 정리 사용 여부 |
+| maintWndBgnTime | Body | String | 자동 유지보수 시작 시간 |
+| maintWndDuration | Body | Enum | 유지보수 윈도우<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
+| logRetentionPeriod | Body | Number | 로그 보관 기간 (일) |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "allowAutoMaintenance": false,
+    "useAutoStorageCleanup": false,
+    "maintWndBgnTime": "maintWndBgnTime-example",
+    "maintWndDuration": "HALF_AN_HOUR",
+    "logRetentionPeriod": 1
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 인스턴스 유지보수 정보 수정
+
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/maintenance-info
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| allowAutoMaintenance | Body | Boolean | X | 자동 유지보수 허용 여부 |
+| useAutoStorageCleanup | Body | Boolean | X | 자동 스토리지 정리 사용 여부 |
+| maintWndBgnTime | Body | String | X | 자동 유지보수 시작 시간 |
+| maintWndDuration | Body | Enum | X | 유지보수 윈도우<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
+| logRetentionPeriod | Body | Number | X | 로그 보관 기간 (일)<br/>- 최솟값: `1`<br/>- 최댓값: `30` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "allowAutoMaintenance": false,
+    "useAutoStorageCleanup": false,
+    "maintWndBgnTime": "maintWndBgnTime-example",
+    "maintWndDuration": "HALF_AN_HOUR",
+    "logRetentionPeriod": 1
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 인스턴스 네트워크 정보 조회
+
+```http
+GET /v1.0/db-instances/{dbInstanceId}/network-info
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| availabilityZone | Body | Enum | DB 인스턴스를 생성할 가용성 영역 |
+| subnet | Body | Object | 서브넷 정보 |
+| subnet.subnetId | Body | String | 서브넷의 식별자 |
+| subnet.subnetName | Body | String | 서브넷을 식별할 수 있는 이름 |
+| subnet.subnetCidr | Body | String | 서브넷의 CIDR |
+| subnet.publicAccessible | Body | Boolean | 퍼블릭 접근 가능 여부 |
+| endPoints | Body | Array | 접속 정보 |
+| endPoints.domain | Body | String | 도메인 |
+| endPoints.ipAddress | Body | String | IP 주소 |
+| endPoints.endPointType | Body | String | 접속 정보 타입 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "availabilityZone": "ENUM_VALUE",
+    "subnet": {
+        "subnetId": "subnetId-example",
+        "subnetName": "subnetName-example",
+        "subnetCidr": "subnetCidr-example",
+        "publicAccessible": false
+    },
+    "endPoints": [
+        {
+            "endPointType": "endPointType-example"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 인스턴스 네트워크 정보 수정하기
+
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/network-info
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| usePublicAccess | Body | Boolean | O | 외부 접속 가능 여부 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "usePublicAccess": false
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 인스턴스 승격하기
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/promote
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 읽기 복제본 생성
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/replicate
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceName | Body | String | O | DB 인스턴스를 식별할 수 있는 이름 |
+| description | Body | String | X | DB 인스턴스에 대한 추가 정보 |
+| dbFlavorId | Body | UUID | X | DB 인스턴스 사양의 식별자 |
+| dbPort | Body | Number | X | DB 포트<br/>- 최솟값: 5432, 최댓값: 45432 |
+| parameterGroupId | Body | UUID | X | 파라미터 그룹의 식별자 |
+| dbSecurityGroupIds | Body | Array | X | DB 보안 그룹의 식별자 목록 |
+| userGroupIds | Body | Array | X | 사용자 그룹의 식별자 목록 |
+| useDefaultNotification | Body | Boolean | X | 기본 알림 사용 여부<br/>- 기본값: `false` |
+| useDeletionProtection | Body | Boolean | X | 삭제 보호 여부<br/>- 기본값: `false` |
+| network | Body | Object | X | 네트워크 정보 객체 |
+| network.usePublicAccess | Body | Boolean | X | 외부 접속 가능 여부<br/>- 기본값: `false` |
+| network.availabilityZone | Body | Enum | X | DB 인스턴스를 생성할 가용성 영역 |
+| storage | Body | Object | X | 스토리지 정보 객체 |
+| storage.storageType | Body | Enum | X | 데이터 스토리지 타입 |
+| storage.storageSize | Body | Number | X | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20`<br/>- 최댓값: `2048` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName-example",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useDefaultNotification": false,
+    "useDeletionProtection": false,
+    "network": {
+        "usePublicAccess": false,
+        "availabilityZone": "ENUM_VALUE"
+    },
+    "storage": {
+        "storageType": "ENUM_VALUE",
+        "storageSize": 20
+    }
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 인스턴스 재시작하기
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/restart
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 인스턴스 복원 정보 조회
+
+```http
+GET /v1.0/db-instances/{dbInstanceId}/restoration-info
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| oldestRestorableYmdt | Body | DateTime | 가장 오래된 복원 가능한 시각 |
+| latestRestorableYmdt | Body | DateTime | 가장 최신의 복원 가능한 시각 |
+| restorableBackups | Body | Array | 복원 가능한 백업 목록 |
+| restorableBackups.backupId | Body | String | 백업의 식별자 |
+| restorableBackups.backupName | Body | String | 백업 이름 |
+| restorableBackups.backupStatus | Body | Enum | 백업 상태<br/>- BACKING_UP: `백업 중 (스피너)`<br/>- VERIFYING: `검증 중 (스피너)`<br/>- COMPLETED: `사용 가능 (녹색 아이콘)`<br/>- DELETING: `삭제 중 (스피너)`<br/>- DELETED: `삭제 됨 (회색 아이콘)`<br/>- ERROR: `에러 (적색 아이콘)` |
+| restorableBackups.dbInstanceId | Body | String | 원본 DB 인스턴스의 식별자 |
+| restorableBackups.dbInstanceName | Body | String | 원본 DB 인스턴스의 이름 |
+| restorableBackups.dbVersion | Body | Enum | DB 엔진 유형 |
+| restorableBackups.backupType | Body | Enum | 백업 유형<br/>- AUTO<br/>- MANUAL |
+| restorableBackups.backupSize | Body | Number | 백업 크기 |
+| restorableBackups.failoverCount | Body | Number | 장애 조치 횟수 |
+| restorableBackups.walFileName | Body | String | WAL 로그 파일 이름 |
+| restorableBackups.createdYmdt | Body | DateTime | 백업 생성 일시 |
+| restorableBackups.updatedYmdt | Body | DateTime | 백업 갱신 일시 |
+| restorableBackups.startYmdt | Body | DateTime | 백업 시작 일시 |
+| restorableBackups.completedYmdt | Body | DateTime | 백업 완료 일시 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "oldestRestorableYmdt": "2023-12-31T15:00:00+09:00",
+    "latestRestorableYmdt": "2023-12-31T15:00:00+09:00",
+    "restorableBackups": [
+        {
+            "completedYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 인스턴스 복원
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/restore
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceName | Body | String | X | DB 인스턴스를 식별할 수 있는 이름 |
+| dbInstanceCandidateName | Body | String | X | DB 인스턴스를 식별할 수 있는 예비 마스터 이름 |
+| description | Body | String | X | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbFlavorId | Body | UUID | O | DB 인스턴스 사양의 식별자 |
+| dbPort | Body | Number | X | DB 포트<br/>- 최솟값: 5432, 최댓값: 45432 |
+| useHighAvailability | Body | Boolean | X | 고가용성 사용 여부<br/>- 기본값: `false` |
+| imageId | Body | UUID | X | 이미지의 식별자 |
+| pingInterval | Body | Number | X | 고가용성 사용 시 Ping 간격(초)<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
+| failoverReplWaitingTime | Body | Number | X | 장애조치 복제 지연 대기 시간(초)<br/>- 최솟값: `-1` |
+| storage | Body | Object | O | 스토리지 정보 객체 |
+| storage.storageType | Body | Enum | O | 스토리지 타입 |
+| storage.storageSize | Body | Number | O | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20` |
+| network | Body | Object | O | 네트워크 정보 객체 |
+| network.subnetId | Body | UUID | O | 서브넷의 식별자 |
+| network.usePublicAccess | Body | Boolean | X | 외부 접속 가능 여부<br/>- 기본값: `false` |
+| network.availabilityZone | Body | Enum | X | DB 인스턴스를 생성할 가용성 영역 |
+| backup | Body | Object | O | 백업 정보 객체 |
+| backup.backupPeriod | Body | Number | O | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
+| backup.backupRetryCount | Body | Number | X | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
+| backup.replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)`<br/>- KR2: `한국(평촌)` |
+| backup.backupSchedules | Body | Array | O | 백업 스케쥴 목록 |
+| backup.backupSchedules.backupWndBgnTime | Body | String | O | 백업 시작 시각 |
+| backup.backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
+| restore | Body | Object | O | 복원 정보 객체 |
+| restore.restoreType | Body | Enum | O | 복원 타입<br/>- BACKUP: `기존에 생성한 백업을 이용한 복원`<br/>- TIMESTAMP: `복원 가능한 시간 이내의 시간을 이용한 시점 복원` |
+| restore.restoreYmdt | Body | DateTime | X | DB 인스턴스 복원 일시 |
+| restore.backupId | Body | UUID | X | 복원에 사용할 백업의 식별자 |
+| useDefaultNotification | Body | Boolean | X | 기본 알림 사용 여부<br/>- 기본값: `false` |
+| parameterGroupId | Body | UUID | O | 파라미터 그룹의 식별자 |
+| dbSecurityGroupIds | Body | Array | X | DB 보안 그룹의 식별자 목록 |
+| userGroupIds | Body | Array | X | 사용자 그룹의 식별자 목록 |
+| useDeletionProtection | Body | Boolean | X | 삭제 보호 여부<br/>- 기본값: `false` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName-example",
+    "dbInstanceCandidateName": "dbInstanceCandidateName-example",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "useHighAvailability": false,
+    "imageId": "550e8400-e29b-41d4-a716-446655440000",
+    "pingInterval": 3,
+    "failoverReplWaitingTime": 60,
+    "storage": {
+        "storageType": "ENUM_VALUE",
+        "storageSize": 20
+    },
+    "network": {
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
+        "availabilityZone": "ENUM_VALUE"
+    },
+    "backup": {
+        "backupPeriod": 0,
+        "backupRetryCount": 0,
+        "replicationRegion": "KR1",
+        "backupSchedules": [
+            {
+                "backupWndDuration": "HALF_AN_HOUR"
+            }
+        ]
+    },
+    "restore": {
+        "restoreType": "BACKUP",
+        "restoreYmdt": "2023-12-31T15:00:00+09:00",
+        "backupId": "550e8400-e29b-41d4-a716-446655440000"
+    },
+    "useDefaultNotification": false,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useDeletionProtection": false
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 인스턴스 시작하기
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/start
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 인스턴스 정지하기
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/stop
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 인스턴스 스토리지 정보 조회
+
+```http
+GET /v1.0/db-instances/{dbInstanceId}/storage-info
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| storageType | Body | Enum | 데이터 스토리지 타입 |
+| storageSize | Body | Number | 데이터 스토리지 크기(GB) |
+| storageStatus | Body | Enum | 데이터 스토리지의 현재 상태<br/>- DELETED: `삭제됨`<br/>- PENDING_DELETION: `삭제 유예됨`<br/>- DELETION_RESERVED: `삭제 예약됨 (스냅샷 정리 대기)`<br/>- DETACHED: `해제됨`<br/>- ATTACHED: `할당됨` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "storageType": "ENUM_VALUE",
+    "storageSize": 1,
+    "storageStatus": "DELETED"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 인스턴스 스토리지 정보 수정하기
+
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/storage-info
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| storageSize | Body | Number | O | 데이터 스토리지 크기(GB)<br/>- 최댓값: `2048` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "storageSize": 1
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+## DB 인스턴스 그룹
+
+### DB 인스턴스 그룹 목록 보기
+
+```http
+GET /v1.0/db-instance-groups
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceGroups | Body | Array | DB 인스턴스 그룹 정보 |
+| dbInstanceGroups.dbInstanceGroupId | Body | String | DB 인스턴스 그룹의 식별자 |
+| dbInstanceGroups.dbInstanceGroupStatus | Body | Enum | DB 인스턴스 그룹의 현재 형태<br/>- CREATED: `생성됨`<br/>- DELETED: `삭제됨` |
+| dbInstanceGroups.replicationType | Body | Enum | DB 인스턴스 그룹의 복제 형태<br/>- STANDALONE: `고가용성 사용 안함`<br/>- HIGH_AVAILABILITY: `고가용성 사용` |
+| dbInstanceGroups.createdYmdt | Body | DateTime | 생성 일시 |
+| dbInstanceGroups.updatedYmdt | Body | DateTime | 수정 일시 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "dbInstanceGroups": [
+        {
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 인스턴스 그룹 상세 보기
+
+```http
+GET /v1.0/db-instance-groups/{dbInstanceGroupId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | O |  |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceGroupId | Body | String | DB 인스턴스 그룹의 식별자 |
+| dbInstanceGroupStatus | Body | Enum | DB 인스턴스 그룹의 현재 상태<br/>- CREATED: `생성됨`<br/>- DELETED: `삭제됨` |
+| replicationType | Body | Enum | DB 인스턴스 그룹의 복제 형태<br/>- STANDALONE: `고가용성 사용 안함`<br/>- HIGH_AVAILABILITY: `고가용성 사용` |
+| dbInstances | Body | Array | DB 인스턴스 그룹에 속한 DB 인스턴스 목록 |
+| dbInstances.dbInstanceId | Body | String | DB 인스턴스의 식별자 |
+| dbInstances.dbInstanceType | Body | Enum | DB 인스턴스의 역할 타입<br/>- MASTER: `마스터`<br/>- FAILED_MASTER: `장애 마스터`<br/>- CANDIDATE_MASTER: `예비 마스터`<br/>- READ_ONLY_SLAVE: `읽기 복제본` |
+| dbInstances.dbInstanceStatus | Body | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전 (회색)`<br/>- AVAILABLE: `사용 가능 (녹색)`<br/>- STORAGE_FULL: `용량 부족 (적색)`<br/>- FAIL_TO_CREATE: `생성 실패 (적색)`<br/>- FAIL_TO_CONNECT: `연결 실패 (적색)`<br/>- REPLICATION_STOP: `복제 중단 (적색)`<br/>- REPLICATION_DELAY: `복제 지연 (황색)`<br/>- FAILOVER: `장애 조치 완료 (적색)`<br/>- SHUTDOWN: `중지 됨 (회색)`<br/>- DELETED: `삭제됨 (회색)` |
+| createdYmdt | Body | DateTime | 생성 일시 |
+| updatedYmdt | Body | DateTime | 수정 일시 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "dbInstanceGroupId": "dbInstanceGroupId-example",
+    "dbInstanceGroupStatus": "CREATED",
+    "replicationType": "STANDALONE",
+    "dbInstances": [
+        {
+            "dbInstanceStatus": "BEFORE_CREATE"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 확장 리스트 조회
+
+```http
+GET /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | O | DB 인스턴스 그룹 ID |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| extensions | Body | Array | 확장 정보 |
+| extensions.extensionId | Body | String | 확장 ID |
+| extensions.extensionName | Body | String | 확장 이름 |
+| extensions.extensionStatus | Body | Enum | 확장 상태<br/>- AVAILABLE: `사용 가능`<br/>- NEED_TO_APPLY: `적용 필요`<br/>- APPLYING: `적용 중` |
+| extensions.databases | Body | Array | 데이터베이스 정보 |
+| extensions.databases.dbInstanceGroupExtensionId | Body | String | DB 인스턴스 그룹 확장 ID |
+| extensions.databases.databaseId | Body | String | 데이터베이스 ID |
+| extensions.databases.databaseName | Body | String | 데이터베이스 이름 |
+| extensions.databases.dbInstanceGroupExtensionStatus | Body | Enum | 데이터베이스 확장 설치 상태<br/>- CREATED: `생성 됨`<br/>- INSTALLED: `설치 됨`<br/>- INSTALLING: `설치 중`<br/>- INSTALL_ERROR: `설치 에러`<br/>- DELETED: `삭제 됨`<br/>- DELETING: `삭제 중`<br/>- DELETE_ERROR: `삭제 에러` |
+| extensions.databases.reservedAction | Body | Enum | 예약 작업<br/>- NONE: `없음`<br/>- INSTALL: `설치 예약 (적용 필요)`<br/>- INSTALL_WITH_CASCADE: `강제 설치 예약 (적용 필요)`<br/>- DELETE: `삭제 예약 (적용 필요)`<br/>- DELETE_WITH_CASCADE: `강제 삭제 예약 (적용 필요)` |
+| extensions.databases.errorReason | Body | String | 에러 원인 |
+| isNeedToApply | Body | Boolean | 적용 필요 여부 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "extensions": [
+        {
+            "databases": {
+                "errorReason": "errorReason-example"
+            }
+        }
+    ],
+    "isNeedToApply": false
+}
+```
+
+</p>
+</details>
+
+---
+
+### 확장 변경사항 적용
+
+```http
+POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/apply
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | O | DB 인스턴스 그룹 ID |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 확장 동기화
+
+```http
+POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/sync
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | O | DB 인스턴스 그룹 ID |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 확장 삭제(취소)
+
+```http
+DELETE /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{dbInstanceGroupExtensionId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | O | DB 인스턴스 그룹 ID |
+| dbInstanceGroupExtensionId | URL | UUID | O | DB 인스턴스 그룹 확장 ID |
+| withCascade | Query | Boolean | O | 강제 삭제 여부 |
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### 확장 설치
+
+```http
+POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{extensionId}
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | O | DB 인스턴스 그룹 ID |
+| extensionId | URL | UUID | O | 확장 ID |
+| databaseId | Body | UUID | O | 데이터베이스 ID |
+| schemaName | Body | String | O | 스키마 이름 |
+| withCascade | Body | Boolean | X | 연관 정보 자동 설치 여부<br/>- 기본값: `false` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "databaseId": "550e8400-e29b-41d4-a716-446655440000",
+    "schemaName": "schemaName-example",
+    "withCascade": false
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+## db-flavors
+
+### DB 인스턴스 유형 목록 보기
+
+```http
+GET /v1.0/db-flavors
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| dbFlavors | Body | Array | DB 인스턴스 사양 정보 |
+| dbFlavors.dbFlavorId | Body | String | DB 인스턴스 사양의 식별자 |
+| dbFlavors.dbFlavorName | Body | String | DB 인스턴스 사양명 |
+| dbFlavors.ram | Body | Number | 메모리 용량(MB) |
+| dbFlavors.vcpus | Body | Number | CPU 코어 수 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "dbFlavors": [
+        {
+            "vcpus": 2
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+## db-versions
+
+### DB 버전 목록 보기
+
+```http
+GET /v1.0/db-versions
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| dbVersions | Body | Array | DB 버전 정보 |
+| dbVersions.dbVersionCode | Body | Enum | DB 버전 코드<br/>- MYSQL_V5633<br/>- MYSQL_V5715<br/>- MYSQL_V5719<br/>- MYSQL_V5726<br/>- MYSQL_V5731<br/>- MYSQL_V5733<br/>- MYSQL_V5737<br/>- MYSQL_V8018<br/>- MYSQL_V8023<br/>- MYSQL_V8028<br/>- MYSQL_V8032<br/>- MYSQL_V8033<br/>- MYSQL_V8034<br/>- MYSQL_V8035<br/>- MYSQL_V8036<br/>- MYSQL_V8040<br/>- MYSQL_V8041<br/>- MYSQL_V8042<br/>- MYSQL_V8043<br/>- MYSQL_V8044<br/>- MYSQL_V8045<br/>- MYSQL_V8405<br/>- MYSQL_V8406<br/>- MYSQL_V8407<br/>- MYSQL_V8408<br/>- MARIADB_V10330<br/>- MARIADB_V10611<br/>- MARIADB_V10612<br/>- MARIADB_V10616<br/>- MARIADB_V10622<br/>- MARIADB_V10625<br/>- MARIADB_V101107<br/>- MARIADB_V101108<br/>- MARIADB_V101113<br/>- MARIADB_V101116<br/>- MARIADB_V11407<br/>- MARIADB_V11410<br/>- MARIADB_V11806<br/>- POSTGRESQL_V14_6<br/>- POSTGRESQL_V14_15<br/>- POSTGRESQL_V14_17<br/>- POSTGRESQL_V14_19<br/>- POSTGRESQL_V17_2<br/>- POSTGRESQL_V17_4<br/>- POSTGRESQL_V17_6 |
+| dbVersions.dbMajorVersionCode | Body | Enum | DB 메이저 버전 코드<br/>- MYSQL_V56<br/>- MYSQL_V57<br/>- MYSQL_V80<br/>- MYSQL_V84<br/>- MARIADB_V103<br/>- MARIADB_V106<br/>- MARIADB_V1011<br/>- MARIADB_V114<br/>- MARIADB_V118<br/>- POSTGRES_V14<br/>- POSTGRES_V17 |
+| dbVersions.name | Body | String | DB 버전명 |
+| dbVersions.canCreate | Body | Boolean | 신규 생성 가능 여부 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "dbVersions": [
+        {
+            "canCreate": false
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+## event-codes
+
+### 구독 가능한 이벤트 코드 목록 보기
+
+```http
+GET /v1.0/event-codes
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| eventCodes | Body | Array | 이벤트 코드 목록 |
+| eventCodes.eventCode | Body | Enum | 이벤트 코드 |
+| eventCodes.eventCategoryType | Body | Enum | 이벤트 카테고리 유형<br/>- ALL: `전체`<br/>- DB_INSTANCE: `DB 인스턴스로 발생한 이벤트`<br/>- DB_SECURITY_GROUP: `DB 보안 그룹으로 발생한 이벤트`<br/>- MONITORING: `모니터링으로 발생한 이벤트`<br/>- JOB: `JOB으로 발생한 이벤트`<br/>- BACKUP: `백업으로 발생한 이벤트`<br/>- TENANT: `테넌트로 발생한 이벤트` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "eventCodes": [
+        {
+            "eventCategoryType": "ALL"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+## events
+
+### 이벤트 목록 보기
+
+```http
+GET /v1.0/events
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | 전체 이벤트 목록 수 |
+| events | Body | Array | 이벤트 목록 |
+| events.eventCategoryType | Body | Enum | 이벤트 카테고리 유형<br/>- ALL: `전체`<br/>- DB_INSTANCE: `DB 인스턴스로 발생한 이벤트`<br/>- DB_SECURITY_GROUP: `DB 보안 그룹으로 발생한 이벤트`<br/>- MONITORING: `모니터링으로 발생한 이벤트`<br/>- JOB: `JOB으로 발생한 이벤트`<br/>- BACKUP: `백업으로 발생한 이벤트`<br/>- TENANT: `테넌트로 발생한 이벤트` |
+| events.eventCode | Body | Enum | 발생한 이벤트의 유형 |
+| events.sourceId | Body | String | 이벤트 소스의 식별자 |
+| events.sourceName | Body | String | 이벤트 소스를 식별할 수 있는 이름 |
+| events.messages | Body | Array | 이벤트 메세지 목록 |
+| events.messages.langCode | Body | Enum | 언어 코드<br/>- KO<br/>- EN<br/>- JA<br/>- ZH |
+| events.messages.message | Body | String | 이벤트 메세지 |
+| events.eventYmdt | Body | DateTime | 이벤트 발생 일시 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "totalCounts": 1,
+    "events": [
+        {
+            "eventYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+## metric-statistics
+
+### 통계 정보 조회
+
+```http
+GET /v1.0/metric-statistics
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+## metrics
+
+### 성능 지표 목록 보기
+
+```http
+GET /v1.0/metrics
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| metrics | Body | Array | Metric 목록 |
+| metrics.metricName | Body | String | 조회 지표 유형 |
+| metrics.unit | Body | String | 측정값 단위 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "metrics": [
+        {
+            "unit": "unit-example"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+## network
+
+### 서브넷 목록 보기
+
+```http
+GET /v1.0/network/subnets
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| subnets | Body | Array | 서브넷 정보 |
+| subnets.subnetId | Body | String | 서브넷의 식별자 |
+| subnets.subnetName | Body | String | 서브넷을 식별할 수 있는 이름 |
+| subnets.subnetCidr | Body | String | 서브넷의 CIDR |
+| subnets.usingGateway | Body | Boolean | 게이트웨이 사용 여부 |
+| subnets.availableIpCount | Body | Number | 사용 가능한 IP 수 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "subnets": [
+        {
+            "availableIpCount": 1
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+## storage-types
+
+### 스토리지 유형 목록 보기
+
+```http
+GET /v1.0/storage-types
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| storageTypes | Body | Array | 스토리지 유형 정보 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "storageTypes": []
+}
+```
+
+</p>
+</details>
+
+---
+
+## 백업
+
+### 백업 상태
+
+| 상태           | 설명           |
+|--------------|--------------|
+| `BACKING_UP` | 백업 중인 경우     |
+| `COMPLETED`  | 백업이 완료된 경우   |
+| `DELETING`   | 백업이 삭제 중인 경우 |
+| `DELETED`    | 백업이 삭제된 경우   |
+| `ERROR`      | 오류가 발생한 경우   |
+
+### 백업 목록 보기
+
+```http
+GET /v1.0/backups
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | 전체 백업 목록 수 |
+| backups | Body | Array | 백업 목록 |
+| backups.backupId | Body | String | 백업의 식별자 |
+| backups.backupName | Body | String | 백업을 식별할 수 있는 이름 |
+| backups.backupStatus | Body | Enum | 백업의 현재 상태<br/>- BACKING_UP: `백업 중 (스피너)`<br/>- VERIFYING: `검증 중 (스피너)`<br/>- COMPLETED: `사용 가능 (녹색 아이콘)`<br/>- DELETING: `삭제 중 (스피너)`<br/>- DELETED: `삭제 됨 (회색 아이콘)`<br/>- ERROR: `에러 (적색 아이콘)` |
+| backups.dbInstanceId | Body | String | 원본 DB 인스턴스의 식별자 |
+| backups.dbVersion | Body | Enum | DB 엔진 버전 |
+| backups.backupType | Body | Enum | 백업 유형<br/>- AUTO<br/>- MANUAL |
+| backups.backupSize | Body | Number | 백업의 크기(Byte) |
+| backups.startYmdt | Body | DateTime | 시작 일시 |
+| backups.createdYmdt | Body | DateTime | 생성 일시 |
+| backups.updatedYmdt | Body | DateTime | 수정 일시 |
+| backups.completedYmdt | Body | DateTime | 완료 일시 |
+
+<details><summary>예시</summary>
+<p>
 
 ```json
 {
@@ -3270,170 +3658,16 @@ GET /v1.0/backups
     "totalCounts": 1,
     "backups": [
         {
-            "backupId": "0017f136-3e01-4530-94aa-20661afe6632",
-            "backupName": "backup",
-            "backupStatus": "COMPLETED",
-            "dbInstanceId": "142e6ccc-3bfb-4e1e-84f7-38861284fafd",
-            "dbVersion": "POSTGRESQL_V17_6",
-            "backupType": "AUTO",
-            "backupSize": 4996786,
-            "createdYmdt": "2023-02-21T00:35:00+09:00",
-            "updatedYmdt": "2023-02-22T00:35:32+09:00",
-            "completedYmdt": "2023-02-22T00:35:32+09:00"
+            "completedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
+
+</p>
 </details>
 
-### 오브젝트 스토리지로 백업 내보내기
-
-```http
-POST /v1.0/backups/{backupId}/export
-```
-
-#### 필요 권한
-
-| 권한명                            | 설명                 |
-|--------------------------------|--------------------|
-| RDSforPostgreSQL:Backup.Export | 오브젝트 스토리지로 백업 내보내기 |
-
-#### 요청
-
-| 이름              | 종류   | 형식     | 필수 | 설명                          |
-|-----------------|------|--------|----|-----------------------------|
-| backupId        | URL  | UUID   | O  | 백업의 식별자                     |
-| tenantId        | Body | String | O  | 백업이 저장될 오브젝트 스토리지의 테넌트 ID   |
-| username        | Body | String | O  | NHN Cloud 계정 또는 IAM 계정 ID   |
-| password        | Body | String | O  | 백업이 저장될 오브젝트 스토리지의 API 비밀번호 |
-| targetContainer | Body | String | O  | 백업이 저장될 오브젝트 스토리지의 컨테이너     |
-| objectPath      | Body | String | O  | 컨테이너에 저장될 백업의 경로            |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "tenantId": "399631c404744dbbb18ce4fa2dc71a5a",
-    "username": "gildong.hong@nhn.com",
-    "password": "password",
-    "targetContainer": "/container",
-    "objectPath": "/backups/backup_file"
-}
-```
-</details>
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### 백업 복원하기
-
-```http
-POST /v1.0/backups/{backupId}/restore
-```
-
-#### 필요 권한
-
-| 권한명                             | 설명      |
-|---------------------------------|---------|
-| RDSforPostgreSQL:Backup.Restore | 백업 복원하기 |
-
-#### 요청
-
-| 이름                                       | 종류   | 형식      | 필수 | 설명                                                                                                                                                                                                                        |
-|------------------------------------------|------|---------|----|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| backupId                                 | URL  | UUID    | O  | 백업의 식별자                                                                                                                                                                                                                   |
-| dbInstanceName                           | Body | String  | O  | DB 인스턴스를 식별할 수 있는 이름                                                                                                                                                                                                      |
-| description                              | Body | String  | X  | DB 인스턴스에 대한 추가 정보                                                                                                                                                                                                         |
-| dbFlavorId                               | Body | UUID    | O  | DB 인스턴스 사양의 식별자                                                                                                                                                                                                           |
-| dbPort                                   | Body | Number  | O  | DB 포트<br/>- 최솟값: `5432`<br/>- 최댓값: `45432`                                                                                                                                                                                |
-| parameterGroupId                         | Body | UUID    | O  | 파라미터 그룹의 식별자                                                                                                                                                                                                              |
-| dbSecurityGroupIds                       | Body | Array   | X  | DB 보안 그룹의 식별자 목록                                                                                                                                                                                                          ||network|Body|Object|O|네트워크 정보 객체|
-| userGroupIds                             | Body | Array   | X  | 사용자 그룹의 식별자 목록                                                                                                                                                                                                            |
-| useDefaultNotification                   | Body | Boolean | X  | 기본 알림 사용 여부<br/>- 기본값: `false`                                                                                                                                                                                            |
-| useDeletionProtection                    | Body | Boolean | X  | 삭제 보호 여부<br/>- 기본값: `false`                                                                                                                                                                                               | 
-| useHighAvailability                      | Body | Boolean | X  | 고가용성 사용 여부                                                                                                                                                                                                                |
-| pingInterval                             | Body | Number  | X  | 고가용성 사용 시 Ping 간격(초)<br/>- 최솟값: `1`<br/>- 최댓값: `600`                                                                                                                                                                      |
-| failoverReplWaitingTime                  | Body | Number  | X  | 고가용성 사용 시 장애 조치 대기 시간<br/>- 최솟값: `-1`<br/>- -1로 설정 시, 복제 지연 해소까지 계속해서 대기합니다.                                                                                                                                              |                                                                                                                                                                                                                      | userGroupIds                             | Body | Array   | X  | 기본 알림 수신용 사용자 그룹의 식별자 목록                                                                                                                                                                                             |
-| network                                  | Body | Object  | O  | 네트워크 정보 객체                                                                                                                                                                                                                |
-| network.subnetId                         | Body | UUID    | O  | 서브넷의 식별자                                                                                                                                                                                                                  |
-| network.usePublicAccess                  | Body | Boolean | X  | 외부 접속 가능 여부<br/>- 기본값: `false`                                                                                                                                                                                            |
-| network.availabilityZone                 | Body | Enum    | X  | DB 인스턴스를 생성할 가용성 영역<br/>- 예시: `kr-pub-a`<br/>- 기본값: `임의의 가용성 영역`                                                                                                                                                          |
-| storage                                  | Body | Object  | O  | 스토리지 정보 객체                                                                                                                                                                                                                |    
-| storage.storageType                      | Body | Enum    | O  | 데이터 스토리지 유형<br/>- 예시: `General SSD`                                                                                                                                                                                       |
-| storage.storageSize                      | Body | Number  | O  | 데이터 스토리지 크기<br/>- 단위: `기가바이트`<br/>- 최솟값: `20`<br/>- 최댓값: `2048`                                                                                                                                                           |
-| backup                                   | Body | Object  | O  | 백업 정보 객체                                                                                                                                                                                                                  |
-| backup.backupPeriod                      | Body | Number  | O  | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730`                                                                                                                                                                               |
-| backup.backupRetryCount                  | Body | Number  | X  | 백업 재시도 횟수<br/>- 기본값: `0`<br/>- 최솟값: `0`<br/>- 최댓값: `10`                                                                                                                                                                   |
-| backup.backupSchedules                   | Body | Array   | X  | 백업 스케줄 목록                                                                                                                                                                                                                 |
-| backup.backupSchedules.backupWndBgnTime  | Body | String  | O  | 백업 시작 시간<br/>- 예시: `00:00:00`                                                                                                                                                                                             |
-| backup.backupSchedules.backupWndDuration | Body | Enum    | O  | 백업 Duration<br/>백업 시작 시간부터 설정된 기간 안에 자동 백업이 실행됩니다.<br/>- `HALF_AN_HOUR`: 30분<br/>- `ONE_HOUR`: 1시간<br/>- `ONE_HOUR_AND_HALF`: 1시간 30분<br/>- `TWO_HOURS`: 2시간<br/>- `TWO_HOURS_AND_HALF`: 2시간 30분<br/>- `THREE_HOURS`: 3시간 |
-
-<details><summary>예시</summary>
-
-```json
-
-{
-  "dbInstanceName": "db-instance-restore",
-  "dbFlavorId": "50be6d9c-02d6-4594-a2d4-12010eb65ec0",
-  "dbPort": 15432,
-  "parameterGroupId": "132d383c-38e3-468a-a826-5e9a8fff15d0",
-  "network": {
-    "subnetId": "e721a9dd-dad0-4cf0-a53b-dd654ebfc683"
-  },
-  "storage": {
-    "storageType": "General SSD",
-    "storageSize": 20
-  },
-  "backup": {
-    "backupPeriod": 1,
-    "backupSchedules": [
-      {
-        "backupWndBgnTime": "00:00:00",
-        "backupWndDuration": "HALF_AN_HOUR",
-        "backupRetryExpireTime": "00:30:00"
-      }
-    ]
-  }
-}
-```
-</details>
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
+---
 
 ### 백업 삭제하기
 
@@ -3441,27 +3675,22 @@ POST /v1.0/backups/{backupId}/restore
 DELETE /v1.0/backups/{backupId}
 ```
 
-#### 필요 권한
-
-| 권한명                            | 설명      |
-|--------------------------------|---------|
-| RDSforPostgreSQL:Backup.Delete | 백업 삭제하기 |
-
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름       | 종류  | 형식   | 필수 | 설명      |
-|----------|-----|------|----|---------|
-| backupId | URL | UUID | O  | 백업의 식별자 |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | O | 백업의 식별자 |
 
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | 요청한 작업의 식별자 |
 
 <details><summary>예시</summary>
+<p>
 
 ```json
 {
@@ -3470,43 +3699,56 @@ DELETE /v1.0/backups/{backupId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-## DB 보안 그룹
+---
 
-### DB 보안 그룹 목록 보기
+### 백업 내보내기
 
 ```http
-GET /v1.0/db-security-groups
+POST /v1.0/backups/{backupId}/export
 ```
-
-#### 필요 권한
-
-| 권한명                                   | 설명             |
-|---------------------------------------|----------------|
-| RDSforPostgreSQL:DbSecurityGroup.List | DB 보안 그룹 목록 보기 |
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | O | 백업의 식별자 |
+| tenantId | Body | String | O | 백업이 저장될 오브젝트 스토리지의 테넌트 ID<br/>- 최소 길이: `32`<br/>- 최대 길이: `32` |
+| username | Body | String | O | NHN Cloud 계정 혹은 IAM 회원 ID |
+| password | Body | String | O | 백업이 저장될 오브젝트 스토리지의 API 비밀번호 |
+| targetContainer | Body | String | O | 백업이 저장될 오브젝트 스토리지의 컨테이너 |
+| objectPath | Body | String | O | 컨테이너에 저장될 백업의 경로 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "tenantId": "tenantId-example",
+    "username": "username-example",
+    "password": "password-example",
+    "targetContainer": "targetContainer-example",
+    "objectPath": "objectPath-example"
+}
+```
+
+</p>
+</details>
 
 #### 응답
 
-| 이름                                     | 종류   | 형식       | 설명                                                                                                                                                                                             |
-|----------------------------------------|------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroups                       | Body | Array    | DB 보안 그룹 목록                                                                                                                                                                                    |
-| dbSecurityGroups.dbSecurityGroupId     | Body | UUID     | DB 보안 그룹의 식별자                                                                                                                                                                                  |
-| dbSecurityGroups.dbSecurityGroupName   | Body | String   | DB 보안 그룹을 식별할 수 있는 이름                                                                                                                                                                          |
-| dbSecurityGroups.dbSecurityGroupStatus | Body | Enum     | DB 보안 그룹의 현재 상태<br/>- `CREATED`: 생성됨<br/>- `DELETED`: 삭제됨                                                                                                                                      |
-| dbSecurityGroups.description           | Body | String   | DB 보안 그룹에 대한 추가 정보                                                                                                                                                                             |
-| dbSecurityGroups.progressStatus        | Body | Enum     | DB 보안 그룹의 현재 진행 상태<br/>- `NONE`: 진행 중인 작업이 없음<br/>- `CREATING_RULE`: 규칙 정책 생성 중<br/>- `UPDATING_RULE`: 규칙 정책 수정 중<br/>- `DELETING_RULE`: 규칙 정책 삭제 중<br/>- `APPLYING_DEFAULT_RULE`: 기본 규칙 적용 중  |
-| dbSecurityGroups.createdYmdt           | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                              |
-| dbSecurityGroups.updatedYmdt           | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                              |
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
 
 <details><summary>예시</summary>
+<p>
 
 ```json
 {
@@ -3515,306 +3757,103 @@ GET /v1.0/db-security-groups
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "dbSecurityGroups": [
-        {
-            "dbSecurityGroupId": "fe4f2aee-afbb-4c19-a5e9-eb2eab394708",
-            "dbSecurityGroupName": "dbSecurityGroup",
-            "dbSecurityGroupStatus": "CREATED",
-            "description": "description",
-            "progressStatus": "NONE",
-            "createdYmdt": "2023-02-19T19:18:13+09:00",
-            "updatedYmdt": "2022-02-19T19:18:13+09:00"
-        }
-    ]
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-### DB 보안 그룹 상세 보기
+---
+
+### 백업 복원하기
 
 ```http
-GET /v1.0/db-security-groups/{dbSecurityGroupId}
+POST /v1.0/backups/{backupId}/restore
 ```
-
-#### 필요 권한
-
-| 권한명                                  | 설명             |
-|--------------------------------------|----------------|
-| RDSforPostgreSQL:DbSecurityGroup.Get | DB 보안 그룹 상세 보기 |
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름                | 종류  | 형식   | 필수 | 설명            |
-|-------------------|-----|------|----|---------------|
-| dbSecurityGroupId | URL | UUID | O  | DB 보안 그룹의 식별자 |
-
-#### 응답
-
-| 이름                    | 종류   | 형식       | 설명                                                                                                                                                                                            |
-|-----------------------|------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId     | Body | UUID     | DB 보안 그룹의 식별자                                                                                                                                                                                 |
-| dbSecurityGroupName   | Body | String   | DB 보안 그룹을 식별할 수 있는 이름                                                                                                                                                                         |
-| dbSecurityGroupStatus | Body | Enum     | DB 보안 그룹의 현재 상태<br/>- `CREATED`: 생성됨<br/>- `DELETED`: 삭제됨                                                                                                                                     |
-| description           | Body | String   | DB 보안 그룹에 대한 추가 정보                                                                                                                                                                            |
-| progressStatus        | Body | Enum     | DB 보안 그룹의 현재 진행 상태<br/>- `NONE`: 진행 중인 작업이 없음<br/>- `CREATING_RULE`: 규칙 정책 생성 중<br/>- `UPDATING_RULE`: 규칙 정책 수정 중<br/>- `DELETING_RULE`: 규칙 정책 삭제 중<br/>- `APPLYING_DEFAULT_RULE`: 기본 규칙 적용 중 |
-| rules                 | Body | Array    | DB 보안 그룹 규칙 목록                                                                                                                                                                                |
-| rules.ruleId          | Body | UUID     | DB 보안 그룹 규칙의 식별자                                                                                                                                                                              |
-| rules.description     | Body | String   | DB 보안 그룹 규칙에 대한 추가 정보                                                                                                                                                                         |
-| rules.direction       | Body | Enum     | 통신 방향<br/>- `INGRESS`: 수신<br/>- `EGRESS`: 송신                                                                                                                                                  |
-| rules.etherType       | Body | Enum     | Ether 유형<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                                |
-| rules.port            | Body | Object   | 포트 객체                                                                                                                                                                                         |
-| rules.port.portType   | Body | Enum     | 포트 유형<br/>- `DB_PORT`: 각 DB 인스턴스 포트값으로 설정됩니다.<br/>- `PORT`: 지정된 포트값으로 설정됩니다.<br/>- `PORT_RANGE`: 지정된 포트 범위로 설정됩니다.                                                                            |
-| rules.port.minPort    | Body | Number   | 최소 포트 범위                                                                                                                                                                                      |
-| rules.port.maxPort    | Body | Number   | 최대 포트 범위                                                                                                                                                                                      |
-| rules.cidr            | Body | String   | 허용할 트래픽의 원격 소스                                                                                                                                                                                |
-| rules.createdYmdt     | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                             |
-| rules.updatedYmdt     | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                             |
-| createdYmdt           | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                             |
-| updatedYmdt           | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                             |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | O | 백업의 식별자 |
+| dbInstanceName | Body | String | O | DB 인스턴스를 식별할 수 있는 이름 |
+| dbInstanceCandidateName | Body | String | X | DB 인스턴스를 식별할 수 있는 예비 마스터 이름 |
+| description | Body | String | X | DB 인스턴스에 대한 추가 정보 |
+| dbFlavorId | Body | UUID | O | DB 인스턴스 사양의 식별자 |
+| dbPort | Body | Number | O | DB 포트<br/>- 최솟값: 5432, 최댓값: 45432 |
+| parameterGroupId | Body | UUID | O | 파라미터 그룹의 식별자 |
+| dbSecurityGroupIds | Body | Array | X | DB 보안 그룹의 식별자 목록 |
+| userGroupIds | Body | Array | X | 사용자 그룹의 식별자 목록 |
+| useHighAvailability | Body | Boolean | X | 고가용성 사용 여부<br/>- 기본값: `false` |
+| useDefaultNotification | Body | Boolean | X | 기본 알림 사용 여부<br/>- 기본값: `false` |
+| useDeletionProtection | Body | Boolean | X | 삭제 보호 여부<br/>- 기본값: `false` |
+| pingInterval | Body | Number | X | Ping 간격(초)<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
+| failoverReplWaitingTime | Body | Number | X | 장애조치 복제 지연 대기 시간(초)<br/>- 최솟값: `-1` |
+| network | Body | Object | O | 네트워크 정보 객체 |
+| network.subnetId | Body | UUID | O | 서브넷의 식별자 |
+| network.usePublicAccess | Body | Boolean | X | 외부 접속 가능 여부<br/>- 기본값: `false` |
+| network.availabilityZone | Body | Enum | X | DB 인스턴스를 생성할 가용성 영역 |
+| storage | Body | Object | O | 스토리지 정보 객체 |
+| storage.storageType | Body | Enum | O | 스토리지 타입 |
+| storage.storageSize | Body | Number | O | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20` |
+| backup | Body | Object | O | 백업 정보 객체 |
+| backup.backupPeriod | Body | Number | O | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
+| backup.backupRetryCount | Body | Number | X | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
+| backup.backupSchedules | Body | Array | O | 백업 스케쥴 목록 |
+| backup.backupSchedules.backupWndBgnTime | Body | String | O | 백업 시작 시간 |
+| backup.backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 
 <details><summary>예시</summary>
+<p>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
+    "dbInstanceName": "dbInstanceName-example",
+    "dbInstanceCandidateName": "dbInstanceCandidateName-example",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useHighAvailability": false,
+    "useDefaultNotification": false,
+    "useDeletionProtection": false,
+    "pingInterval": 1,
+    "failoverReplWaitingTime": 1,
+    "network": {
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
+        "availabilityZone": "ENUM_VALUE"
     },
-    "dbSecurityGroup": {
-        "dbSecurityGroupId": "fe4f2aee-afbb-4c19-a5e9-eb2eab394708",
-        "dbSecurityGroupName": "dbSecurityGroup",
-        "dbSecurityGroupStatus": "CREATED",
-        "description": "description",
-        "progressStatus": "NONE",
-        "rules": [
+    "storage": {
+        "storageType": "ENUM_VALUE",
+        "storageSize": 20
+    },
+    "backup": {
+        "backupPeriod": 0,
+        "backupRetryCount": 0,
+        "backupSchedules": [
             {
-                "ruleId": "17c88ef6-95f1-4678-84f9-fee1b22e250d",
-                "description": "description",
-                "direction": "INGRESS",
-                "etherType": "IPV4",
-                "port": {
-                    "portType": "PORT_RANGE",
-                    "minPort": 10000,
-                    "maxPort": 10005
-                },
-                "cidr": "0.0.0.0/0",
-                "createdYmdt": "2023-02-19T19:18:13+09:00",
-                "updatedYmdt": "2023-02-19T19:18:13+09:00"
+                "backupWndDuration": "HALF_AN_HOUR"
             }
-        ],
-        "createdYmdt": "2023-02-19T19:18:13+09:00",
-        "updatedYmdt": "2023-02-19T19:18:13+09:00"
+        ]
     }
 }
 ```
-</details>
 
-### DB 보안 그룹 생성하기
-
-```http
-POST /v1.0/db-security-groups
-```
-
-#### 필요 권한
-
-| 권한명                                     | 설명            |
-|-----------------------------------------|---------------|
-| RDSforPostgreSQL:DbSecurityGroup.Create | DB 보안 그룹 생성하기 |
-
-#### 요청
-
-| 이름                  | 종류   | 형식     | 필수 | 설명                                                                                                                                                                                       |
-|---------------------|------|--------|----|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupName | Body | String | O  | DB 보안 그룹을 식별할 수 있는 이름                                                                                                                                                                    |
-| description         | Body | String | X  | DB 보안 그룹에 대한 추가 정보                                                                                                                                                                       |
-| rules               | Body | Array  | O  | DB 보안 그룹 규칙 목록                                                                                                                                                                           |
-| rules.description   | Body | String | X  | DB 보안 그룹 규칙에 대한 추가 정보                                                                                                                                                                    |
-| rules.direction     | Body | Enum   | O  | 통신 방향<br/>- `INGRESS`: 수신<br/>- `EGRESS`: 송신                                                                                                                                             |
-| rules.etherType     | Body | Enum   | O  | Ether 유형<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                           |
-| rules.cidr          | Body | String | O  | 허용할 트래픽의 원격 소스<br/>- 예시: `1.1.1.1/32`                                                                                                                                                    |
-| rules.port          | Body | Object | O  | 포트 객체                                                                                                                                                                                    |
-| rules.port.portType | Body | Enum   | O  | 포트 유형<br/>- `DB_PORT`: 각 DB 인스턴스 포트값으로 설정됩니다. `minPort`값과 `maxPort`값을 필요로 하지 않습니다.<br/>- `PORT`: 지정된 포트값으로 설정됩니다. `minPort`값과 `maxPort`값이 같아야 합니다.<br/>- `PORT_RANGE`: 지정된 포트 범위로 설정됩니다. |
-| rules.port.minPort  | Body | Number | X  | 최소 포트 범위<br/>- 수신 최솟값: 5432<br/>- 송신 최솟값: 1                                                                                                                                              |
-| rules.port.maxPort  | Body | Number | X  | 최대 포트 범위<br/>- 수신 최댓값: 45432<br/>- 송신 최댓값: 65535                                                                                                                                         |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "dbSecurityGroupName": "dbSecurityGroup",
-    "description": "description",
-    "rules": [
-        {
-            "direction": "INGRESS",
-            "etherType": "IPV4",
-            "port": {
-                "portType": "PORT_RANGE",
-                "minPort": 10000,
-                "maxPort": 10005
-            },
-            "cidr": "0.0.0.0/0"
-        }
-    ]
-}
-```
+</p>
 </details>
 
 #### 응답
 
-| 이름                | 종류   | 형식   | 설명            |
-|-------------------|------|------|---------------|
-| dbSecurityGroupId | Body | UUID | DB 보안 그룹의 식별자 |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbSecurityGroupId": "fe4f2aee-afbb-4c19-a5e9-eb2eab394708"
-}
-```
-</details>
-
-### DB 보안 그룹 수정하기
-
-```http
-PUT /v1.0/db-security-groups/{dbSecurityGroupId}
-```
-
-#### 필요 권한
-
-| 권한명                                     | 설명            |
-|-----------------------------------------|---------------|
-| RDSforPostgreSQL:DbSecurityGroup.Modify | DB 보안 그룹 수정하기 |
-
-#### 요청
-
-| 이름                  | 종류   | 형식     | 필수 | 설명                    |
-|---------------------|------|--------|----|-----------------------|
-| dbSecurityGroupId   | URL  | UUID   | O  | DB 보안 그룹의 식별자         |
-| dbSecurityGroupName | Body | String | X  | DB 보안 그룹을 식별할 수 있는 이름 |
-| description         | Body | String | X  | DB 보안 그룹에 대한 추가 정보    |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "dbSecurityGroupName": "dbSecurityGroup",
-    "description": "description"
-}
-```
-</details>
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
-
-### DB 보안 그룹 삭제하기
-
-```http
-DELETE /v1.0/db-security-groups/{dbSecurityGroupId}
-```
-
-#### 필요 권한
-
-| 권한명                                     | 설명            |
-|-----------------------------------------|---------------|
-| RDSforPostgreSQL:DbSecurityGroup.Delete | DB 보안 그룹 삭제하기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름                | 종류  | 형식   | 필수 | 설명            |
-|-------------------|-----|------|----|---------------|
-| dbSecurityGroupId | URL | UUID | O  | DB 보안 그룹의 식별자 |
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
-
-### DB 보안 그룹 규칙 생성하기
-
-```http
-POST /v1.0/db-security-groups/{dbSecurityGroupId}/rules
-```
-
-#### 필요 권한
-
-| 권한명                                         | 설명               |
-|---------------------------------------------|------------------|
-| RDSforPostgreSQL:DbSecurityGroupRule.Create | DB 보안 그룹 규칙 생성하기 |
-
-#### 요청
-
-| 이름                | 종류   | 형식     | 필수 | 설명                                                                                                                                                                                       |
-|-------------------|------|--------|----|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId | URL  | UUID   | O  | DB 보안 그룹의 식별자                                                                                                                                                                            |
-| description       | Body | String | X  | DB 보안 그룹 규칙에 대한 추가 정보                                                                                                                                                                    |
-| direction         | Body | Enum   | O  | 통신 방향<br/>- `INGRESS`: 수신<br/>- `EGRESS`: 송신                                                                                                                                             |
-| etherType         | Body | Enum   | O  | Ether 유형<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                           |
-| port              | Body | Object | O  | 포트 객체                                                                                                                                                                                    |
-| port.portType     | Body | Enum   | O  | 포트 유형<br/>- `DB_PORT`: 각 DB 인스턴스 포트값으로 설정됩니다. `minPort`값과 `maxPort`값을 필요로 하지 않습니다.<br/>- `PORT`: 지정된 포트값으로 설정됩니다. `minPort`값과 `maxPort`값이 같아야 합니다.<br/>- `PORT_RANGE`: 지정된 포트 범위로 설정됩니다. |
-| port.minPort      | Body | Number | X  | 최소 포트 범위<br/>- 수신 최솟값: 5432<br/>- 송신 최솟값: 1                                                                                                                                              |
-| port.maxPort      | Body | Number | X  | 최대 포트 범위<br/>- 수신 최댓값: 45432<br/>- 송신 최댓값: 65535                                                                                                                                         |
-| cidr              | Body | String | O  | 허용할 트래픽의 원격 소스<br/>- 예시: `1.1.1.1/32`                                                                                                                                                    |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "direction": "INGRESS",
-    "etherType": "IPV4",
-    "port": {
-        "portType": "PORT",
-        "minPort": 10000,
-        "maxPort": 10000
-    },
-    "cidr": "0.0.0.0/0"
-}
-```
-</details>
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | 요청한 작업의 식별자 |
 
 <details><summary>예시</summary>
+<p>
 
 ```json
 {
@@ -3823,521 +3862,14 @@ POST /v1.0/db-security-groups/{dbSecurityGroupId}/rules
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-### DB 보안 그룹 규칙 수정하기
-
-```http
-PUT /v1.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
-```
-
-#### 필요 권한
-
-| 권한명                                         | 설명               |
-|---------------------------------------------|------------------|
-| RDSforPostgreSQL:DbSecurityGroupRule.Modify | DB 보안 그룹 규칙 수정하기 |
-
-#### 요청
-
-| 이름                | 종류   | 형식     | 필수 | 설명                                                                                                                                                                                       |
-|-------------------|------|--------|----|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId | URL  | UUID   | O  | DB 보안 그룹의 식별자                                                                                                                                                                            |
-| ruleId            | URL  | UUID   | O  | DB 보안 그룹 규칙의 식별자                                                                                                                                                                         |
-| description       | Body | String | X  | DB 보안 그룹 규칙에 대한 추가 정보                                                                                                                                                                    |
-| direction         | Body | Enum   | O  | 통신 방향<br/>- `INGRESS`: 수신<br/>- `EGRESS`: 송신                                                                                                                                             |
-| etherType         | Body | Enum   | O  | Ether 유형<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                           |
-| port              | Body | Object | O  | 포트 객체                                                                                                                                                                                    |
-| port.portType     | Body | Enum   | O  | 포트 유형<br/>- `DB_PORT`: 각 DB 인스턴스 포트값으로 설정됩니다. `minPort`값과 `maxPort`값을 필요로 하지 않습니다.<br/>- `PORT`: 지정된 포트값으로 설정됩니다. `minPort`값과 `maxPort`값이 같아야 합니다.<br/>- `PORT_RANGE`: 지정된 포트 범위로 설정됩니다. |
-| port.minPort      | Body | Number | X  | 최소 포트 범위<br/>- 수신 최솟값: 5432<br/>- 송신 최솟값: 1                                                                                                                                              |
-| port.maxPort      | Body | Number | X  | 최대 포트 범위<br/>- 수신 최댓값: 45432<br/>- 송신 최댓값: 65535                                                                                                                                         |
-| cidr              | Body | String | O  | 허용할 트래픽의 원격 소스<br/>- 예시: `1.1.1.1/32`                                                                                                                                                    |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "direction": "INGRESS",
-    "etherType": "IPV4",
-    "port": {
-        "portType": "DB_PORT"
-    },
-    "cidr": "0.0.0.0/0"
-}
-```
-</details>
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### DB 보안 그룹 규칙 삭제하기
-
-```http
-DELETE /v1.0/db-security-groups/{dbSecurityGroupId}/rules
-```
-
-#### 필요 권한
-
-| 권한명                                         | 설명               |
-|---------------------------------------------|------------------|
-| RDSforPostgreSQL:DbSecurityGroupRule.Create | DB 보안 그룹 규칙 삭제하기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름                | 종류    | 형식    | 필수 | 설명                  |
-|-------------------|-------|-------|----|---------------------|
-| dbSecurityGroupId | URL   | UUID  | O  | DB 보안 그룹의 식별자       |
-| ruleIds           | Query | Array | O  | DB 보안 그룹 규칙의 식별자 목록 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-## 파라미터 그룹
-
-### 파라미터 그룹 목록 보기
-
-```http
-GET /v1.0/parameter-groups
-```
-
-#### 필요 권한
-
-| 권한명                                  | 설명            |
-|--------------------------------------|---------------|
-| RDSforPostgreSQL:ParameterGroup.List | 파라미터 그룹 목록 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름        | 종류    | 형식   | 필수 | 설명       |
-|-----------|-------|------|----|----------|
-| dbVersion | Query | Enum | X  | DB 버전 정보 |
-
-#### 응답
-
-| 이름                                   | 종류   | 형식       | 설명                                                                |
-|--------------------------------------|------|----------|-------------------------------------------------------------------|
-| parameterGroups                      | Body | Array    | 파라미터 그룹 목록                                                        |
-| parameterGroups.parameterGroupId     | Body | UUID     | 파라미터 그룹의 식별자                                                      |
-| parameterGroups.parameterGroupName   | Body | String   | 파라미터 그룹을 식별할 수 있는 이름                                              |
-| parameterGroups.parameterGroupStatus | Body | Enum     | 파라미터 그룹의 현재 상태<br/>- `STABLE`: 적용 완료<br/>- `NEED_TO_APPLY`: 적용 필요 |
-| parameterGroups.description          | Body | String   | 파라미터 그룹에 대한 추가 정보                                                 |
-| parameterGroups.dbVersion            | Body | Enum     | DB 버전 정보                                                          |
-| parameterGroups.createdYmdt          | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                 |
-| parameterGroups.updatedYmdt          | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                 |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroups": [
-        {
-            "parameterGroupId": "404e8a89-ca4d-4fca-96c2-1518754d50b7",
-            "parameterGroupName": "parameter-group",
-            "parameterGroupStatus": "STABLE",
-            "description": null,
-            "dbVersion": "POSTGRESQL_V17_6",
-            "createdYmdt": "2023-02-31T15:28:17+09:00",
-            "updatedYmdt": "2023-02-31T15:28:17+09:00"
-        }
-    ]
-}
-```
-</details>
-
-
-### 파라미터 그룹 상세 보기
-
-```http
-GET /v1.0/parameter-groups/{parameterGroupId}
-```
-
-#### 필요 권한
-
-| 권한명                                 | 설명            |
-|-------------------------------------|---------------|
-| RDSforPostgreSQL:ParameterGroup.Get | 파라미터 그룹 상세 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름               | 종류  | 형식   | 필수 | 설명           |
-|------------------|-----|------|----|--------------|
-| parameterGroupId | URL | UUID | O  | 파라미터 그룹의 식별자 |
-
-#### 응답
-
-| 이름                           | 종류   | 형식       | 설명                                                                                                                                                                                                                                                                                                                                                 |
-|------------------------------|------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| parameterGroupId             | Body | UUID     | 파라미터 그룹의 식별자                                                                                                                                                                                                                                                                                                                                       |
-| parameterGroupName           | Body | String   | 파라미터 그룹을 식별할 수 있는 이름                                                                                                                                                                                                                                                                                                                               |
-| description                  | Body | String   | 파라미터 그룹에 대한 추가 정보                                                                                                                                                                                                                                                                                                                                  |
-| dbVersion                    | Body | Enum     | DB 버전 정보                                                                                                                                                                                                                                                                                                                                           |
-| parameterGroupStatus         | Body | Enum     | 파라미터 그룹의 현재 상태<br/>- `STABLE`: 적용 완료<br/>- `NEED_TO_APPLY`: 적용 필요<br/>- `DELETED`: 삭제됨                                                                                                                                                                                                                                                             |
-| parameters                   | Body | Array    | 파라미터 목록                                                                                                                                                                                                                                                                                                                                            |
-| parameters.parameterCategory | Body | String   | 파라미터 카테고리                                                                                                                                                                                                                                                                                                                                          |
-| parameters.parameterName     | Body | String   | 파라미터 이름                                                                                                                                                                                                                                                                                                                                            |
-| parameters.value             | Body | String   | 현재 설정된 값                                                                                                                                                                                                                                                                                                                                           |
-| parameters.valueUnit         | Body | Enum     | 현재 설정된 값의 단위<br/>- `B`: 바이트<br/>- `kB`: 킬로바이트<br/>- `MB`: 메가바이트<br/>- `GB`: 기가바이트<br/>- `TB`: 테라바이트<br/>- `us`: 마이크로초<br/>- `ms`: 밀리초<br/>- `s`: 초<br/>- `min`: 분<br/>- `h`: 시<br/>- `d`: 일                                                                                                                                                        |
-| parameters.defaultValue      | Body | String   | 기본값                                                                                                                                                                                                                                                                                                                                                |
-| parameters.allowedValue      | Body | String   | 허용된 값                                                                                                                                                                                                                                                                                                                                              |
-| parameters.valueType         | Body | Enum     | 값 유형<br/>- `BOOLEAN`: 불린 유형<br/>- `STRING`: 문자열 유형<br/>- `NUMERIC`: 정수 및 부동 소수점 유형<br/>- `NUMERIC_WITH_BYTE_UNIT`: 바이트 단위의 숫자 유형(예: 120KB, 100MB)<br/>- `NUMERIC_WITH_TIME_UNIT`: 시간 단위의 숫자 유형(예: 120ms, 100s, 1d)<br/>- `ENUMERATED`: 허용된 값에 선언된 값 중 한 개 입력<br/>- `MULTI_ENUMERATED`: 허용된 값에 선언된 값 중 여러 개 입력(콤마(,)로 구분됨)<br/>- `TIMEZONE`: 타임존 유형 |
-| parameters.updateType        | Body | Enum     | 수정 유형<br/>- `VARIABLE`: 언제든 수정 가능<br/>- `CONSTANT`: 수정 불가능                                                                                                                                                                                                                                                                                         |
-| parameters.applyType         | Body | Enum     | 적용 유형<br/>- `SESSION`: 세션 적용<br/>- `FILE`: 설정 파일 적용(재시작 필요)<br/>- `BOTH`: 전체                                                                                                                                                                                                                                                                       | 
-| createdYmdt                  | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                                                                                                                                                                                  |
-| updatedYmdt                  | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                                                                                                                                                                                  |
-| expressionAvailable          | Body | Boolean  | 수식 허용 여부                                                                                                                                                                                                                                                                                                                                           |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroupId": "404e8a89-ca4d-4fca-96c2-1518754d50b7",
-    "parameterGroupName": "parameter-group",
-    "description": null,
-    "dbVersion": "POSTGRESQL_V17_6",
-    "parameterGroupStatus": "STABLE",
-    "parameters": [
-        {
-            "parameterCategory": "Write-Ahead Log / Checkpoints",
-            "parameterName": "checkpoint_timeout",
-            "value": "300s",
-            "defaultValue": "300s",
-            "allowedValue": "30~86400s",
-            "valueType": "NUMERIC_WITH_TIME_UNIT",
-            "updateType": "VARIABLE",
-            "applyType": "BOTH",
-            "expressionAvailable": true
-        }
-    ],
-    "createdYmdt": "2023-03-13T11:02:28+09:00",
-    "updatedYmdt": "2023-03-13T11:02:28+09:00"
-}
-```
-</details>
-
-
-### 파라미터 그룹 생성하기
-
-```http
-POST /v1.0/parameter-groups
-```
-
-#### 필요 권한
-
-| 권한명                                    | 설명           |
-|----------------------------------------|--------------|
-| RDSforPostgreSQL:ParameterGroup.Create | 파라미터 그룹 생성하기 |
-
-#### 요청
-
-| 이름                 | 종류   | 형식     | 필수 | 설명                   |
-|--------------------|------|--------|----|----------------------|
-| parameterGroupName | Body | String | O  | 파라미터 그룹을 식별할 수 있는 이름 |
-| description        | Body | String | X  | 파라미터 그룹에 대한 추가 정보    |
-| dbVersion          | Body | Enum   | O  | DB 버전 정보             |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "parameterGroupName": "parameter-group",
-    "description": "description",
-    "dbVersion": "POSTGRESQL_V17_6"
-}
-```
-</details>
-
-#### 응답
-
-| 이름               | 종류   | 형식   | 설명           |
-|------------------|------|------|--------------|
-| parameterGroupId | Body | UUID | 파라미터 그룹의 식별자 |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroupId": "404e8a89-ca4d-4fca-96c2-1518754d50b7"
-}
-```
-</details>
-
-### 파라미터 그룹 복사하기
-
-```http
-POST /v1.0/parameter-groups/{parameterGroupId}/copy
-```
-
-#### 필요 권한
-
-| 권한명                                  | 설명           |
-|--------------------------------------|--------------|
-| RDSforPostgreSQL:ParameterGroup.Copy | 파라미터 그룹 복사하기 |
-
-#### 요청
-
-| 이름                 | 종류   | 형식     | 필수 | 설명                   |
-|--------------------|------|--------|----|----------------------|
-| parameterGroupId   | URL  | UUID   | O  | 파라미터 그룹의 식별자         |
-| parameterGroupName | Body | String | O  | 파라미터 그룹을 식별할 수 있는 이름 |
-| description        | Body | String | X  | 파라미터 그룹에 대한 추가 정보    |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "parameterGroupName": "parameter-group-copy",
-    "description": "copy"
-}
-```
-</details>
-
-#### 응답
-
-| 이름               | 종류   | 형식   | 설명           |
-|------------------|------|------|--------------|
-| parameterGroupId | Body | UUID | 파라미터 그룹의 식별자 |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroupId": "404e8a89-ca4d-4fca-96c2-1518754d50b7"
-}
-```
-</details>
-
-### 파라미터 그룹 수정하기
-
-```http
-PUT /v1.0/parameter-groups/{parameterGroupId}
-```
-
-#### 필요 권한
-
-| 권한명                                    | 설명           |
-|----------------------------------------|--------------|
-| RDSforPostgreSQL:ParameterGroup.Modify | 파라미터 그룹 수정하기 |
-
-#### 요청
-
-| 이름                 | 종류   | 형식     | 필수 | 설명                   |
-|--------------------|------|--------|----|----------------------|
-| parameterGroupId   | URL  | UUID   | O  | 파라미터 그룹의 식별자         |
-| parameterGroupName | Body | String | X  | 파라미터 그룹을 식별할 수 있는 이름 |
-| description        | Body | String | X  | 파라미터 그룹에 대한 추가 정보    |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "parameterGroupName": "parameter-group",
-    "description": "description"
-}
-```
-</details>
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
-
-### 파라미터 수정하기
-
-```http
-PUT /v1.0/parameter-groups/{parameterGroupId}/parameters
-```
-
-#### 필요 권한
-
-| 권한명                                    | 설명           |
-|----------------------------------------|--------------|
-| RDSforPostgreSQL:ParameterGroup.Modify | 파라미터 그룹 수정하기 |
-
-#### 요청
-
-| 이름                               | 종류   | 형식     | 필수 | 설명           |
-|----------------------------------|------|--------|----|--------------|
-| parameterGroupId                 | URL  | UUID   | O  | 파라미터 그룹의 식별자 |
-| modifiedParameters               | Body | Array  | O  | 변경할 파라미터 목록  |
-| modifiedParameters.parameterName | Body | UUID   | O  | 파라미터 이름      |
-| modifiedParameters.value         | Body | String | O  | 변경할 파라미터 값   |
-
-<details><summary>예시</summary>
-
-```json
-{
-   "modifiedParameters": [
-       {
-           "parameterName": "checkpoint_timeout",
-           "value": "100s"
-       }
-   ]
-}
-```
-</details>
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
-
-### 파라미터 그룹 재설정하기
-
-```http
-PUT /v1.0/parameter-groups/{parameterGroupId}/reset
-```
-
-#### 필요 권한
-
-| 권한명                                   | 설명            |
-|---------------------------------------|---------------|
-| RDSforPostgreSQL:ParameterGroup.Reset | 파라미터 그룹 재설정하기 |
-
-#### 요청
-
-| 이름               | 종류  | 형식   | 필수 | 설명           |
-|------------------|-----|------|----|--------------|
-| parameterGroupId | URL | UUID | O  | 파라미터 그룹의 식별자 |
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
-
-### 파라미터 그룹 삭제하기
-
-```http
-DELETE /v1.0/parameter-groups/{parameterGroupId}
-```
-
-#### 필요 권한
-
-| 권한명                                    | 설명           |
-|----------------------------------------|--------------|
-| RDSforPostgreSQL:ParameterGroup.Delete | 파라미터 그룹 삭제하기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름               | 종류  | 형식   | 필수 | 설명           |
-|------------------|-----|------|----|--------------|
-| parameterGroupId | URL | UUID | O  | 파라미터 그룹의 식별자 |
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
+---
 
 ## 사용자 그룹
 
@@ -4347,28 +3879,23 @@ DELETE /v1.0/parameter-groups/{parameterGroupId}
 GET /v1.0/user-groups
 ```
 
-#### 필요 권한
-
-| 권한명                             | 설명           |
-|---------------------------------|--------------|
-| RDSforPostgreSQL:UserGroup.List | 사용자 그룹 목록 보기 |
-
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름                       | 종류   | 형식       | 설명                                                      |
-|--------------------------|------|----------|---------------------------------------------------------|
-| userGroups               | Body | Array    | 사용자 그룹 목록                                               |
-| userGroups.userGroupId   | Body | UUID     | 사용자 그룹의 식별자                                             |
-| userGroups.userGroupName | Body | String   | 사용자 그룹을 식별할 수 있는 이름                                     |
-| userGroupStatus          | Body | Enum     | 사용자 그룹의 현재 상태<br/>- `CREATED`: 생성됨<br/>- `DELETED`: 삭제됨 |
-| userGroups.createdYmdt   | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                       |
-| userGroups.updatedYmdt   | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                       |
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| userGroups | Body | Array | 사용자 그룹 정보 |
+| userGroups.userGroupId | Body | String | 사용자 그룹의 식별자 |
+| userGroups.userGroupName | Body | String | 사용자 그룹을 식별할 수 있는 이름 |
+| userGroups.userGroupStatus | Body | Enum | 사용자 그룹의 현재 상태<br/>- CREATED<br/>- DELETED |
+| userGroups.createdYmdt | Body | DateTime | 생성 일시 |
+| userGroups.updatedYmdt | Body | DateTime | 수정 일시 |
 
 <details><summary>예시</summary>
+<p>
 
 ```json
 {
@@ -4379,52 +3906,53 @@ GET /v1.0/user-groups
     },
     "userGroups": [
         {
-            "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-            "userGroupName": "dev-team",
-            "userGroupStatus": "CREATED",
-            "createdYmdt": "2023-02-23T10:07:54+09:00",
-            "updatedYmdt": "2023-02-26T01:15:50+09:00"
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
+
+</p>
 </details>
 
+---
 
-### 사용자 그룹 상세 보기
+### 사용자 그룹 생성하기
 
 ```http
-GET /v1.0/user-groups/{userGroupId}
+POST /v1.0/user-groups
 ```
-
-#### 필요 권한
-
-| 권한명                            | 설명           |
-|--------------------------------|--------------|
-| RDSforPostgreSQL:UserGroup.Get | 사용자 그룹 상세 보기 |
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| userGroupName | Body | String | O | 사용자 그룹을 식별할 수 있는 이름 |
+| memberIds | Body | Array | O | 프로젝트 멤버의 식별자 목록 |
+| selectAllYN | Body | Boolean | O | 프로젝트 멤버 전체 유무<br/>- 기본값: `false` |
 
-| 이름          | 종류  | 형식   | 필수 | 설명          |
-|-------------|-----|------|----|-------------|
-| userGroupId | URL | UUID | O  | 사용자 그룹의 식별자 |
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "userGroupName": "userGroupName-example",
+    "memberIds": [],
+    "selectAllYN": false
+}
+```
+
+</p>
+</details>
 
 #### 응답
 
-| 이름                | 종류   | 형식       | 설명                                                                                                        |
-|-------------------|------|----------|-----------------------------------------------------------------------------------------------------------|
-| userGroupId       | Body | UUID     | 사용자 그룹의 식별자                                                                                               |
-| userGroupName     | Body | String   | 사용자 그룹을 식별할 수 있는 이름                                                                                       |
-| userGroupTypeCode | Body | Enum     | 사용자 그룹 종류    <br /> `ENTIRE`: 프로젝트 멤버 전체를 포함하는 사용자 그룹 <br /> `INDIVIDUAL_MEMBER`: 특정 프로젝트 멤버를 포함하는 사용자 그룹 |
-| userGroupStatus   | Body | Enum     | 사용자 그룹의 현재 상태<br/>- `CREATED`: 생성됨<br/>- `DELETED`: 삭제됨                                                   |
-| members           | Body | Array    | 프로젝트 멤버 목록                                                                                                |
-| members.memberId  | Body | UUID     | 프로젝트 멤버의 식별자                                                                                              |
-| createdYmdt       | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                         |
-| updatedYmdt       | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                         |
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| userGroupId | Body | String | 사용자 그룹의 식별자 |
 
 <details><summary>예시</summary>
+<p>
 
 ```json
 {
@@ -4433,113 +3961,14 @@ GET /v1.0/user-groups/{userGroupId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-    "userGroupName": "dev-team",
-    "userGroupStatus": "CREATED",
-	"userGroupTypeCode": "INDIVIDUAL_MEMBER",
-    "members": [
-        {
-            "memberId": "1321e759-2ef3-4b85-9921-b13e918b24b5"
-        }
-    ],
-    "createdYmdt": "2023-02-23T10:07:54+09:00",
-    "updatedYmdt": "2023-02-26T01:15:50+09:00"
+    "userGroupId": "userGroupId-example"
 }
 ```
+
+</p>
 </details>
 
-
-### 사용자 그룹 생성하기
-
-```http
-POST /v1.0/user-groups
-```
-
-#### 필요 권한
-
-| 권한명                               | 설명          |
-|-----------------------------------|-------------|
-| RDSforPostgreSQL:UserGroup.Create | 사용자 그룹 생성하기 |
-
-#### 요청
-
-| 이름            | 종류   | 형식      | 필수 | 설명                                                              |
-|---------------|------|---------|----|-----------------------------------------------------------------|
-| userGroupName | Body | String  | O  | 사용자 그룹을 식별할 수 있는 이름                                             |
-| memberIds     | Body | Array   | O  | 프로젝트 멤버의 식별자 목록     <br /> `selectAllYN`이 true인 경우 해당 필드 값은 무시됨 |
-| selectAllYN   | Body | Boolean | X  | 프로젝트 멤버 전체 유무 <br /> true인 경우 해당 그룹은 전체 멤버에 대해 설정됨              |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "userGroupName": "dev-team",
-    "memberIds": ["1321e759-2ef3-4b85-9921-b13e918b24b5"]
-}
-```
-
-```json
-{
-    "userGroupName": "dev-team",
-    "selectAllYN":true
-}
-```
-</details>
-
-#### 응답
-
-| 이름          | 종류   | 형식   | 설명          |
-|-------------|------|------|-------------|
-| userGroupId | Body | UUID | 사용자 그룹의 식별자 |
-
-
-### 사용자 그룹 수정하기
-
-```http
-PUT /v1.0/user-groups/{userGroupId}
-```
-
-#### 필요 권한
-
-| 권한명                               | 설명          |
-|-----------------------------------|-------------|
-| RDSforPostgreSQL:UserGroup.Modify | 사용자 그룹 수정하기 |
-
-#### 요청
-
-| 이름            | 종류   | 형식      | 필수 | 설명                                                 |
-|---------------|------|---------|----|----------------------------------------------------|
-| userGroupId   | URL  | UUID    | O  | 사용자 그룹의 식별자                                        |
-| userGroupName | Body | String  | X  | 사용자 그룹을 식별할 수 있는 이름                                |
-| memberIds     | Body | Array   | X  | 프로젝트 멤버의 식별자 목록                                    |
-| selectAllYN   | Body | Boolean | X  | 프로젝트 멤버 전체 유무 <br /> true인 경우 해당 그룹은 전체 멤버에 대해 설정됨 |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "userGroupName": "dev-team",
-    "memberIds": ["1321e759-2ef3-4b85-9921-b13e918b24b5","f9064b09-2b15-442e-a4b0-3a5a2754555e"]
-}
-```
-</details>
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
+---
 
 ### 사용자 그룹 삭제하기
 
@@ -4547,23 +3976,49 @@ PUT /v1.0/user-groups/{userGroupId}
 DELETE /v1.0/user-groups/{userGroupId}
 ```
 
-#### 필요 권한
-
-| 권한명                               | 설명          |
-|-----------------------------------|-------------|
-| RDSforPostgreSQL:UserGroup.Delete | 사용자 그룹 삭제하기 |
-
 #### 요청
 
-| 이름          | 종류  | 형식   | 필수 | 설명          |
-|-------------|-----|------|----|-------------|
-| userGroupId | URL | UUID | O  | 사용자 그룹의 식별자 |
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | O | 사용자 그룹 ID |
 
 #### 응답
 
 이 API는 응답 본문을 반환하지 않습니다.
 
+---
+
+### 사용자 그룹 상세 보기
+
+```http
+GET /v1.0/user-groups/{userGroupId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | O | 사용자 그룹 ID |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| userGroupId | Body | String | 사용자 그룹의 식별자 |
+| userGroupName | Body | String | 사용자 그룹을 식별할 수 있는 이름 |
+| userGroupTypeCode | Body | Enum | 사용자 그룹 종류<br/>- ENTIRE: `전체 프로젝트 멤버`<br/>- INDIVIDUAL_MEMBER: `사용자 지정` |
+| userGroupStatus | Body | Enum | 사용자 그룹의 현재 상태<br/>- CREATED<br/>- DELETED |
+| members | Body | Array | 프로젝트 멤버 목록 |
+| members.memberId | Body | String | 프로젝트 멤버의 식별자 |
+| createdYmdt | Body | DateTime | 생성 일시 |
+| updatedYmdt | Body | DateTime | 수정 일시 |
+
 <details><summary>예시</summary>
+<p>
 
 ```json
 {
@@ -4571,10 +4026,60 @@ DELETE /v1.0/user-groups/{userGroupId}
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "userGroupId": "userGroupId-example",
+    "userGroupName": "userGroupName-example",
+    "userGroupTypeCode": "ENTIRE",
+    "userGroupStatus": "CREATED",
+    "members": [
+        {
+            "memberId": "memberId-example"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
+
+</p>
 </details>
+
+---
+
+### 사용자 그룹 수정하기
+
+```http
+PUT /v1.0/user-groups/{userGroupId}
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | O | 사용자 그룹 ID |
+| userGroupName | Body | String | X | 사용자 그룹을 식별할 수 있는 이름 |
+| memberIds | Body | Array | X | 프로젝트 멤버의 식별자 목록 |
+| selectAllYN | Body | Boolean | O | 프로젝트 멤버 전체 유무<br/>- 기본값: `false` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "userGroupName": "userGroupName-example",
+    "memberIds": [],
+    "selectAllYN": false
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
 
 ## 알림 그룹
 
@@ -4584,31 +4089,26 @@ DELETE /v1.0/user-groups/{userGroupId}
 GET /v1.0/notification-groups
 ```
 
-#### 필요 권한
-
-| 권한명                                     | 설명          |
-|-----------------------------------------|-------------|
-| RDSforPostgreSQL:NotificationGroup.List | 알림 그룹 목록 보기 |
-
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름                                         | 종류   | 형식       | 설명                                                     |
-|--------------------------------------------|------|----------|--------------------------------------------------------|
-| notificationGroups                         | Body | Array    | 알림 그룹 목록                                               |
-| notificationGroups.notificationGroupId     | Body | UUID     | 알림 그룹의 식별자                                             |
-| notificationGroups.notificationGroupName   | Body | String   | 알림 그룹을 식별할 수 있는 이름                                     |
-| notificationGroups.notificationGroupStatus | Body | Enum     | 알림 그룹의 현재 상태<br/>- `CREATED`: 생성됨<br/>- `DELETED`: 삭제됨 |
-| notificationGroups.notifyEmail             | Body | Boolean  | 이메일 알림 여부                                              |
-| notificationGroups.notifySms               | Body | Boolean  | SMS 알림 여부                                              |
-| notificationGroups.isEnabled               | Body | Boolean  | 활성화 여부                                                 |
-| notificationGroups.createdYmdt             | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                      |
-| notificationGroups.updatedYmdt             | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                      |
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| notificationGroups | Body | Array |  |
+| notificationGroups.notificationGroupId | Body | String | 알림 그룹의 식별자 |
+| notificationGroups.notificationGroupName | Body | String | 알림 그룹을 식별할 수 있는 이름 |
+| notificationGroups.notificationGroupStatus | Body | Enum | 알림 그룹의 현재 상태<br/>- CREATED: `생성됨`<br/>- DELETED: `삭제됨` |
+| notificationGroups.notifyEmail | Body | Boolean | 이메일 알림 여부 |
+| notificationGroups.notifySms | Body | Boolean | SMS 알림 여부 |
+| notificationGroups.isEnabled | Body | Boolean | 활성화 여부 |
+| notificationGroups.createdYmdt | Body | DateTime | 생성 일시 |
+| notificationGroups.updatedYmdt | Body | DateTime | 수정 일시 |
 
 <details><summary>예시</summary>
+<p>
 
 ```json
 {
@@ -4619,91 +4119,16 @@ GET /v1.0/notification-groups
     },
     "notificationGroups": [
         {
-            "notificationGroupId": "b3901f17-9971-4d1e-8a81-8448cf533dc7",
-            "notificationGroupName": "dev-team-noti",
-            "notifyEmail": true,
-            "notifySms": false,
-            "isEnabled": true,
-            "createdYmdt": "2023-02-20T13:34:13+09:00",
-            "updatedYmdt": "2023-02-20T13:34:13+09:00"
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
+
+</p>
 </details>
 
-
-### 알림 그룹 상세 보기
-
-```http
-GET /v1.0/notification-groups/{notificationGroupId}
-```
-
-#### 필요 권한
-
-| 권한명                                    | 설명          |
-|----------------------------------------|-------------|
-| RDSforPostgreSQL:NotificationGroup.Get | 알림 그룹 상세 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름                  | 종류  | 형식   | 필수 | 설명         |
-|---------------------|-----|------|----|------------|
-| notificationGroupId | URL | UUID | O  | 알림 그룹의 식별자 |
-
-#### 응답
-
-| 이름                         | 종류   | 형식       | 설명                                                     |
-|----------------------------|------|----------|--------------------------------------------------------|
-| notificationGroupId        | Body | UUID     | 알림 그룹의 식별자                                             |
-| notificationGroupName      | Body | String   | 알림 그룹을 식별할 수 있는 이름                                     |
-| notificationGroupStatus    | Body | Enum     | 알림 그룹의 현재 상태<br/>- `CREATED`: 생성됨<br/>- `DELETED`: 삭제됨 |
-| notifyEmail                | Body | Boolean  | 이메일 알림 여부                                              |
-| notifySms                  | Body | Boolean  | SMS 알림 여부                                              |
-| isEnabled                  | Body | Boolean  | 활성화 여부                                                 |
-| dbInstances                | Body | Array    | 감시 대상 DB 인스턴스 목록                                       |
-| dbInstances.dbInstanceId   | Body | UUID     | DB 인스턴스의 식별자                                           |
-| dbInstances.dbInstanceName | Body | String   | DB 인스턴스를 식별할 수 있는 이름                                   |
-| userGroups                 | Body | Array    | 사용자 그룹 목록                                              |
-| userGroups.userGroupId     | Body | UUID     | 사용자 그룹의 식별자                                            |
-| userGroups.userGroupName   | Body | String   | 사용자 그룹을 식별할 수 있는 이름                                    |
-| createdYmdt                | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                      |
-| updatedYmdt                | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                      |
-
-<details><summary>예시</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "notificationGroupId": "b3901f17-9971-4d1e-8a81-8448cf533dc7",
-    "notificationGroupName": "dev-team-noti",
-    "notifyEmail": true,
-    "notifySms": false,
-    "isEnabled": true,
-    "dbInstances": [
-        {
-            "dbInstanceId": "ed5cb985-526f-4c54-9ae0-40288593de65",
-            "dbInstanceName": "database"
-        }
-    ],
-    "userGroups": [
-        {
-            "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-            "userGroupName": "dev-team"
-        }
-    ],
-    "createdYmdt": "2023-02-20T13:34:13+09:00",
-    "updatedYmdt": "2023-02-20T13:34:13+09:00"
-}
-```
-</details>
-
+---
 
 ### 알림 그룹 생성하기
 
@@ -4711,82 +4136,42 @@ GET /v1.0/notification-groups/{notificationGroupId}
 POST /v1.0/notification-groups
 ```
 
-#### 필요 권한
-
-| 권한명                                       | 설명         |
-|-------------------------------------------|------------|
-| RDSforPostgreSQL:NotificationGroup.Create | 알림 그룹 생성하기 |
-
 #### 요청
 
-| 이름                    | 종류   | 형식      | 필수 | 설명                          |
-|-----------------------|------|---------|----|-----------------------------|
-| notificationGroupName | Body | String  | O  | 알림 그룹을 식별할 수 있는 이름          |
-| notifyEmail           | Body | Boolean | X  | 이메일 알림 여부<br/>- 기본값: `true` |
-| notifySms             | Body | Boolean | X  | SMS 알림 여부<br/>- 기본값: `true` |
-| isEnabled             | Body | Boolean | X  | 활성화 여부<br/>- 기본값: `true`    |
-| dbInstanceIds         | Body | Array   | X  | 감시 대상 DB 인스턴스의 식별자 목록       |
-| userGroupIds          | Body | Array   | X  | 사용자 그룹의 식별자 목록              |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| notificationGroupName | Body | String | O | 알림 그룹을 식별할 수 있는 이름 |
+| notifyEmail | Body | Boolean | X | 이메일 알림 여부<br/>- 기본값: `true` |
+| notifySms | Body | Boolean | X | SMS 알림 여부<br/>- 기본값: `true` |
+| isEnabled | Body | Boolean | X | 활성화 여부<br/>- 기본값: `true` |
+| dbInstanceIds | Body | Array | O | 감시 대상 DB 인스턴스의 식별자 목록 |
+| userGroupIds | Body | Array | O | 사용자 그룹의 식별자 목록 |
 
 <details><summary>예시</summary>
+<p>
 
 ```json
 {
-    "notificationGroupName": "dev-team-noti",
-    "notifyEmail": false,
-    "isEnable": true,
-    "dbInstanceIds": ["ed5cb985-526f-4c54-9ae0-40288593de65"],
-    "userGroupIds": ["1aac0437-f32d-4923-ad3c-ac61c1cfdfe0"]
-}
-```
-</details>
-
-#### 응답
-
-| 이름                  | 종류   | 형식   | 설명         |
-|---------------------|------|------|------------|
-| notificationGroupId | Body | UUID | 알림 그룹의 식별자 |
-
-
-### 알림 그룹 수정하기
-
-```http
-PUT /v1.0/notification-groups/{notificationGroupId}
-```
-
-#### 필요 권한
-
-| 권한명                                       | 설명         |
-|-------------------------------------------|------------|
-| RDSforPostgreSQL:NotificationGroup.Modify | 알림 그룹 수정하기 |
-
-#### 요청
-
-| 이름                    | 종류   | 형식      | 필수 | 설명                    |
-|-----------------------|------|---------|----|-----------------------|
-| notificationGroupId   | URL  | UUID    | O  | 알림 그룹의 식별자            |
-| notificationGroupName | Body | String  | X  | 알림 그룹을 식별할 수 있는 이름    |
-| notifyEmail           | Body | Boolean | X  | 이메일 알림 여부             |
-| notifySms             | Body | Boolean | X  | SMS 알림 여부             |
-| isEnabled             | Body | Boolean | X  | 활성화 여부                |
-| dbInstanceIds         | Body | Array   | X  | 감시 대상 DB 인스턴스의 식별자 목록 |
-| userGroupIds          | Body | Array   | X  | 사용자 그룹의 식별자 목록        |
-
-<details><summary>예시</summary>
-
-```json
-{
+    "notificationGroupName": "notificationGroupName-example",
     "notifyEmail": true,
-    "dbInstanceIds": ["ed5cb985-526f-4c54-9ae0-40288593de65", "d51b7da0-682f-47ff-b588-b739f6adc740"]
+    "notifySms": true,
+    "isEnabled": true,
+    "dbInstanceIds": [],
+    "userGroupIds": []
 }
 ```
+
+</p>
 </details>
 
 #### 응답
 
-이 API는 응답 본문을 반환하지 않습니다.
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| notificationGroupId | Body | String | 알림 그룹의 식별자 |
 
 <details><summary>예시</summary>
+<p>
 
 ```json
 {
@@ -4794,10 +4179,15 @@ PUT /v1.0/notification-groups/{notificationGroupId}
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "notificationGroupId": "notificationGroupId-example"
 }
 ```
+
+</p>
 </details>
+
+---
 
 ### 알림 그룹 삭제하기
 
@@ -4805,25 +4195,55 @@ PUT /v1.0/notification-groups/{notificationGroupId}
 DELETE /v1.0/notification-groups/{notificationGroupId}
 ```
 
-#### 필요 권한
-
-| 권한명                                       | 설명         |
-|-------------------------------------------|------------|
-| RDSforPostgreSQL:NotificationGroup.Delete | 알림 그룹 삭제하기 |
-
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름                  | 종류  | 형식   | 필수 | 설명         |
-|---------------------|-----|------|----|------------|
-| notificationGroupId | URL | UUID | O  | 알림 그룹의 식별자 |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O | 알림 그룹의 식별자 |
 
 #### 응답
 
 이 API는 응답 본문을 반환하지 않습니다.
 
+---
+
+### 알림 그룹 상세 보기
+
+```http
+GET /v1.0/notification-groups/{notificationGroupId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O | 알림 그룹의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| notificationGroupId | Body | String | 알림 그룹의 식별자 |
+| notificationGroupName | Body | String | 알림 그룹을 식별할 수 있는 이름 |
+| notificationGroupStatus | Body | Enum | 알림 그룹의 현재 상태<br/>- CREATED: `생성됨`<br/>- DELETED: `삭제됨` |
+| notifyEmail | Body | Boolean | 이메일 알림 여부 |
+| notifySms | Body | Boolean | SMS 알림 여부 |
+| isEnabled | Body | Boolean | 활성화 여부 |
+| dbInstances | Body | Array | 감시 대상 DB 인스턴스 목록 |
+| dbInstances.dbInstanceId | Body | String | DB 인스턴스의 식별자 |
+| dbInstances.dbInstanceName | Body | String | DB 인스턴스를 식별할 수 있는 이름 |
+| userGroups | Body | Array | 사용자 그룹 목록 |
+| userGroups.userGroupId | Body | String | 사용자 그룹의 식별자 |
+| userGroups.userGroupName | Body | String | 사용자 그룹을 식별할 수 있는 이름 |
+| createdYmdt | Body | DateTime | 생성 일시 |
+| updatedYmdt | Body | DateTime | 수정 일시 |
+
 <details><summary>예시</summary>
+<p>
 
 ```json
 {
@@ -4831,10 +4251,73 @@ DELETE /v1.0/notification-groups/{notificationGroupId}
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "notificationGroupId": "notificationGroupId-example",
+    "notificationGroupName": "notificationGroupName-example",
+    "notificationGroupStatus": "CREATED",
+    "notifyEmail": false,
+    "notifySms": false,
+    "isEnabled": false,
+    "dbInstances": [
+        {
+            "dbInstanceName": "dbInstanceName-example"
+        }
+    ],
+    "userGroups": [
+        {
+            "userGroupName": "userGroupName-example"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
+
+</p>
 </details>
+
+---
+
+### 알림 그룹 수정하기
+
+```http
+PUT /v1.0/notification-groups/{notificationGroupId}
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O | 알림 그룹의 식별자 |
+| notificationGroupName | Body | String | X | 알림 그룹을 식별할 수 있는 이름 |
+| notifyEmail | Body | Boolean | X | 이메일 알림 여부<br/>- 기본값: `false` |
+| notifySms | Body | Boolean | X | SMS 알림 여부<br/>- 기본값: `false` |
+| isEnabled | Body | Boolean | X | 활성화 여부<br/>- 기본값: `false` |
+| dbInstanceIds | Body | Array | O | 감시 대상 DB 인스턴스의 식별자 목록 |
+| userGroupIds | Body | Array | O | 사용자 그룹의 식별자 목록 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "notificationGroupName": "notificationGroupName-example",
+    "notifyEmail": false,
+    "notifySms": false,
+    "isEnabled": false,
+    "dbInstanceIds": [],
+    "userGroupIds": []
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
 
 ### 감시 설정 목록 보기
 
@@ -4842,30 +4325,28 @@ DELETE /v1.0/notification-groups/{notificationGroupId}
 GET /v1.0/notification-groups/{notificationGroupId}/watchdogs
 ```
 
-#### 필요 권한
-
-| 권한명                                        | 설명          |
-|--------------------------------------------|-------------|
-| RDSforPostgreSQL:NotificationWatchdog.List | 감시 설정 목록 보기 |
-
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O | 알림 그룹의 식별자 |
+
 #### 응답
 
-| 이름                           | 종류   | 형식       | 설명                                                                     |
-|------------------------------|------|----------|------------------------------------------------------------------------|
-| notificationGroupId          | URL  | UUID     | 알림 그룹의 식별자                                                             | 알림 그룹의 식별자                                                            |
-| watchdogs                    | Body | Array    | 감시 설정 목록                                                               |
-| watchdogs.watchdogId         | Body | UUID     | 감시 설정의 식별자                                                             |
-| watchdogs.metricName         | Body | Enum     | 감시 대상 성능 지표<br/>- 설정 가능한 성능 지표는 [성능 지표 목록 보기](#성능-지표-목록-보기) 항목을 참고합니다. |
-| watchdogs.comparisonOperator | Body | Enum     | 감시 대상 비교 방법<br/>- `LE`: <=<br/>- `LT`: <<br/>- `GE`: >=<br/>- `GT`: >  |
-| watchdogs.threshold          | Body | Long     | 감시 대상 임곗값                                                              |
-| watchdogs.duration           | Body | Long     | 감시 대상 지속 시간<br/>- 단위: `분`                                              |
-| watchdogs.createdYmdt        | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                      |
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| notificationWatchdogs | Body | Array | 감시 설정 정보 |
+| notificationWatchdogs.watchdogId | Body | String | 감시 설정의 식별자 |
+| notificationWatchdogs.metricName | Body | String | 감시 대상 성능 지표 |
+| notificationWatchdogs.comparisonOperator | Body | Enum | 감시 대상 비교 방법<br/>- LE: `<=`<br/>- LT: `<`<br/>- GE: `>=`<br/>- GT: `>` |
+| notificationWatchdogs.threshold | Body | Number | 감시 대상 임곗값 |
+| notificationWatchdogs.duration | Body | Number | 감시 대상 지속 시간 |
+| notificationWatchdogs.createdYmdt | Body | DateTime | 생성 일시 |
 
 <details><summary>예시</summary>
+<p>
 
 ```json
 {
@@ -4874,20 +4355,18 @@ GET /v1.0/notification-groups/{notificationGroupId}/watchdogs
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "watchdogs": [
+    "notificationWatchdogs": [
         {
-            "watchdogId": "b3901f17-9971-4d1e-8a81-8448cf533dc7",
-            "metricName": "DATABASE_STATUS",
-            "comparisonOperator": "LE",
-            "threshold": 0,
-            "duration": 5,
-            "createdYmdt": "2023-02-20T13:34:13+09:00",
-            "updatedYmdt": "2023-02-20T13:34:13+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
+
+</p>
 </details>
+
+---
 
 ### 감시 설정 생성하기
 
@@ -4895,40 +4374,76 @@ GET /v1.0/notification-groups/{notificationGroupId}/watchdogs
 POST /v1.0/notification-groups/{notificationGroupId}/watchdogs
 ```
 
-#### 필요 권한
-
-| 권한명                                          | 설명         |
-|----------------------------------------------|------------|
-| RDSforPostgreSQL:NotificationWatchdog.Create | 감시 설정 생성하기 |
-
 #### 요청
 
-| 이름                  | 종류   | 형식   | 필수 | 설명                                                                     |
-|---------------------|------|------|----|------------------------------------------------------------------------|
-| notificationGroupId | URL  | UUID | O  | 알림 그룹의 식별자                                                             |
-| metricName          | Body | Enum | O  | 감시 대상 성능 지표<br/>- 설정 가능한 성능 지표는 [성능 지표 목록 보기](#성능-지표-목록-보기) 항목을 참고합니다. |
-| comparisonOperator  | Body | Enum | O  | 감시 대상 비교 방법<br/>- `LE`: <=<br/>- `LT`: <<br/>- `GE`: >=<br/>- `GT`: >  |
-| threshold           | Body | Long | O  | 감시 대상 임곗값                                                              |
-| duration            | Body | Long | O  | 감시 대상 지속 시간<br/>- 단위: `분`                                              |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O | 알림 그룹의 식별자 |
+| metricName | Body | String | O | 감시 대상 성능 지표 |
+| comparisonOperator | Body | Enum | O | 감시 대상 비교 방법<br/>- LE: `<=`<br/>- LT: `<`<br/>- GE: `>=`<br/>- GT: `>` |
+| threshold | Body | Number | O | 감시 대상 임곗값<br/>- 최솟값: `0` |
+| duration | Body | Number | O | 감시 대상 지속 시간 (분)<br/>- 최솟값: `0` |
 
 <details><summary>예시</summary>
+<p>
 
 ```json
 {
-    "metricName": "DATABASE_STATUS",
+    "metricName": "metricName-example",
     "comparisonOperator": "LE",
     "threshold": 0,
-    "duration": 5
+    "duration": 0
 }
 ```
+
+</p>
 </details>
 
 #### 응답
 
-| 이름         | 종류   | 형식   | 설명         |
-|------------|------|------|------------|
-| watchdogId | Body | UUID | 감시 설정의 식별자 |
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| watchdogId | Body | String | 감시 설정의 식별자 |
 
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "watchdogId": "watchdogId-example"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 알림 그룹 삭제하기
+
+```http
+DELETE /v1.0/notification-groups/{notificationGroupId}/watchdogs/{watchdogId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O | 알림 그룹의 식별자 |
+| watchdogId | URL | UUID | O | 감시 설정의 식별자 |
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
 
 ### 감시 설정 수정하기
 
@@ -4936,40 +4451,85 @@ POST /v1.0/notification-groups/{notificationGroupId}/watchdogs
 PUT /v1.0/notification-groups/{notificationGroupId}/watchdogs/{watchdogId}
 ```
 
-#### 필요 권한
-
-| 권한명                                          | 설명         |
-|----------------------------------------------|------------|
-| RDSforPostgreSQL:NotificationWatchdog.Modify | 감시 설정 수정하기 |
-
 #### 요청
 
-| 이름                  | 종류   | 형식   | 필수 | 설명                                                                     |
-|---------------------|------|------|----|------------------------------------------------------------------------|
-| notificationGroupId | URL  | UUID | O  | 알림 그룹의 식별자                                                             |
-| watchdogId          | URL  | UUID | O  | 감시 설정의 식별자                                                             |
-| metricName          | Body | Enum | O  | 감시 대상 성능 지표<br/>- 설정 가능한 성능 지표는 [성능 지표 목록 보기](#성능-지표-목록-보기) 항목을 참고합니다. |
-| comparisonOperator  | Body | Enum | O  | 감시 대상 비교 방법<br/>- `LE`: <=<br/>- `LT`: <<br/>- `GE`: >=<br/>- `GT`: >  |
-| threshold           | Body | Long | O  | 감시 대상 임곗값                                                              |
-| duration            | Body | Long | O  | 감시 대상 지속 시간<br/>- 단위: `분`                                              |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O | 알림 그룹의 식별자 |
+| watchdogId | URL | UUID | O | 감시 설정의 식별자 |
+| metricName | Body | String | O | 감시 대상 성능 지표 |
+| comparisonOperator | Body | Enum | O | 감시 대상 비교 방법<br/>- LE: `<=`<br/>- LT: `<`<br/>- GE: `>=`<br/>- GT: `>` |
+| threshold | Body | Number | O | 감시 대상 임곗값<br/>- 최솟값: `0` |
+| duration | Body | Number | O | 감시 대상 지속 시간 (분)<br/>- 최솟값: `0` |
 
 <details><summary>예시</summary>
+<p>
 
 ```json
 {
-    "metricName": "DATABASE_STATUS",
+    "metricName": "metricName-example",
     "comparisonOperator": "LE",
     "threshold": 0,
-    "duration": 10
+    "duration": 0
 }
 ```
+
+</p>
 </details>
 
 #### 응답
 
 이 API는 응답 본문을 반환하지 않습니다.
 
+---
+
+## 작업 정보
+
+### 작업 상태
+
+| 상태명                | 설명                   |
+|--------------------|----------------------|
+| `PREPARING`        | 작업이 준비 중인 경우         |
+| `READY`            | 작업이 준비 완료된 경우        |
+| `RUNNING`          | 작업이 진행 중인 경우         |
+| `COMPLETED`        | 작업이 완료된 경우           |
+| `REGISTERED`       | 작업이 등록된 경우           |
+| `WAIT_TO_REGISTER` | 작업 등록 대기 중인 경우       |
+| `INTERRUPTED`      | 작업 진행 중 인터럽트가 발생한 경우 |
+| `CANCELED`         | 작업이 취소된 경우           |
+| `FAILED`           | 작업이 실패한 경우           |
+| `ERROR`            | 작업 진행 중 오류가 발생한 경우   |
+| `DELETED`          | 작업이 삭제된 경우           |
+| `FAIL_TO_READY`    | 작업 준비에 실패한 경우        |
+
+### 작업 정보 상세 보기
+
+```http
+GET /v1.0/jobs/{jobId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| jobId | URL | UUID | O |  |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | String | 작업의 식별자 |
+| jobStatus | Body | Enum | 작업의 현재 상태<br/>- DELETED<br/>- CANNOT_PROGRESS<br/>- FAILED<br/>- ERROR<br/>- CANCELED<br/>- INTERRUPTED<br/>- COMPLETED<br/>- COMPLETED_WITH_ERROR<br/>- RUNNING<br/>- PREPARING<br/>- READY<br/>- CREATED<br/>- FAIL_TO_READY<br/>- REGISTERED<br/>- FAIL_TO_REGISTER<br/>- WAIT_TO_REGISTER |
+| resourceRelations | Body | Array | 연관 리소스 목록 |
+| resourceRelations.resourceType | Body | String | 연관 리소스 유형 |
+| resourceRelations.resourceId | Body | String | 연관 리소스의 식별자 |
+| createdYmdt | Body | DateTime | 생성 일시 |
+| updatedYmdt | Body | DateTime | 수정 일시 |
+
 <details><summary>예시</summary>
+<p>
 
 ```json
 {
@@ -4977,76 +4537,189 @@ PUT /v1.0/notification-groups/{notificationGroupId}/watchdogs/{watchdogId}
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "jobId": "jobId-example",
+    "jobStatus": "DELETED",
+    "resourceRelations": [
+        {
+            "resourceId": "resourceId-example"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
+
+</p>
 </details>
 
-### 감시 설정 삭제하기
+---
+
+## 파라미터 그룹
+
+### 파라미터 그룹 목록 보기
 
 ```http
-DELETE /v1.0/notification-groups/{notificationGroupId}/watchdogs/{watchdogId}
+GET /v1.0/parameter-groups
 ```
-
-#### 필요 권한
-
-| 권한명                                          | 설명         |
-|----------------------------------------------|------------|
-| RDSforPostgreSQL:NotificationWatchdog.Delete | 감시 설정 삭제하기 |
 
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름                  | 종류  | 형식   | 필수 | 설명         |
-|---------------------|-----|------|----|------------|
-| notificationGroupId | URL | UUID | O  | 알림 그룹의 식별자 |
-| watchdogId          | URL | UUID | O  | 감시 설정의 식별자 |
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| parameterGroups | Body | Array | 파라미터 그룹 목록 |
+| parameterGroups.parameterGroupId | Body | String | 파라미터 그룹의 식별자 |
+| parameterGroups.parameterGroupName | Body | String | 파라미터 그룹을 식별할 수 있는 이름 |
+| parameterGroups.description | Body | String | 파라미터 그룹에 대한 추가 정보 |
+| parameterGroups.dbVersion | Body | Enum | DB 엔진 버전 |
+| parameterGroups.parameterGroupStatus | Body | Enum | 파라미터 그룹의 현재 상태<br/>- STABLE: `적용 완료`<br/>- NEED_TO_APPLY: `적용 필요`<br/>- DELETED: `삭제됨` |
+| parameterGroups.createdYmdt | Body | DateTime | 생성 일시 |
+| parameterGroups.updatedYmdt | Body | DateTime | 수정 일시 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "parameterGroups": [
+        {
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### 파라미터 그룹 생성하기
+
+```http
+POST /v1.0/parameter-groups
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupName | Body | String | O | 파라미터 그룹을 식별할 수 있는 이름 |
+| description | Body | String | X | 파라미터 그룹에 대한 추가 정보 |
+| dbVersion | Body | Enum | O | DB 엔진 버전 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "parameterGroupName": "parameterGroupName-example",
+    "description": "description-example",
+    "dbVersion": "ENUM_VALUE"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| parameterGroupId | Body | String | 파라미터 그룹의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "parameterGroupId": "parameterGroupId-example"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 파라미터 그룹 삭제하기
+
+```http
+DELETE /v1.0/parameter-groups/{parameterGroupId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O | 파라미터 그룹 ID |
 
 #### 응답
 
 이 API는 응답 본문을 반환하지 않습니다.
 
-<details><summary>예시</summary>
+---
 
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
-
-## 모니터링
-
-### 성능 지표 목록 보기
+### 파라미터 그룹 상세 조회
 
 ```http
-GET /v1.0/metrics
+GET /v1.0/parameter-groups/{parameterGroupId}
 ```
-
-#### 필요 권한
-
-| 권한명                          | 설명       |
-|------------------------------|----------|
-| RDSforPostgreSQL:Metric.List | 통계 정보 조회 |
 
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O | 파라미터 그룹 ID |
+
 #### 응답
 
-| 이름                 | 종류   | 형식     | 설명       |
-|--------------------|------|--------|----------|
-| metrics            | Body | Array  | 성능 지표 목록 |
-| metrics.metricName | Body | Enum   | 성능 지표 유형 |
-| metrics.unit       | Body | String | 측정값 단위   |
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| parameterGroupId | Body | String | 파라미터 그룹의 식별자 |
+| parameterGroupName | Body | String | 파라미터 그룹을 식별할 수 있는 이름 |
+| description | Body | String | 파라미터 그룹에 대한 추가 정보 |
+| dbVersion | Body | Enum | DB 엔진 버전 |
+| parameterGroupStatus | Body | Enum | 파라미터 그룹의 현재 상태<br/>- STABLE: `적용 완료`<br/>- NEED_TO_APPLY: `적용 필요`<br/>- DELETED: `삭제됨` |
+| parameters | Body | Array | 파라미터 정보 |
+| parameters.parameterCategory | Body | String | 파라미터 카테고리 |
+| parameters.parameterName | Body | String | 파라미터 이름 |
+| parameters.value | Body | String | 현재 설정된 값 |
+| parameters.valueUnit | Body | String | 값 단위 (바이트: B,kB,MB,GB,TB, 시간: us,ms,s,min,h,d) |
+| parameters.defaultValue | Body | String | 기본값 |
+| parameters.allowedValue | Body | String | 허용된 값 |
+| parameters.valueType | Body | Enum | 값 타입<br/>- BOOLEAN: `불린 타입
+ * ex) on, off, true, false, yes, no, 1, 0`<br/>- STRING: `문자열`<br/>- NUMERIC: `정수 및 부동 소수점`<br/>- NUMERIC_WITH_BYTE_UNIT: `단위가 있는 숫자
+ * ex) 120kB, 100MB
+ * 허용된 바이트 단위: B (bytes), kB (kilobytes), MB (megabytes), GB (gigabytes), and TB (terabytes)`<br/>- NUMERIC_WITH_TIME_UNIT: `단위가 있는 숫자
+ * ex) 120ms, 100s, 1d
+ * 허용된 시간 단위: us (microseconds), ms (milliseconds), s (seconds), min (minutes), h (hours), and d (days)`<br/>- ENUMERATED: `allowed_value에 선언된 값 중 한 개 선택 (콤마(,)로 구분됨)`<br/>- MULTI_ENUMERATED: `allowed_value에 선언된 값 중 여러개 선택 (콤마(,)로 구분됨)` |
+| parameters.updateType | Body | Enum | 수정 타입<br/>- VARIABLE: `동적, 언제든 수정 가능`<br/>- CONSTANT: `수정 불가능` |
+| parameters.applyType | Body | Enum | 적용 타입<br/>- BOTH: `세션, 파일 모두 적용`<br/>- SESSION: `세션에만 적용`<br/>- FILE: `파일에만 적용` |
+| parameters.expressionAvailable | Body | Boolean | 수식 허용 여부 |
+| createdYmdt | Body | DateTime | 생성 일시 |
+| updatedYmdt | Body | DateTime | 수정 일시 |
 
 <details><summary>예시</summary>
+<p>
 
 ```json
 {
@@ -5055,121 +4728,94 @@ GET /v1.0/metrics
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "metrics": [
+    "parameterGroupId": "parameterGroupId-example",
+    "parameterGroupName": "parameterGroupName-example",
+    "description": "description-example",
+    "dbVersion": "ENUM_VALUE",
+    "parameterGroupStatus": "STABLE",
+    "parameters": [
         {
-            "metricName": "CPU_USAGE",
-            "unit": "%"
+            "expressionAvailable": false
         }
-    ]
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
+
+</p>
 </details>
 
-### 통계 정보 조회
+---
+
+### 파라미터 그룹 수정하기
 
 ```http
-GET /v1.0/metric-statistics
+PUT /v1.0/parameter-groups/{parameterGroupId}
 ```
-
-#### 필요 권한
-
-| 권한명                          | 설명       |
-|------------------------------|----------|
-| RDSforPostgreSQL:Metric.List | 통계 정보 조회 |
 
 #### 요청
 
-| 이름           | 종류    | 형식       | 필수 | 설명                                                        |
-|--------------|-------|----------|----|-----------------------------------------------------------|
-| dbInstanceId | Query | UUID     | O  | DB 인스턴스의 식별자                                              |
-| metricNames  | Query | Array    | O  | 조회할 성능 지표 목록<br/>- 최소 크기: `1`                             |
-| from         | Query | Datetime | O  | 시작 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                         |
-| to           | Query | Datetime | O  | 종료 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                         |
-| interval     | Query | Number   | X  | 조회 간격<br/>- 단위: `분`<br/>- 기본값: 시작/종료 일시에 따라 적절한 값을 자동 선택함 |
-
-#### 응답
-
-| 이름                                | 종류   | 형식        | 설명       |
-|-----------------------------------|------|-----------|----------|
-| metricStatistics                  | Body | Array     | 통계 정보 목록 |
-| metricStatistics.metricName       | Body | Enum      | 성능 지표 유형 |
-| metricStatistics.unit             | Body | String    | 측정값 단위   |
-| metricStatistics.values           | Body | Array     | 측정값 목록   |
-| metricStatistics.values.timestamp | Body | Timestamp | 측정 시간    |
-| metricStatistics.values.value     | Body | Object    | 측정값      |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O | 파라미터 그룹 ID |
+| parameterGroupName | Body | String | X | 파라미터 그룹을 식별할 수 있는 이름 |
+| description | Body | String | X | 파라미터 그룹에 대한 추가 정보 |
 
 <details><summary>예시</summary>
+<p>
 
 ```json
 {
-    "metricStatistics": [
-        {
-            "metricName": "DATABASE_STATUS",
-            "unit": "",
-            "values": [
-                [
-                    1679298540,
-                    "1"
-                ],
-                [
-                    1679298600,
-                    "1"
-                ],
-                [
-                    1679298660,
-                    "1"
-                ]
-            ]
-        }
-    ]
+    "parameterGroupName": "parameterGroupName-example",
+    "description": "description-example"
 }
 ```
+
+</p>
 </details>
-
-## 이벤트
-
-### 이벤트 목록 보기
-
-```
-GET /v1.0/events
-```
-
-#### 필요 권한
-
-| 권한명                         | 설명        |
-|-----------------------------|-----------|
-| RDSforPostgreSQL:Event.List | 이벤트 목록 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름                | 종류    | 형식       | 필수 | 설명                                                                                                                                                                               |
-|-------------------|-------|----------|----|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| page              | Query | Number   | O  | 조회할 목록의 페이지<br/>- 최솟값: `1`                                                                                                                                                       |
-| size              | Query | Number   | O  | 조회할 목록의 페이지 크기<br/>- 최솟값: `1`<br/>- 최댓값: `100`                                                                                                                                   |
-| from              | Query | Datetime | O  | 시작 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                |
-| to                | Query | Datetime | O  | 종료 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                |
-| eventCategoryType | Query | Enum     | O  | 조회할 이벤트 카테고리 유형<br/>- `ALL`: 전체<br/>- `BACKUP`: 백업<br/>- `DB_INSTANCE`: DB 인스턴스<br/>- `DB_SECURITY_GROUP`: DB 보안 그룹<br/>- `JOB`: 작업<br/>- `TENANT`: 테넌트<br/>- `MONITORING`: 모니터링 |
-| sourceId          | Query | String   | X  | 이벤트가 발생한 대상 리소스의 식별자                                                                                                                                                             |
-| keyword           | Query | String   | X  | 이벤트 메시지에 포함된 문자열 검색어                                                                                                                                                             |
 
 #### 응답
 
-| 이름                       | 종류   | 형식       | 설명                                                 |
-|--------------------------|------|----------|----------------------------------------------------|
-| totalCounts              | Body | Number   | 전체 이벤트 목록 수                                        |
-| events                   | Body | Array    | 이벤트 목록                                             |
-| events.eventCategoryType | Body | Enum     | 이벤트 카테고리 유형                                        |
-| events.eventCode         | Body | Enum     | 발생한 이벤트의 유형<br/>- 자세한 설명은 [이벤트](event/) 항목을 참고합니다. |
-| events.sourceId          | Body | String   | 이벤트 소스의 식별자                                        |
-| events.sourceName        | Body | String   | 이벤트 소스를 식별할 수 있는 이름                                |
-| events.messages          | Body | Array    | 이벤트 메시지 목록                                         |
-| events.messages.langCode | Body | String   | 언어 코드                                              |
-| events.messages.message  | Body | String   | 이벤트 메시지                                            |
-| events.eventYmdt         | Body | DateTime | 이벤트 발생 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)              |
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### 파라미터 그룹 복사하기
+
+```http
+POST /v1.0/parameter-groups/{parameterGroupId}/copy
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O | 파라미터 그룹 ID |
+| parameterGroupName | Body | String | O | 파라미터 그룹을 식별할 수 있는 이름 |
+| description | Body | String | X | 파라미터 그룹에 대한 추가 정보 |
 
 <details><summary>예시</summary>
+<p>
+
+```json
+{
+    "parameterGroupName": "parameterGroupName-example",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| parameterGroupId | Body | String | 파라미터 그룹의 식별자 |
+
+<details><summary>예시</summary>
+<p>
 
 ```json
 {
@@ -5178,50 +4824,79 @@ GET /v1.0/events
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "totalCounts": 28,
-    "events": [
+    "parameterGroupId": "parameterGroupId-example"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 파라미터 그룹 내 파라미터 수정하기
+
+```http
+PUT /v1.0/parameter-groups/{parameterGroupId}/parameters
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O | 파라미터 그룹 ID |
+| modifiedParameters | Body | Array | O | 변경할 파라미터 목록 |
+| modifiedParameters.parameterName | Body | String | O | 파라미터 이름 |
+| modifiedParameters.value | Body | String | O | 변경할 파라미터 값 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "modifiedParameters": [
         {
-            "eventCategoryType": "DB_INSTANCE",
-            "eventCode": "DB_INSTANCE_02_01",
-            "sourceId": "76f00947-356e-4a20-8922-428368cc45ed",
-            "sourceName": "db-instance",
-            "messages": [
-                {
-                    "langCode": "EN",
-                    "message": "DB instance started"
-                },
-                {
-                    "langCode": "JA",
-                    "message": "DBインスタンスの起動"
-                },
-                {
-                    "langCode": "KO",
-                    "message": "DB 인스턴스 시작"
-                },
-                {
-                    "langCode": "ZH",
-                    "message": "DB instance started"
-                }
-            ],
-            "eventYmdt": "2023-03-20T16:31:59+09:00"
+            "value": "value-example"
         }
     ]
 }
 ```
+
+</p>
 </details>
 
+#### 응답
 
-### 구독 가능한 이벤트 코드 목록 보기
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### 파라미터 그룹 재설정하기
 
 ```http
-GET /v1.0/event-codes
+PUT /v1.0/parameter-groups/{parameterGroupId}/reset
 ```
 
-#### 필요 권한
+#### 요청
 
-| 권한명                         | 설명        |
-|-----------------------------|-----------|
-| RDSforPostgreSQL:Event.List | 이벤트 목록 보기 |
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O | 파라미터 그룹 ID |
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+## 프로젝트
+
+### 프로젝트의 멤버 목록 조회
+
+```http
+GET /v1.0/project/members
+```
 
 #### 요청
 
@@ -5229,13 +4904,16 @@ GET /v1.0/event-codes
 
 #### 응답
 
-| 이름                           | 종류   | 형식    | 설명          |
-|------------------------------|------|-------|-------------|
-| eventCodes                   | Body | Array | 이벤트 코드 목록   |
-| eventCodes.eventCode         | Body | Enum  | 이벤트 코드      |
-| eventCodes.eventCategoryType | Body | Enum  | 이벤트 카테고리 유형 |
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| projectMembers | Body | Array | 프로젝트 멤버 정보 |
+| projectMembers.memberId | Body | String | 프로젝트 멤버의 식별자 |
+| projectMembers.memberName | Body | String | 프로젝트 멤버의 이름 |
+| projectMembers.emailAddress | Body | String | 프로젝트 멤버의 이메일 주소 |
+| projectMembers.phoneNumber | Body | String | 프로젝트 멤버의 전화번호 |
 
 <details><summary>예시</summary>
+<p>
 
 ```json
 {
@@ -5244,12 +4922,57 @@ GET /v1.0/event-codes
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "eventCodes": [
+    "projectMembers": [
         {
-            "eventCode": "DB_INSTANCE_02_01",
-            "eventCategoryType": "DB_INSTANCE"
+            "phoneNumber": "phoneNumber-example"
         }
     ]
 }
 ```
+
+</p>
 </details>
+
+---
+
+### 프로젝트의 리전 목록 조회
+
+```http
+GET /v1.0/project/regions
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| regions | Body | Array | 리전 정보 |
+| regions.regionCode | Body | Enum | 리전 코드<br/>- KR1: `한국(판교)`<br/>- KR2: `한국(평촌)` |
+| regions.isEnabled | Body | Boolean | 리전의 활성화 여부 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "regions": [
+        {
+            "isEnabled": false
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+

--- a/template-builder/config/public.json
+++ b/template-builder/config/public.json
@@ -20,5 +20,7 @@
       "endpoint": "https://kr1-rds-postgres.api.nhncloudservice.com"
     }
   ],
-  "exclusionDocs": []
+  "exclusionDocs": [
+    "api-guide-v1.0"
+  ]
 }


### PR DESCRIPTION
## 개요
nc-rds `feature/4321` 의 API 가이드 생성기 출력으로 `ko/api-guide-v1.0.md` 를 동기화합니다.

## 핵심 변경
- **백업 복제 리전(replicationRegion)/리전 코드 노출을 PostgreSQL public 가용 리전 KR1, KR2 로 정합화**
  - 근거: 배포 config `region.master-region`(kr1) + `slave-regions`(kr2)

## 참고
- 생성기 기준 전체 재생성이라 표 정렬/문구 등 포맷 차이가 diff 에 포함됩니다.
- 대상: ko 한국어, public(api-guide-v1.0.md).
- **ngovc/ngoic 환경**: 현재 repo 에 PostgreSQL API 가이드의 환경별 페이지(`api-guide-v1.0-ngovc.md` 등)가 없어 이번 PR 범위에서 제외했습니다. 생성기에는 ngovc/ngoic(각 KR4) 가이드가 있으므로, 신규 페이지로 추가할지는 별도 결정 필요.