### PR TITLE
docs(ko): API 가이드 예시 품질 개선 (nhn-api-codex 1.0.4)

### DIFF
--- a/ko/api-guide-v1.0.md
+++ b/ko/api-guide-v1.0.md
@@ -205,8 +205,8 @@ GET /v1.0/project/members
         {
             "memberId": "550e8400-e29b-41d4-a716-446655440000",
             "memberName": "memberName-example",
-            "emailAddress": "emailAddress-example",
-            "phoneNumber": "phoneNumber-example"
+            "emailAddress": "user@example.com",
+            "phoneNumber": "010-1234-5678"
         }
     ]
 }
@@ -308,7 +308,7 @@ GET /v1.0/network/subnets
         {
             "subnetId": "550e8400-e29b-41d4-a716-446655440000",
             "subnetName": "subnetName-example",
-            "subnetCidr": "subnetCidr-example",
+            "subnetCidr": "192.168.0.0/24",
             "usingGateway": false,
             "availableIpCount": 1
         }
@@ -956,7 +956,7 @@ POST /v1.0/db-instances
 | backup.backupPeriod | Body | Number | O | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
 | backup.backupRetryCount | Body | Number | X | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
 | backup.backupSchedules | Body | Array | O | 백업 스케쥴 정보 |
-| backup.backupSchedules.backupWndBgnTime | Body | String | O | 백업 시작 시각 |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | O | 백업 시작 시각 |
 | backup.backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 
 <details><summary>예시</summary>
@@ -995,7 +995,7 @@ POST /v1.0/db-instances
         "backupRetryCount": 0,
         "backupSchedules": [
             {
-                "backupWndBgnTime": "backupWndBgnTime-example",
+                "backupWndBgnTime": "00:00:00",
                 "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
@@ -1069,7 +1069,7 @@ POST /v1.0/db-instances/restore-from-obs
 | backup.backupRetryCount | Body | Number | X | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
 | backup.replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)`<br/>- KR2: `한국(평촌)` |
 | backup.backupSchedules | Body | Array | O | 백업 스케쥴 목록 |
-| backup.backupSchedules.backupWndBgnTime | Body | String | O | 백업 시작 시각 |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | O | 백업 시작 시각 |
 | backup.backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 | restore | Body | Object | O | 복원 정보 객체 |
 | restore.tenantId | Body | String | O | 백업이 저장된 오브젝트 스토리지의 테넌트 ID |
@@ -1113,7 +1113,7 @@ POST /v1.0/db-instances/restore-from-obs
         "replicationRegion": "KR1",
         "backupSchedules": [
             {
-                "backupWndBgnTime": "backupWndBgnTime-example",
+                "backupWndBgnTime": "00:00:00",
                 "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
@@ -1555,7 +1555,7 @@ GET /v1.0/db-instances/{dbInstanceId}/backup-info
 | backupPeriod | Body | Number | 백업 보관 기간(일) |
 | backupRetryCount | Body | Number | 백업 재시도 횟수 |
 | backupSchedules | Body | Array | 백업 스케쥴 목록 |
-| backupSchedules.backupWndBgnTime | Body | String | 백업 시작 시각 |
+| backupSchedules.backupWndBgnTime | Body | Time | 백업 시작 시각 |
 | backupSchedules.backupWndDuration | Body | Enum | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 
 <details><summary>예시</summary>
@@ -1574,7 +1574,7 @@ GET /v1.0/db-instances/{dbInstanceId}/backup-info
     "backupRetryCount": 1,
     "backupSchedules": [
         {
-            "backupWndBgnTime": "backupWndBgnTime-example",
+            "backupWndBgnTime": "00:00:00",
             "backupWndDuration": "HALF_AN_HOUR"
         }
     ]
@@ -1608,7 +1608,7 @@ PUT /v1.0/db-instances/{dbInstanceId}/backup-info
 | backupPeriod | Body | Number | X | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
 | backupRetryCount | Body | Number | X | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
 | backupSchedules | Body | Array | X | 백업 스케쥴 목록 |
-| backupSchedules.backupWndBgnTime | Body | String | O | 백업 시작 시각 |
+| backupSchedules.backupWndBgnTime | Body | Time | O | 백업 시작 시각 |
 | backupSchedules.backupWndDuration | Body | Enum | O | 백업 윈도우<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 
 <details><summary>예시</summary>
@@ -1622,7 +1622,7 @@ PUT /v1.0/db-instances/{dbInstanceId}/backup-info
     "backupRetryCount": 0,
     "backupSchedules": [
         {
-            "backupWndBgnTime": "backupWndBgnTime-example",
+            "backupWndBgnTime": "00:00:00",
             "backupWndDuration": "HALF_AN_HOUR"
         }
     ]
@@ -2871,7 +2871,7 @@ GET /v1.0/db-instances/{dbInstanceId}/maintenance-info
 |-----|-----|-----|-----|
 | allowAutoMaintenance | Body | Boolean | 자동 유지보수 허용 여부 |
 | useAutoStorageCleanup | Body | Boolean | 자동 스토리지 정리 사용 여부 |
-| maintWndBgnTime | Body | String | 자동 유지보수 시작 시간 |
+| maintWndBgnTime | Body | Time | 자동 유지보수 시작 시간 |
 | maintWndDuration | Body | Enum | 유지보수 윈도우<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 | logRetentionPeriod | Body | Number | 로그 보관 기간 (일) |
 
@@ -2887,7 +2887,7 @@ GET /v1.0/db-instances/{dbInstanceId}/maintenance-info
     },
     "allowAutoMaintenance": false,
     "useAutoStorageCleanup": false,
-    "maintWndBgnTime": "maintWndBgnTime-example",
+    "maintWndBgnTime": "00:00:00",
     "maintWndDuration": "HALF_AN_HOUR",
     "logRetentionPeriod": 1
 }
@@ -2917,7 +2917,7 @@ PUT /v1.0/db-instances/{dbInstanceId}/maintenance-info
 | dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
 | allowAutoMaintenance | Body | Boolean | X | 자동 유지보수 허용 여부 |
 | useAutoStorageCleanup | Body | Boolean | X | 자동 스토리지 정리 사용 여부 |
-| maintWndBgnTime | Body | String | X | 자동 유지보수 시작 시간 |
+| maintWndBgnTime | Body | Time | X | 자동 유지보수 시작 시간 |
 | maintWndDuration | Body | Enum | X | 유지보수 윈도우<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 | logRetentionPeriod | Body | Number | X | 로그 보관 기간 (일)<br/>- 최솟값: `1`<br/>- 최댓값: `30` |
 
@@ -2928,7 +2928,7 @@ PUT /v1.0/db-instances/{dbInstanceId}/maintenance-info
 {
     "allowAutoMaintenance": false,
     "useAutoStorageCleanup": false,
-    "maintWndBgnTime": "maintWndBgnTime-example",
+    "maintWndBgnTime": "00:00:00",
     "maintWndDuration": "HALF_AN_HOUR",
     "logRetentionPeriod": 1
 }
@@ -3011,14 +3011,14 @@ GET /v1.0/db-instances/{dbInstanceId}/network-info
     "subnet": {
         "subnetId": "550e8400-e29b-41d4-a716-446655440000",
         "subnetName": "subnetName-example",
-        "subnetCidr": "subnetCidr-example",
+        "subnetCidr": "192.168.0.0/24",
         "publicAccessible": false
     },
     "endPoints": [
         {
             "domain": "domain-example",
-            "ipAddress": "ipAddress-example",
-            "endPointType": "endPointType-example"
+            "ipAddress": "192.168.0.1",
+            "endPointType": "https://example.com"
         }
     ]
 }
@@ -3379,7 +3379,7 @@ POST /v1.0/db-instances/{dbInstanceId}/restore
 | backup.backupRetryCount | Body | Number | X | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
 | backup.replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)`<br/>- KR2: `한국(평촌)` |
 | backup.backupSchedules | Body | Array | O | 백업 스케쥴 목록 |
-| backup.backupSchedules.backupWndBgnTime | Body | String | O | 백업 시작 시각 |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | O | 백업 시작 시각 |
 | backup.backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 | restore | Body | Object | O | 복원 정보 객체 |
 | restore.restoreType | Body | Enum | O | 복원 타입<br/>- BACKUP: `기존에 생성한 백업을 이용한 복원`<br/>- TIMESTAMP: `복원 가능한 시간 이내의 시간을 이용한 시점 복원` |
@@ -3420,7 +3420,7 @@ POST /v1.0/db-instances/{dbInstanceId}/restore
         "replicationRegion": "KR1",
         "backupSchedules": [
             {
-                "backupWndBgnTime": "backupWndBgnTime-example",
+                "backupWndBgnTime": "00:00:00",
                 "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
@@ -3891,7 +3891,7 @@ POST /v1.0/backups/{backupId}/restore
 | backup.backupPeriod | Body | Number | O | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
 | backup.backupRetryCount | Body | Number | X | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
 | backup.backupSchedules | Body | Array | O | 백업 스케쥴 목록 |
-| backup.backupSchedules.backupWndBgnTime | Body | String | O | 백업 시작 시간 |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | O | 백업 시작 시간 |
 | backup.backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 
 <details><summary>예시</summary>
@@ -3926,7 +3926,7 @@ POST /v1.0/backups/{backupId}/restore
         "backupRetryCount": 0,
         "backupSchedules": [
             {
-                "backupWndBgnTime": "backupWndBgnTime-example",
+                "backupWndBgnTime": "00:00:00",
                 "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
@@ -4075,7 +4075,7 @@ POST /v1.0/db-security-groups
                 "minPort": 1,
                 "maxPort": 1
             },
-            "cidr": "cidr-example",
+            "cidr": "192.168.0.0/24",
             "description": "description-example"
         }
     ]
@@ -4208,7 +4208,7 @@ GET /v1.0/db-security-groups/{dbSecurityGroupId}
                     "minPort": 1,
                     "maxPort": 1
                 },
-                "cidr": "cidr-example",
+                "cidr": "192.168.0.0/24",
                 "createdYmdt": "2023-12-31T15:00:00+09:00",
                 "updatedYmdt": "2023-12-31T15:00:00+09:00"
             }
@@ -4347,7 +4347,7 @@ POST /v1.0/db-security-groups/{dbSecurityGroupId}/rules
         "minPort": 1,
         "maxPort": 1
     },
-    "cidr": "cidr-example",
+    "cidr": "192.168.0.0/24",
     "description": "description-example"
 }
 ```
@@ -4419,7 +4419,7 @@ PUT /v1.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
         "minPort": 1,
         "maxPort": 1
     },
-    "cidr": "cidr-example",
+    "cidr": "192.168.0.0/24",
     "description": "description-example"
 }
 ```


### PR DESCRIPTION
## 요약
기존 PR(`feature/4321`, nhn-api-codex 1.0.3) 위에 **예시 품질 개선분(1.0.4)만** 분리한 PR.
base 가 `feature/4321` 이라 diff = 1.0.3→1.0.4 예시 개선만 보입니다.

## 변경
- email/cidr/phone/ip/uuid → 형식에 맞는 실제 예시 (placeholder 제거)
- 시각 필드(LocalTime) 형식 표기 String→Time, 예시 `00:00:00`
- nc-rds feature/4321 코드 기반 재생성 (nhn-api-codex 1.0.4)

## 비고
nhn-api-codex 1.0.4 Nexus 릴리스 + nc-rds 의존 bump 완료. 검토 후 feature/4321 로 머지.