### PR TITLE
docs: feature/4321 API 가이드 EN/JA 번역 추가

### DIFF
--- a/en/api-guide-v1.0.md
+++ b/en/api-guide-v1.0.md
@@ -56,20 +56,7 @@ The API responds with "200 OK" to all API requests. For more information on the 
 | resultMessage | String    | Result message                           |
 | successful    | Boolean   | Successful or not                        |
 
-## DB version
-
-| DB version        | Available for creation |
-|-------------------|------------------------|
-| POSTGRESQL_V14_6  |                        |
-| POSTGRESQL_V14_15 |                        |
-| POSTGRESQL_V14_17 | O                      |
-| POSTGRESQL_V14_19 | O                      |
-| POSTGRESQL_V17_2  |                        |
-| POSTGRESQL_V17_4  | O                      |
-| POSTGRESQL_V17_6  | O                      |
-
-* You can use that value for dbVersion fields of type ENUM.
-* Depending on the version, there may be some cases where it is not possible to create or restore.
+## DB Version
 
 ### View DB Version List
 
@@ -77,10 +64,10 @@ The API responds with "200 OK" to all API requests. For more information on the 
 GET /v1.0/db-versions
 ```
 
-#### Required permissions
+#### Required Permissions
 
-| Permission Name                 | Description          |
-|---------------------------------|----------------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforPostgreSQL:DbVersion.List | View DB Version List |
 
 #### Request
@@ -89,14 +76,16 @@ This API does not require a request body.
 
 #### Response
 
-| Name                         | Type | Format  | Description                                           |
-|------------------------------|------|---------|-------------------------------------------------------|
-| dbVersions                   | Body | Array   | DB version list                                       |
-| dbVersions.dbVersion         | Body | String  | DB version                                            |
-| dbVersions.dbVersionName     | Body | String  | DB version name                                       |
-| dbVersions.restorableFromObs | Body | Boolean | Restoring backup from object storage available or not |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| dbVersions | Body | Array | DB version information |
+| dbVersions.dbVersionCode | Body | Enum | DB version code<br/>- MYSQL_V5633<br/>- MYSQL_V5715<br/>- MYSQL_V5719<br/>- MYSQL_V5726<br/>- MYSQL_V5731<br/>- MYSQL_V5733<br/>- MYSQL_V5737<br/>- MYSQL_V8018<br/>- MYSQL_V8023<br/>- MYSQL_V8028<br/>- MYSQL_V8032<br/>- MYSQL_V8033<br/>- MYSQL_V8034<br/>- MYSQL_V8035<br/>- MYSQL_V8036<br/>- MYSQL_V8040<br/>- MYSQL_V8041<br/>- MYSQL_V8042<br/>- MYSQL_V8043<br/>- MYSQL_V8044<br/>- MYSQL_V8045<br/>- MYSQL_V8405<br/>- MYSQL_V8406<br/>- MYSQL_V8407<br/>- MYSQL_V8408<br/>- MYSQL_V8409<br/>- MARIADB_V10330<br/>- MARIADB_V10611<br/>- MARIADB_V10612<br/>- MARIADB_V10616<br/>- MARIADB_V10622<br/>- MARIADB_V10625<br/>- MARIADB_V101107<br/>- MARIADB_V101108<br/>- MARIADB_V101113<br/>- MARIADB_V101116<br/>- MARIADB_V11407<br/>- MARIADB_V11410<br/>- MARIADB_V11806<br/>- POSTGRESQL_V14_6<br/>- POSTGRESQL_V14_15<br/>- POSTGRESQL_V14_17<br/>- POSTGRESQL_V14_19<br/>- POSTGRESQL_V17_2<br/>- POSTGRESQL_V17_4<br/>- POSTGRESQL_V17_6 |
+| dbVersions.dbMajorVersionCode | Body | Enum | DB major version code<br/>- MYSQL_V56<br/>- MYSQL_V57<br/>- MYSQL_V80<br/>- MYSQL_V84<br/>- MARIADB_V103<br/>- MARIADB_V106<br/>- MARIADB_V1011<br/>- MARIADB_V114<br/>- MARIADB_V118<br/>- POSTGRES_V14<br/>- POSTGRES_V17 |
+| dbVersions.name | Body | String | DB version name |
+| dbVersions.canCreate | Body | Boolean | Whether new creation is available |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -107,14 +96,19 @@ This API does not require a request body.
     },
     "dbVersions": [
         {
-            "dbVersion": "POSTGRESQL_V17_6",
-            "dbVersionName": "PostgreSQL V17.6",
-            "restorableFromObs": true
+            "dbVersionCode": "MYSQL_V5633",
+            "dbMajorVersionCode": "MYSQL_V56",
+            "name": "PostgreSQL V14.6",
+            "canCreate": false
         }
     ]
 }
 ```
+
+</p>
 </details>
+
+---
 
 ## Specifications of DB Instance
 
@@ -124,10 +118,10 @@ This API does not require a request body.
 GET /v1.0/db-flavors
 ```
 
-#### Required permissions
+#### Required Permissions
 
-| Permission Name                            | Description               |
-|--------------------------------|------------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforPostgreSQL:DbFlavor.List | List DB Instance Specifications |
 
 #### Request
@@ -136,15 +130,16 @@ This API does not require a request body.
 
 #### Response
 
-| Name                     | Type   | Format     | Description              |
-|------------------------|------|--------|-----------------|
-| dbFlavors              | Body | Array  | List of DB instance specifications   |
-| dbFlavors.dbFlavorId   | Body | UUID   | Identifier of DB instance specifications |
-| dbFlavors.dbFlavorName | Body | String | Name of DB instance specifications   |
-| dbFlavors.ram          | Body | Number | Memory size (MB)      |
-| dbFlavors.vcpus        | Body | Number | CPU cores        |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| dbFlavors | Body | Array | List of DB instance specifications |
+| dbFlavors.dbFlavorId | Body | UUID | Identifier of DB instance specifications |
+| dbFlavors.dbFlavorName | Body | String | Name of DB instance specifications |
+| dbFlavors.ram | Body | Number | Memory size (MB) |
+| dbFlavors.vcpus | Body | Number | CPU cores |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -155,29 +150,33 @@ This API does not require a request body.
     },
     "dbFlavors": [
         {
-            "dbFlavorId": "50be6d9c-02d6-4594-a2d4-12010eb65ec0",
-            "dbFlavorName": "m2.c1m2",
-            "ram": 2048,
-            "vcpus": 1
+            "dbFlavorId": "289e34e9-cd8a-4baf-82e3-a3d013c5186b",
+            "dbFlavorName": "r2.c2m4",
+            "ram": 4096,
+            "vcpus": 2
         }
     ]
 }
 ```
+
+</p>
 </details>
+
+---
 
 ## Project Information
 
-### List Regions
+### List Project Members
 
 ```http
-GET /v1.0/project/regions
+GET /v1.0/project/members
 ```
 
-#### Required permissions
+#### Required Permissions
 
-| Permission Name                          | Description         |
-|------------------------------|------------|
-| RDSforPostgreSQL:Project.Get | Get project information |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:Project.Get | List Project Members |
 
 #### Request
 
@@ -185,13 +184,66 @@ This API does not require a request body.
 
 #### Response
 
-| Name                 | Type   | Format      | Description                           |
-|--------------------|------|---------|------------------------------|
-| regions            | Body | Array   | Region list                        |
-| regions.regionCode | Body | Enum    | Region code<br/>`KR1`: Korea (Pangyo) Region |
-| regions.isEnabled  | Body | Boolean | Whether to enable a region                   |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| projectMembers | Body | Array | Project member information |
+| projectMembers.memberId | Body | UUID | Project member identifier |
+| projectMembers.memberName | Body | String | Project member name |
+| projectMembers.emailAddress | Body | String | Project member email address |
+| projectMembers.phoneNumber | Body | String | Project member phone number |
 
 <details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "projectMembers": [
+        {
+            "memberId": "550e8400-e29b-41d4-a716-446655440000",
+            "memberName": "memberName-example",
+            "emailAddress": "user@example.com",
+            "phoneNumber": "010-1234-5678"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### List Regions
+
+```http
+GET /v1.0/project/regions
+```
+
+#### Required Permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:Project.Get | List Regions |
+
+#### Request
+
+This API does not require a request body.
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| regions | Body | Array | Region information |
+| regions.regionCode | Body | Enum | Region code<br/>- KR1: `Korea (Pangyo)`<br/>- KR2: `Korea (Pyeongchon)` |
+| regions.isEnabled | Body | Boolean | Whether the region is enabled |
+
+<details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -203,59 +255,16 @@ This API does not require a request body.
     "regions": [
         {
             "regionCode": "KR1",
-            "isEnabled": true
+            "isEnabled": false
         }
     ]
 }
 ```
+
+</p>
 </details>
 
-### List Project Members
-
-```http
-GET /v1.0/project/members
-```
-
-#### Required permissions
-
-| Permission Name                          | Description         |
-|------------------------------|------------|
-| RDSforPostgreSQL:Project.Get | Get project information |
-
-#### Request
-
-This API does not require a request body.
-
-#### Response
-
-| Name                   | Type   | Format     | Description              |
-|----------------------|------|--------|-----------------|
-| members              | Body | Array  | Project member list      |
-| members.memberId     | Body | UUID   | Project member identifier    |
-| members.memberName   | Body | String | Project member name     |
-| members.emailAddress | Body | String | Project member email address |
-| members.phoneNumber  | Body | String | Project member mobile   |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "members": [
-        {
-            "memberId": "1b1d3627-507a-49ea-8cb7-c86dfa9caa58",
-            "memberName": "Hong Gildong",
-            "emailAddress": "gildong.hong@nhn.com",
-            "phoneNumber": "+821012345678"
-        }
-    ]
-}
-```
-</details>
+---
 
 ## Network
 
@@ -265,10 +274,10 @@ This API does not require a request body.
 GET /v1.0/network/subnets
 ```
 
-#### Required permissions
+#### Required Permissions
 
-| Permission Name                           | Description        |
-|-------------------------------|-----------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforPostgreSQL:Network.List | List Subnets |
 
 #### Request
@@ -277,17 +286,17 @@ This API does not require a request body.
 
 #### Response
 
-| Name                       | Type   | Format      | Description               |
-|--------------------------|------|---------|------------------|
-| subnets                  | Body | Array   | Subnet list           |
-| subnets.subnetId         | Body | UUID    | Subnet identifier         |
-| subnets.subnetName       | Body | String  | Name to identify subnets |
-| subnets.subnetCidr       | Body | String  | CIDR of subnet        |
-| subnets.usingGateway     | Body | Boolean | Whether to use gateway      |
-| subnets.availableIpCount | Body | Number  | Number of available IPs      |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| subnets | Body | Array | Subnet information |
+| subnets.subnetId | Body | UUID | Subnet identifier |
+| subnets.subnetName | Body | String | Name to identify subnets |
+| subnets.subnetCidr | Body | String | Subnet CIDR |
+| subnets.usingGateway | Body | Boolean | Whether to use gateway |
+| subnets.availableIpCount | Body | Number | Number of available IPs |
 
-<details>
-<summary>Example</summary>
+<details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -298,30 +307,34 @@ This API does not require a request body.
     },
     "subnets": [
         {
-            "subnetId": "1b2a9b23-0725-4b92-8c78-35db66b8ad9f",
-            "subnetName": "Default Network",
+            "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+            "subnetName": "subnetName-example",
             "subnetCidr": "192.168.0.0/24",
-            "usingGateway": true,
-            "availableIpCount": 240
+            "usingGateway": false,
+            "availableIpCount": 1
         }
     ]
 }
 ```
+
+</p>
 </details>
+
+---
 
 ## Storage
 
-### View the list of storage types
+### View the List of Storage Types
 
 ```http
 GET /v1.0/storage-types
 ```
 
-#### Required permissions
+#### Required Permissions
 
-| Permission Name                           | Description            |
-|-------------------------------|---------------|
-| RDSforPostgreSQL:Storage.List | View the list of storage types |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:Storage.List | View the List of Storage Types |
 
 #### Request
 
@@ -329,11 +342,12 @@ This API does not require a request body.
 
 #### Response
 
-| Name           | Type   | Format    | Description         |
-|--------------|------|-------|------------|
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
 | storageTypes | Body | Array | List of storage types |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -348,43 +362,65 @@ This API does not require a request body.
     ]
 }
 ```
+
+</p>
 </details>
+
+---
 
 ## Task Information
 
-### List Task Details
+### Task Status
+
+| Status | Description |
+|--------------------|----------------------|
+| `PREPARING` | When the task is being prepared |
+| `READY` | When the task is ready |
+| `RUNNING` | When the task is in progress |
+| `COMPLETED` | When the task is complete |
+| `REGISTERED` | When the task is registered |
+| `WAIT_TO_REGISTER` | When the task is waiting to be registered |
+| `INTERRUPTED` | When an interrupt occurred while the task was in progress |
+| `CANCELED` | When the task is canceled |
+| `FAILED` | When the task has failed |
+| `ERROR` | When an error occurred while the task was in progress |
+| `DELETED` | When the task has been deleted |
+| `FAIL_TO_READY` | When the task failed to be ready |
+
+### View Task Details
 
 ```http
-GET /v3.0/jobs/{jobId}
+GET /v1.0/jobs/{jobId}
 ```
 
-#### Required permissions
+#### Required Permissions
 
-| Permission Name                      | Description          |
-|--------------------------|-------------|
-| RDSforPostgreSQL:Job.Get | List Task Details |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:Job.Get | View Task Details |
 
 #### Request
 
 This API does not require a request body.
 
-| Name    | Type  | Format   | Required | Description      |
-|-------|-----|------|----|---------|
-| jobId | URL | UUID | O  | Task identifier |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| jobId | URL | UUID | O |  |
 
 #### Response
 
-| Name                             | Type   | Format       | Description                                                                                                                                                                                                                                                                                                                                                                                                              |
-|--------------------------------|------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| jobId                          | Body | UUID     | Task identifier                                                                                                                                                                                                                                                                                                                                                                                                         |
-| jobStatus                      | Body | Enum     | Current task status<br/>- `PREPARING`: If the task is being prepared<br/>- `READY`: When the task is ready<br/>- `RUNNING`: If the task is in progress<br/>- `COMPLETED`: When the task is complete<br/>- `REGISTERED`: If the task is registered<br/>- `WAIT_TO_REGISTER`: If the job is waiting to be registered<br/>- `INTERRUPTED`: If an interrupt occurred while the operation was in progress.<br/>- `CANCELED`: If the task is canceled<br/>- `FAILED`: If the operation failed<br/>- `ERROR`: If an error occurred while the operation was in progress<br/>- `DELETED`: If the task has been deleted<br/>- `FAIL_TO_READY`: The job failed to be ready. |
-| resourceRelations              | Body | Array    | Relevant resource list                                                                                                                                                                                                                                                                                                                                                                                                       |
-| resourceRelations.resourceType | Body | Enum     | Relevant resource type<br/>- `DB_INSTANCE`: DB instance<br/>- `DB_INSTANCE_GROUP`: DB instance group<br/>- `DB_SECURITY_GROUP`: DB security group<br/>- `PARAMETER_GROUP`: Parameter Group<br/>- `BACKUP`: Backup<br/>- `TENANT`: Tenant                                                                                                                                                                                                                        |
-| resourceRelations.resourceId   | Body | UUID     | Relevant resource identifier                                                                                                                                                                                                                                                                                                                                                                                                     |
-| createdYmdt                    | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                                                                                                                                                                                                                                               |
-| updatedYmdt                    | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                                                                                                                                                                                                                                               |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Task identifier |
+| jobStatus | Body | Enum | Current task status<br/>- DELETED<br/>- CANNOT_PROGRESS<br/>- FAILED<br/>- ERROR<br/>- CANCELED<br/>- INTERRUPTED<br/>- COMPLETED<br/>- COMPLETED_WITH_ERROR<br/>- RUNNING<br/>- PREPARING<br/>- READY<br/>- CREATED<br/>- FAIL_TO_READY<br/>- REGISTERED<br/>- FAIL_TO_REGISTER<br/>- WAIT_TO_REGISTER |
+| resourceRelations | Body | Array | Related resource list |
+| resourceRelations.resourceType | Body | String | Related resource type |
+| resourceRelations.resourceId | Body | String | Related resource identifier |
+| createdYmdt | Body | DateTime | Created date and time |
+| updatedYmdt | Body | DateTime | Modified date and time |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -393,23 +429,26 @@ This API does not require a request body.
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c",
-    "jobStatus": "RUNNING",
+    "jobId": "550e8400-e29b-41d4-a716-446655440000",
+    "jobStatus": "DELETED",
     "resourceRelations": [
         {
-            "resourceType": "DB_INSTANCE",
-            "resourceId": "56b39dcf-65eb-47ec-9d4f-09f160ba2266"
+            "resourceType": "resourceType-example",
+            "resourceId": "resourceId-example"
         }
     ],
-    "createdYmdt": "2023-02-22T20:47:12+09:00",
-    "updatedYmdt": "2023-02-22T20:49:46+09:00"
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
+
+</p>
 </details>
 
+---
 ## DB Instance Group
 
-### List DB Instances
+### List DB Instance Groups
 
 ```http
 GET /v1.0/db-instance-groups
@@ -417,9 +456,9 @@ GET /v1.0/db-instance-groups
 
 #### Required permissions
 
-| Permission Name                                   | Description               |
-|---------------------------------------|------------------|
-| RDSforPostgreSQL:DbInstanceGroup.List | List DB Instances |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceGroup.List | List DB Instance Groups |
 
 #### Request
 
@@ -427,16 +466,17 @@ This API does not require a request body.
 
 #### Response
 
-| Name                                     | Type   | Format       | Description                                                          |
-|----------------------------------------|------|----------|-------------------------------------------------------------|
-| dbInstanceGroups                       | Body | Array    | DB instance groups                                               |
-| dbInstanceGroups.dbInstanceGroupId     | Body | UUID     | DB instance group identifier                                             |
-| dbInstanceGroups.dbInstanceGroupStatus | Body | Enum     | Current status of DB instance groups<br/>- `CREATED: Created`<br/>- `DELETED`: Deleted |
-| dbInstanceGroups.replicationType       | Body | Enum     | DB instance group replication type<br/>- `STANDALONE`: Standalone                    |
-| dbInstanceGroups.createdYmdt           | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                           |
-| dbInstanceGroups.updatedYmdt           | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                           |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| dbInstanceGroups | Body | Array | DB instance group information |
+| dbInstanceGroups.dbInstanceGroupId | Body | UUID | DB instance group identifier |
+| dbInstanceGroups.dbInstanceGroupStatus | Body | Enum | Current status of the DB instance group<br/>- CREATED: `Created`<br/>- DELETED: `Deleted` |
+| dbInstanceGroups.replicationType | Body | Enum | DB instance group replication type<br/>- STANDALONE: `High availability not used`<br/>- HIGH_AVAILABILITY: `High availability used` |
+| dbInstanceGroups.createdYmdt | Body | DateTime | Created date and time |
+| dbInstanceGroups.updatedYmdt | Body | DateTime | Modified date and time |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -447,17 +487,20 @@ This API does not require a request body.
     },
     "dbInstanceGroups": [
         {
-            "dbInstanceGroupId": "05de0746-89fd-49c8-94f9-9c5b1df97009",
+            "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
             "dbInstanceGroupStatus": "CREATED",
             "replicationType": "STANDALONE",
-            "createdYmdt": "2023-02-13T17:35:20+09:00",
-            "updatedYmdt": "2023-02-13T17:35:20+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
+
+</p>
 </details>
 
+---
 
 ### List DB Instance Group Details
 
@@ -467,33 +510,34 @@ GET /v1.0/db-instance-groups/{dbInstanceGroupId}
 
 #### Required permissions
 
-| Permission Name                                  | Description               |
-|--------------------------------------|------------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforPostgreSQL:DbInstanceGroup.Get | List DB Instance Group Details |
 
 #### Request
 
 This API does not require a request body.
 
-| Name                | Type  | Format   | Required | Description              |
-|-------------------|-----|------|----|-----------------|
-| dbInstanceGroupId | URL | UUID | O  | DB instance group identifier |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | O |  |
 
 #### Response
 
-| Name                           | Type   | Format       | Description                                                                                                                                    |
-|------------------------------|------|----------|---------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceGroupId            | Body | UUID     | DB instance group identifier                                                                                                                       |
-| dbInstanceGroupStatus        | Body | Enum     | Current status of DB instance groups<br/>- `CREATED: Created`<br/>- `DELETED`: Deleted                                                                           |
-| replicationType              | Body | Enum     | DB instance group replication type<br/>- `STANDALONE`: Standalone<br/>- `HIGH_AVAILABILITY`: High availability                                                              |
-| dbInstances                  | Body | Array    | DB instances belong to DB instance group                                                                                                             |
-| dbInstances.dbInstanceId     | Body | UUID     | DB instance identifier                                                                                                                          |
-| dbInstances.dbInstanceType   | Body | Enum     | DB instance role type<br/>- `MASTER`: Master<br/>- `FAILED_MASTER`: Failed over master<br/>- `CANDIDATE_MASTER`: Candidate master<br/>- `READ_ONLY_SLAVE`: Read replica |
-| dbInstances.dbInstanceStatus | Body | Enum     | DB instance current status                                                                                                                        |
-| createdYmdt                  | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-| updatedYmdt                  | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| dbInstanceGroupId | Body | UUID | DB instance group identifier |
+| dbInstanceGroupStatus | Body | Enum | Current status of the DB instance group<br/>- CREATED: `Created`<br/>- DELETED: `Deleted` |
+| replicationType | Body | Enum | DB instance group replication type<br/>- STANDALONE: `High availability not used`<br/>- HIGH_AVAILABILITY: `High availability used` |
+| dbInstances | Body | Array | List of DB instances belonging to the DB instance group |
+| dbInstances.dbInstanceId | Body | UUID | DB instance identifier |
+| dbInstances.dbInstanceType | Body | Enum | DB instance role type<br/>- MASTER: `Master`<br/>- FAILED_MASTER: `Failed over master`<br/>- CANDIDATE_MASTER: `Candidate master`<br/>- READ_ONLY_SLAVE: `Read replica` |
+| dbInstances.dbInstanceStatus | Body | Enum | Current status of the DB instance<br/>- BEFORE_CREATE: `Before creation (gray)`<br/>- AVAILABLE: `Available (green)`<br/>- STORAGE_FULL: `Insufficient storage (red)`<br/>- FAIL_TO_CREATE: `Failed to create (red)`<br/>- FAIL_TO_CONNECT: `Failed to connect (red)`<br/>- REPLICATION_STOP: `Replication stopped (red)`<br/>- REPLICATION_DELAY: `Replication delayed (yellow)`<br/>- FAILOVER: `Failover complete (red)`<br/>- SHUTDOWN: `Stopped (gray)`<br/>- DELETED: `Deleted (gray)` |
+| createdYmdt | Body | DateTime | Created date and time |
+| updatedYmdt | Body | DateTime | Modified date and time |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -502,24 +546,25 @@ This API does not require a request body.
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "dbInstanceGroupId": "36617a8e-0df8-4b16-b6ea-6306019e95da",
+    "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
     "dbInstanceGroupStatus": "CREATED",
     "replicationType": "STANDALONE",
     "dbInstances": [
         {
-            "dbInstanceId": "6d2db0ef-fe9b-4ed4-97b1-d97fcb4cf1b8",
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
             "dbInstanceType": "MASTER",
-            "dbInstanceStatus": "AVAILABLE"
+            "dbInstanceStatus": "BEFORE_CREATE"
         }
     ],
-    "createdYmdt": "2023-03-03T17:38:14+09:00",
-    "updatedYmdt": "2023-03-03T17:38:14+09:00"
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
+
+</p>
 </details>
 
-
-## DB Instance Group > Manage Extensions
+---
 
 ### View Extension List
 
@@ -527,38 +572,39 @@ This API does not require a request body.
 GET /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions
 ```
 
-#### Required Permission
+#### Required permissions
 
-| Permission name                                            | Description       |
-|------------------------------------------------|----------|
-| RDSforPostgreSQL:DbInstanceGroupExtension.List | View extension lists |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceGroupExtension.List | View Extension List |
 
 #### Request
 
 This API does not require a request body.
 
-| Name                | Type  | Format   | Required | Description              |
-|-------------------|-----|------|----|-----------------|
-| dbInstanceGroupId | URL | UUID | O  | Identifier of DB instance group |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | O | DB instance group ID |
 
 #### Response
 
-| Name                                                  | Type   | Format      | Description                                                                                                                                                                                              |
-|-----------------------------------------------------|------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| extensions                                          | Body | Array   | Extension list                                                                                                                                                                                           |
-| extensions.extensionId                              | Body | UUID    | Identifier of the extension                                                                                                                                                                                         |
-| extensions.extensionName                            | Body | String  | Extension name                                                                                                                                                                                           |
-| extensions.extensionStatus                          | Body | ENUM    | Extension status<br/>- `AVAILABLE`: available<br/>- `NEED_TO_APPLY`: need to apply<br/>- `APPLYING`: applying                                                                                                               |
-| extensions.databases                                | Body | Array   | Database information with installed extensions                                                                                                                                                                               |
-| extensions.databases.dbInstanceGroupExtensionId     | Body | UUID    | Identifier of an extension within a DB instance group                                                                                                                                                                            |
-| extensions.databases.dbInstanceGroupExtensionStatus | Body | ENUM    | Extension status within a DB instance group<br/>- `CREATED`: created<br/>- `INSTALLED`: installed<br/>- `INSTALLING`: installing<br/>- `INSTALL_ERROR`: installation error<br/>- `DELETED`: deleted<br/>- `DELETING`: deleting<br/>- `DELETE_ERROR`: deletion error |
-| extensions.databases.databaseId                     | Body | UUID    | Identifier of the database                                                                                                                                                                                     |
-| extensions.databases.databaseName                   | Body | String  | Database name                                                                                                                                                                                       |
-| extensions.databases.reservedAction                 | Body | ENUM    | Scheduled Task<br/>- `NONE`: none<br/>- `INSTALL`: scheduled installation (need to apply)<br/>- `INSTALL_WITH_CASCADE`: scheduled forced installation (need to apply)<br/>- `DELETE`: scheduled deletion (need to apply)<br/>- `DELETE_WITH_CASCADE`: scheduled forced deletion (need to apply)                |
-| extensions.databases.errorReason                    | Body | String  | Reason for Error                                                                                                                                                                                           |
-| isNeedToApply                                       | Body | Boolean | Whether to apply changes                                                                                                                                                                                  |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| extensions | Body | Array | Extension information |
+| extensions.extensionId | Body | UUID | Extension identifier |
+| extensions.extensionName | Body | String | Extension name |
+| extensions.extensionStatus | Body | Enum | Extension status<br/>- AVAILABLE: `Available`<br/>- NEED_TO_APPLY: `Need to apply`<br/>- APPLYING: `Applying` |
+| extensions.databases | Body | Array | Database information |
+| extensions.databases.dbInstanceGroupExtensionId | Body | UUID | Identifier of an extension within a DB instance group |
+| extensions.databases.databaseId | Body | UUID | Database identifier |
+| extensions.databases.databaseName | Body | String | Database name |
+| extensions.databases.dbInstanceGroupExtensionStatus | Body | Enum | Extension installation status within the database<br/>- CREATED: `Created`<br/>- INSTALLED: `Installed`<br/>- INSTALLING: `Installing`<br/>- INSTALL_ERROR: `Installation error`<br/>- DELETED: `Deleted`<br/>- DELETING: `Deleting`<br/>- DELETE_ERROR: `Deletion error` |
+| extensions.databases.reservedAction | Body | Enum | Scheduled task<br/>- NONE: `None`<br/>- INSTALL: `Scheduled installation (need to apply)`<br/>- INSTALL_WITH_CASCADE: `Scheduled forced installation (need to apply)`<br/>- DELETE: `Scheduled deletion (need to apply)`<br/>- DELETE_WITH_CASCADE: `Scheduled forced deletion (need to apply)` |
+| extensions.databases.errorReason | Body | String | Reason for error |
+| isNeedToApply | Body | Boolean | Whether changes need to be applied |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -569,108 +615,29 @@ This API does not require a request body.
     },
     "extensions": [
         {
-            "extensionId": "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4",
-            "extensionName": "address_standardizer",
+            "extensionId": "550e8400-e29b-41d4-a716-446655440000",
+            "extensionName": "extensionName-example",
             "extensionStatus": "AVAILABLE",
             "databases": [
                 {
-                    "dbInstanceGroupExtensionId": "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4",
-                    "databaseId": "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4",
-                    "databaseName": "database-1",
-                    "dbInstanceGroupExtensionStatus": "INSTALLED",
+                    "dbInstanceGroupExtensionId": "550e8400-e29b-41d4-a716-446655440000",
+                    "databaseId": "550e8400-e29b-41d4-a716-446655440000",
+                    "databaseName": "databaseName-example",
+                    "dbInstanceGroupExtensionStatus": "CREATED",
                     "reservedAction": "NONE",
-                    "errorReason": null
+                    "errorReason": "errorReason-example"
                 }
             ]
         }
     ],
-    "isNeedToApply": true
+    "isNeedToApply": false
 }
 ```
+
+</p>
 </details>
 
-
-### Install Extensions
-
-```http
-POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{extensionId}
-```
-
-#### Required Permission
-
-| Permission name                                               | Description    |
-|---------------------------------------------------|-------|
-| RDSforPostgreSQL:DbInstanceGroupExtension.Install | Install extensions |
-
-#### Request
-
-This API does not require a request body.
-
-| Name                | Type   | Format      | Required | Description                |
-|-------------------|------|---------|----|-------------------|
-| dbInstanceGroupId | URL  | UUID    | O  | Identifier of DB instance group   |
-| extensionId       | URL  | UUID    | O  | Identifier of the extension           |
-| databaseId        | Body | UUID    | O  | Identifier of the database to be installed |
-| schemaName        | Body | String  | O  | Name of the schema to be installed      |
-| withCascade       | Body | Boolean | X  | Whether to force installation of dependency information    |
-
-#### Response
-
-This API does not return a response body.
-
-<details><summary>Example</summary>
-
-```json
-{
-  "header": {
-    "resultCode": 0,
-    "resultMessage": "SUCCESS",
-    "isSuccessful": true
-  }
-}
-```
-</details>
-
-
-### Delete Extensions (Cancel)
-
-```http
-DELETE /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{dbInstanceGroupExtensionId}
-```
-
-#### Required Permission
-
-| Permission name                                              | Description        |
-|--------------------------------------------------|-----------|
-| RDSforPostgreSQL:DbInstanceGroupExtension.Delete | Delete extensions (cancel) |
-
-#### Request
-
-This API does not require a request body.
-
-| Name                         | Type    | Format      | Required | Description                   |
-|----------------------------|-------|---------|----|----------------------|
-| dbInstanceGroupId          | URL   | UUID    | O  | Identifier of DB instance group      |
-| dbInstanceGroupExtensionId | URL   | UUID    | O  | Identifier of the extension within the DB instance group |
-| withCascade                | Query | Boolean | O  | Whether to force installation of dependency information       |
-
-#### Response
-
-This API does not return a response body.
-
-<details><summary>Example</summary>
-
-```json
-{
-  "header": {
-    "resultCode": 0,
-    "resultMessage": "SUCCESS",
-    "isSuccessful": true
-  }
-}
-```
-</details>
-
+---
 
 ### Apply Extension Changes
 
@@ -678,40 +645,44 @@ This API does not return a response body.
 POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/apply
 ```
 
-#### Required Permission
+#### Required permissions
 
-| Permission name                                             | Description         |
-|-------------------------------------------------|------------|
-| RDSforPostgreSQL:DbInstanceGroupExtension.Apply | Apply extension changes |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceGroupExtension.Apply | Apply Extension Changes |
 
 #### Request
 
 This API does not require a request body.
 
-| Name                         | Type    | Format      | Required | Description                   |
-|----------------------------|-------|---------|----|----------------------|
-| dbInstanceGroupId          | URL   | UUID    | O  | Identifier of DB instance group      |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | O | DB instance group ID |
 
 #### Response
 
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | Identifier of the requested task |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
-  "header": {
-    "resultCode": 0,
-    "resultMessage": "SUCCESS",
-    "isSuccessful": true
-  },
-  "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
+---
 
 ### Synchronize Extensions
 
@@ -719,97 +690,162 @@ This API does not require a request body.
 POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/sync
 ```
 
-#### Required Permission
+#### Required permissions
 
-| Permission name                                            | Description     |
-|------------------------------------------------|--------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforPostgreSQL:DbInstanceGroupExtension.Sync | Synchronize Extensions |
 
 #### Request
 
 This API does not require a request body.
 
-| Name                         | Type    | Format      | Required | Description                   |
-|----------------------------|-------|---------|----|----------------------|
-| dbInstanceGroupId          | URL   | UUID    | O  | Identifier of DB instance group      |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | O | DB instance group ID |
 
 #### Response
 
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | Identifier of the requested task |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
-  "header": {
-    "resultCode": 0,
-    "resultMessage": "SUCCESS",
-    "isSuccessful": true
-  },
-  "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
+---
 
+### Delete Extension (Cancel)
+
+```http
+DELETE /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{dbInstanceGroupExtensionId}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceGroupExtension.Delete | Delete Extension (Cancel) |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | O | DB instance group ID |
+| dbInstanceGroupExtensionId | URL | UUID | O | Identifier of the extension within the DB instance group |
+| withCascade | Query | Boolean | O | Whether to force deletion |
+
+#### Response
+
+This API does not return a response body.
+
+---
+
+### Install Extension
+
+```http
+POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{extensionId}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceGroupExtension.Install | Install Extension |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | O | DB instance group ID |
+| extensionId | URL | UUID | O | Extension identifier |
+| databaseId | Body | UUID | O | Database identifier |
+| schemaName | Body | String | O | Schema name |
+| withCascade | Body | Boolean | X | Whether to automatically install dependencies<br/>- Default: `false` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "databaseId": "550e8400-e29b-41d4-a716-446655440000",
+    "schemaName": "schemaName-example",
+    "withCascade": false
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+This API does not return a response body.
+
+---
 ## DB Instance
 
 ### DB Instance Status
 
-| Status                  | Description                          |
-|---------------------|-----------------------------|
-| `AVAILABLE`         | DB instance is available          |
-| `BEFORE_CREATE`     | Before creating a DB instance           |
-| `STORAGE_FULL`      | Insufficient DB instance storage         |
-| `FAIL_TO_CREATE`    | Failed to create DB instance          |
-| `FAIL_TO_CONNECT`   | Failed to connect DB instance          |
-| `REPLICATION_STOP`  | Replication of DB instance is stopped         |
-| `REPLICATION_DELAY` | When replication of a DB instance is delayed       |
-| `FAILOVER`          | When failover of a highly available DB instance is complete |
-| `SHUTDOWN`          | DB instance is stopped             |
-| `DELETED`           | DB instance is deleted             |
+| Status                  | Description                           |
+|---------------------|-------------------------------|
+| `AVAILABLE`         | DB instance is available           |
+| `BEFORE_CREATE`     | Before creating a DB instance            |
+| `STORAGE_FULL`      | Insufficient DB instance storage          |
+| `FAIL_TO_CREATE`    | Failed to create DB instance           |
+| `FAIL_TO_CONNECT`   | Failed to connect DB instance           |
+| `REPLICATION_STOP`  | Replication of DB instance is stopped          |
+| `FAILOVER`          | When failover of a highly available DB instance is complete       |
+| `SHUTDOWN`          | DB instance is stopped               |
+| `DELETED`           | DB instance is deleted               |
 
 ### DB Instance Progress Status
 
-| Status                              | Description             |
-|---------------------------------|----------------|
-| `APPLYING_DB_INSTANCE_HBA_RULE` | Applying an access control rule  |
-| `APPLYING_PARAMETER_GROUP`      | Parameter group is being applied   |
-| `APPLYING_EXTENSION`            | Applying an extension        |
-| `BACKING_UP`                    | Backing up           |
-| `CANCELING`                     | Canceling           |
-| `CREATING`                      | Creating           |
-| `CREATING_DATABASE`             | Creating a database	   |
-| `CREATING_USER`                 | Creating user	      |
-| `DELETING`                      | Deleting           |
-| `DELETING_DATABASE`             | Deleting a database    |
-| `DELETING_USER`                 | Deleting user       |
-| `EXPORTING_BACKUP`              | Exporting a backup     |
-| `FAILING_OVER`                  | Under failover        |
-| `MIGRATING`                     | Under migration       |
-| `MODIFYING`                     | Under modification           |
-| `OCCUPIED`                      | Occupied           |
-| `PREPARING`                     | In preparation           |
-| `PROMOTING`                     | Promoting           |
-| `PROMOTING_FORCIBLY`            | Force Promoting        |
-| `REBUILDING`                    | Rebuilding          |
-| `REPAIRING`                     | Recovering           |
-| `REPLICATING`                   | Replicating           |
-| `RESTARTING`                    | Restarting          |
-| `RESTARTING_FORCIBLY`           | Force restarting       |
-| `RESTORING`                     | Restoring           |
-| `STARTING`                      | Starting           |
-| `STOPPING`                      | Stopping           |
-| `SYNCING_DATABASE`              | Synchronizing the database   |
-| `SYNCING_USER`                  | Synchronizing user	     |
-| `SYNCING_EXTENSION`             | Synchronizing extensions	      |
-| `UPDATING_USER`                 | Modifying user	      |
-| `UPDATING_DATABASE`             | Modifying the database	   |
-| `WAIT_MANUAL_CONTROL`           | Waiting for manual failover	 |
+| Status                       | Description            |
+|----------------------------|--------------|
+| `APPLYING_PARAMETER_GROUP` | Parameter group is being applied |
+| `BACKING_UP`               | Backing up          |
+| `CANCELING`                | Canceling          |
+| `CREATING`                 | Creating          |
+| `CREATING_SCHEMA`          | Creating a schema  |
+| `CREATING_USER`            | Creating user      |
+| `DELETING`                 | Deleting          |
+| `DELETING_SCHEMA`          | Deleting a schema  |
+| `DELETING_USER`            | Deleting user      |
+| `EXPORTING_BACKUP`         | Exporting a backup   |
+| `FAILING_OVER`             | Under failover      |
+| `MIGRATING`                | Under migration       |
+| `MODIFYING`                | Under modification           |
+| `PREPARING`                | In preparation           |
+| `PROMOTING`                | Promoting           |
+| `REBUILDING`               | Rebuilding          |
+| `REPAIRING`                | Recovering           |
+| `REPLICATING`              | Replicating           |
+| `RESTARTING`               | Restarting          |
+| `RESTARTING_FORCIBLY`      | Force restarting       |
+| `RESTORING`                | Restoring           |
+| `STARTING`                 | Starting           |
+| `STOPPING`                 | Stopping           |
+| `SYNCING_SCHEMA`           | Synchronizing the schema   |
+| `SYNCING_USER`             | Synchronizing user     |
+| `UPDATING_USER`            | Modifying user      |
 
-### List DB instances
+### List DB Instances
 
 ```http
 GET /v1.0/db-instances
@@ -817,8 +853,8 @@ GET /v1.0/db-instances
 
 #### Required permissions
 
-| Permission Name                              | Description            |
-|----------------------------------|---------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforPostgreSQL:DbInstance.List | List DB instances |
 
 #### Request
@@ -827,22 +863,23 @@ This API does not require a request body.
 
 #### Response
 
-| Name                            | Type   | Format       | Description                                                                                                                                    |
-|-------------------------------|------|----------|---------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstances                   | Body | Array    | DB instances                                                                                                                            |
-| dbInstances.dbInstanceId      | Body | UUID     | DB instance identifier                                                                                                                          |
-| dbInstances.dbInstanceGroupId | Body | UUID     | DB instance group identifier                                                                                                                       |
-| dbInstances.dbInstanceName    | Body | String   | Name to identify DB instances                                                                                                                  |
-| dbInstances.description       | Body | String   | Additional information on DB instances                                                                                                                     |
-| dbInstances.dbVersion         | Body | Enum     | DB version information                                                                                                                              |
-| dbInstances.dbPort            | Body | Number   | DB port                                                                                                                                 |
-| dbInstances.dbInstanceType    | Body | Enum     | DB instance role type<br/>- `MASTER`: Master<br/>- `FAILED_MASTER`: Failed over master<br/>- `CANDIDATE_MASTER`: Candidate master<br/>- `READ_ONLY_SLAVE`: Read replica |
-| dbInstances.dbInstanceStatus  | Body | Enum     | DB instance current status                                                                                                                        |
-| dbInstances.progressStatus    | Body | Enum     | DB instance current status                                                                                                                     |
-| dbInstances.createdYmdt       | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-| dbInstances.updatedYmdt       | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| dbInstances | Body | Array | DB instances |
+| dbInstances.dbInstanceId | Body | UUID | DB instance identifier |
+| dbInstances.dbInstanceGroupId | Body | UUID | DB instance group identifier |
+| dbInstances.dbInstanceName | Body | String | Name to identify DB instances |
+| dbInstances.description | Body | String | Additional information on DB instances |
+| dbInstances.dbVersion | Body | Enum | DB version information |
+| dbInstances.dbPort | Body | Number | DB port |
+| dbInstances.dbInstanceType | Body | Enum | DB instance role type<br/>- MASTER: `Master`<br/>- FAILED_MASTER: `Failed over master`<br/>- CANDIDATE_MASTER: `Candidate master`<br/>- READ_ONLY_SLAVE: `Read replica` |
+| dbInstances.dbInstanceStatus | Body | Enum | DB instance current status<br/>- BEFORE_CREATE: `Before creating (gray)`<br/>- AVAILABLE: `Available (green)`<br/>- STORAGE_FULL: `Insufficient storage (red)`<br/>- FAIL_TO_CREATE: `Failed to create (red)`<br/>- FAIL_TO_CONNECT: `Failed to connect (red)`<br/>- REPLICATION_STOP: `Replication stopped (red)`<br/>- REPLICATION_DELAY: `Replication delayed (yellow)`<br/>- FAILOVER: `Failover complete (red)`<br/>- SHUTDOWN: `Stopped (gray)`<br/>- DELETED: `Deleted (gray)` |
+| dbInstances.progressStatus | Body | String | DB instance current progress status |
+| dbInstances.createdYmdt | Body | DateTime | Created date and time |
+| dbInstances.updatedYmdt | Body | DateTime | Modified date and time |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -853,98 +890,26 @@ This API does not require a request body.
     },
     "dbInstances": [
         {
-            "dbInstanceId": "d067593b-1acc-4ccc-9e8a-cc72d6d79ec3",
-            "dbInstanceGroupId": "51c7d080-ff36-4025-84b1-9d9d0b4fe9e0",
-            "dbInstanceName": "db-instance",
-            "description": null,
-            "dbVersion": "POSTGRESQL_V17_6",
-            "dbPort": 15432,
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbInstanceName": "dbInstanceName-example",
+            "description": "description-example",
+            "dbVersion": "POSTGRESQL_V14_17",
+            "dbPort": 1,
             "dbInstanceType": "MASTER",
-            "dbInstanceStatus": "AVAILABLE",
-            "progressStatus": "NONE",
-            "createdYmdt": "2023-01-23T12:03:13+09:00",
-            "updatedYmdt": "2023-02-02T17:20:17+09:00"
+            "dbInstanceStatus": "BEFORE_CREATE",
+            "progressStatus": "progressStatus-example",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
+
+</p>
 </details>
 
-
-### List DB Instance Details
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}
-```
-
-#### Required permissions
-
-| Permission Name                             | Description            |
-|---------------------------------|---------------|
-| RDSforPostgreSQL:DbInstance.Get | List DB Instance Details |
-
-#### Request
-
-This API does not require a request body.
-
-| Name           | Type  | Format   | Required | Description           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB instance identifier |
-
-#### Response
-
-| Name                        | Type   | Format       | Description                                                                                                                                    |
-|---------------------------|------|----------|---------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId              | Body | UUID     | DB instance identifier                                                                                                                          |
-| dbInstanceGroupId         | Body | UUID     | DB instance group identifier                                                                                                                       |
-| dbInstanceName            | Body | String   | Name to identify DB instances                                                                                                                  |
-| description               | Body | String   | Additional information on DB instances                                                                                                                     |
-| dbVersion                 | Body | Enum     | DB version information                                                                                                                              |
-| dbPort                    | Body | Number   | DB port                                                                                                                                 |
-| dbInstanceType            | Body | Enum     | DB instance role type<br/>- `MASTER`: Master<br/>- `FAILED_MASTER`: Failed over master<br/>- `CANDIDATE_MASTER`: Candidate master<br/>- `READ_ONLY_SLAVE`: Read replica |
-| dbInstanceStatus          | Body | Enum     | DB instance current status                                                                                                                        |
-| progressStatus            | Body | Enum     | Current task status of DB instance                                                                                                                  |
-| dbFlavorId                | Body | UUID     | Identifier of DB instance specifications                                                                                                                       |
-| parameterGroupId          | Body | UUID     | Parameter group identifier applied to DB instance                                                                                                             |
-| dbSecurityGroupIds        | Body | Array    | DB security group identifiers applied to DB instance                                                                                                         |
-| notificationGroupIds      | Body | Array    | List of identifiers of notification groups applied to the DB instance                                                                                                            |
-| useDeletionProtection     | Body | Boolean  | Whether to protect DB instance against deletion                                                                                                                      |
-| needToApplyParameterGroup | Body | Boolean  | Need to apply the latest parameter group                                                                                                                   |
-| needMigration             | Body | Boolean  | Need to migrate                                                                                                                          |
-| osVersion                 | Body | String   | OS Version                                                                                                                               |
-| createdYmdt               | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-| updatedYmdt               | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceId": "d067593b-1acc-4ccc-9e8a-cc72d6d79ec3",
-    "dbInstanceGroupId": "51c7d080-ff36-4025-84b1-9d9d0b4fe9e0",
-    "dbInstanceName": "db-instance",
-    "description": null,
-    "dbVersion": "POSTGRESQL_V17_6",
-    "dbPort": 15432,
-    "dbInstanceType": "MASTER",
-    "dbInstanceStatus": "AVAILABLE",
-    "progressStatus": "NONE",
-    "dbFlavorId": "e9ed4ef6-78d7-46fa-ace9-32481e97f3b7",
-    "parameterGroupId": "b03e8b13-de27-4d04-a488-ff5689589372",
-    "dbSecurityGroupIds": ["01908c35-d2c9-4852-baf0-17f06ec42c03"],
-    "notificationGroupIds": ["83a62a33-ddbf-4a04-8653-e54463d5b1ac"],
-    "useDeletionProtection": false,
-    "needToApplyParameterGroup": false,
-    "needMigration": false,
-    "createdYmdt": "2022-11-23T12:03:13+09:00",
-    "updatedYmdt": "2022-12-02T17:20:17+09:00"
-}
-```
-</details>
+---
 
 ### Create DB Instance
 
@@ -954,62 +919,70 @@ POST /v1.0/db-instances
 
 #### Required permissions
 
-| Permission Name                                | Description           |
-|------------------------------------|--------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforPostgreSQL:DbInstance.Create | Create DB Instance |
 
 #### Request
 
-| Name                                       | Type   | Format      | Required | Description                                                                                                                                                                                                                   |
-|------------------------------------------|------|---------|----|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceName                           | Body | String  | O  | Name to identify DB instances                                                                                                                                                                                                 |
-| description                              | Body | String  | X  | Additional information on DB instances                                                                                                                                                                                                    |
-| dbFlavorId                               | Body | UUID    | O  | Identifier of DB instance specifications                                                                                                                                                                                                      |
-| dbVersion                                | Body | Enum    | O  | DB version information                                                                                                                                                                                                             |
-| dbPort                                   | Body | Number  | O  | DB port<br/>- Minimum value: `0`<br/>- Maximum value: 65535                                                                                                                                                                           |
-| databaseName                             | Body | String  | O  | Name of the new database to create in the DB Engine                                                                                                                                                                                               |
-| dbUserName                               | Body | String  | O  | New user account name to create in DB Engine                                                                                                                                                                                               |
-| dbPassword                               | Body | String  | O  | Password for the new user account to be created in the DB Engine<br/>- Minimum length: `4`<br/>- Maximum length: `16`                                                                                                                                                          |
-| parameterGroupId                         | Body | UUID    | O  | Parameter group identifier                                                                                                                                                                                                         |
-| dbSecurityGroupIds                       | Body | Array   | X  | DB security group identifiers                                                                                                                                                                                                     |
-| useDeletionProtection                    | Body | Boolean | X  | Whether to protect against deletion<br/>Default: `false`                                                                                                                                                                                          |
-| useDefaultNotification                   | Body | Boolean | X  | Whether to use default notification<br/>Default: `false`                                                                                                                                                                                       |
-| useHighAvailability                      | Body | Boolean | X  | Whether to use high availability                                                                                                                                                                                                           |
-| pingInterval                             | Body | Number  | X  | Ping interval (sec) when using high availability<br/>- Minimum value: `1`<br/>- Maximum value: `600`                                                                                                                                                                 |
-| failoverReplWaitingTime                  | Body | Number  | X  | Failover latency when using high availability<br/>- Minimum value: `0`<br/>- If set to -1, it will continue to wait for the replication delay to resolve.                                                                                                                                         |                                                                                                                                                                                                                      | userGroupIds                             | Body | Array   | X  | List of identifiers for user groups that receive default notifications                                                                                                                                                                                             |
-| network                                  | Body | Object  | O  | Network information objects                                                                                                                                                                                                           |
-| network.subnetId                         | Body | UUID    | O  | Subnet identifier                                                                                                                                                                                                             |
-| network.usePublicAccess                  | Body | Boolean | X  | External access is available or not<br/>Default: `false`                                                                                                                                                                                      |
-| network.availabilityZone                 | Body | Enum    | X  | Availability zone where DB instance will be created<br/>- Example: `kr-pub-a`<br/>- Default: `Any availability` zone                                                                                                                                                     |
-| storage                                  | Body | Object  | O  | Storage information objects                                                                                                                                                                                                           |    
-| storage.storageType                      | Body | Enum    | O  | Data storage types<br/>- Example: `General SSD`                                                                                                                                                                                  |
-| storage.storageSize                      | Body | Number  | O  | Block Storage Size (GB)<br/>- Minimum value: `20`<br/>- Maximum value: `2048`                                                                                                                                                                    |
-| backup                                   | Body | Object  | O  | Backup information objects                                                                                                                                                                                                             |
-| backup.backupPeriod                      | Body | Number  | O  | Backup retention period<br/>- Minimum value: `0`<br/>- Maximum value: `730`                                                                                                                                                                          |
-| backup.backupRetryCount                  | Body | Number  | X  | Number of backup retries<br/>Default: `6`<br/>- Minimum value: `0`<br/>- Maximum value: `10`                                                                                                                                                              |
-| backup.backupSchedules                   | Body | Array   | X  | Backup schedules                                                                                                                                                                                                            |
-| backup.backupSchedules.backupWndBgnTime  | Body | String  | O  | Backup Start Time<br/>- Example: `00:00:00`                                                                                                                                                                                        |
-| backup.backupSchedules.backupWndDuration | Body | Enum    | O  | Backup Window<br/>Auto backup is executed within the set duration from the backup start time.<br/>- `HALF_AN_HOUR`: 30 minutes<br/>- `ONE_HOUR`: 1 hour<br/>- `ONE_HOUR_AND_HALF`: 1.5 hour<br/>- `TWO_HOURS`: 2 hour<br/>- `TWO_HOURS_AND_HALF`: 2.5 hour<br/>- `THREE_HOURS`: 3 hour |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceName | Body | String | O | Name to identify DB instances |
+| dbInstanceCandidateName | Body | String | X | Name to identify the candidate master of the DB instance |
+| description | Body | String | X | Additional information on DB instances |
+| dbFlavorId | Body | UUID | O | Identifier of DB instance specifications |
+| dbVersion | Body | Enum | O | DB version information |
+| dbPort | Body | Number | O | DB port<br/>- Minimum value: 5432, Maximum value: 45432 |
+| databaseName | Body | String | O | Database name |
+| dbUserName | Body | String | O | DB user account name |
+| dbPassword | Body | String | O | DB user account password |
+| parameterGroupId | Body | UUID | O | Parameter group identifier |
+| dbSecurityGroupIds | Body | Array | X | List of DB security group identifiers |
+| userGroupIds | Body | Array | X | List of user group identifiers |
+| useHighAvailability | Body | Boolean | X | Whether to use high availability<br/>- Default: `false` |
+| useDefaultNotification | Body | Boolean | X | Whether to use default notification<br/>- Default: `false` |
+| useDeletionProtection | Body | Boolean | X | Whether to enable deletion protection<br/>- Default: `false` |
+| pingInterval | Body | Number | X | Ping interval (sec)<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
+| failoverReplWaitingTime | Body | Number | X | Failover replication delay waiting time (sec)<br/>- Minimum value: `-1` |
+| network | Body | Object | O | Network information objects |
+| network.subnetId | Body | UUID | O | Subnet identifier |
+| network.usePublicAccess | Body | Boolean | X | External access is available or not<br/>- Default: `false` |
+| network.availabilityZone | Body | Enum | X | Availability zone where DB instance will be created |
+| storage | Body | Object | O | Storage information objects |
+| storage.storageType | Body | Enum | O | Data storage type |
+| storage.storageSize | Body | Number | O | Block storage size (GB)<br/>- Minimum value: `20` |
+| backup | Body | Object | O | Backup information objects |
+| backup.backupPeriod | Body | Number | O | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| backup.backupRetryCount | Body | Number | X | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| backup.backupSchedules | Body | Array | O | Backup schedule information |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | O | Backup start time |
+| backup.backupSchedules.backupWndDuration | Body | Enum | O | Backup window<br/>Auto backup is executed within the set duration from the backup start time.<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hours`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2.5 hours`<br/>- THREE_HOURS: `3 hours` |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbVersion": "POSTGRESQL_V17_6",
-    "dbPort": 15432,
-    "databaseName": "database",
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
+    "dbInstanceName": "dbInstanceName-example",
+    "dbInstanceCandidateName": "dbInstanceCandidateName-example",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbVersion": "POSTGRESQL_V14_17",
+    "dbPort": 1,
+    "databaseName": "databaseName-example",
+    "dbUserName": "dbUserName-example",
+    "dbPassword": "dbPassword-example",
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
     "userGroupIds": [],
+    "useHighAvailability": false,
+    "useDefaultNotification": false,
+    "useDeletionProtection": false,
+    "pingInterval": 1,
+    "failoverReplWaitingTime": 1,
     "network": {
-        "subnetId": "e721a9dd-dad0-4cf0-a53b-dd654ebfc683",
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
         "availabilityZone": "kr-pub-a"
     },
     "storage": {
@@ -1017,26 +990,29 @@ POST /v1.0/db-instances
         "storageSize": 20
     },
     "backup": {
-        "backupPeriod": 1,
+        "backupPeriod": 0,
+        "backupRetryCount": 0,
         "backupSchedules": [
             {
                 "backupWndBgnTime": "00:00:00",
-                "backupWndDuration": "ONE_HOUR_AND_HALF",
-                "backupRetryExpireTime": "01:30:00"
+                "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
     }
 }
 ```
+
+</p>
 </details>
 
 #### Response
 
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | Identifier of requested task |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -1045,10 +1021,273 @@ POST /v1.0/db-instances
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
+
+---
+### Restore DB Instance from Backup in Object Storage
+
+```http
+POST /v1.0/db-instances/restore-from-obs
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.RestoreFromObs | Restore DB Instance from Backup in Object Storage |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceName | Body | String | X | Name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| dbInstanceCandidateName | Body | String | X | Candidate master name to identify the DB instance |
+| description | Body | String | X | Additional information on DB instances<br/>- Maximum length: `100` |
+| dbFlavorId | Body | UUID | O | Identifier of DB instance specifications |
+| dbPort | Body | Number | X | DB port<br/>- Minimum value: 5432, Maximum value: 45432 |
+| dbVersion | Body | Enum | O | DB engine type |
+| useHighAvailability | Body | Boolean | X | Whether to use high availability<br/>- Default: `false` |
+| imageId | Body | UUID | X | Image identifier |
+| pingInterval | Body | Number | X | Ping interval (sec) when using high availability<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
+| failoverReplWaitingTime | Body | Number | X | Failover replication delay waiting time (sec)<br/>- Minimum value: `-1` |
+| storage | Body | Object | O | Storage information object |
+| storage.storageType | Body | Enum | O | Storage type |
+| storage.storageSize | Body | Number | O | Data storage size (GB)<br/>- Minimum value: `20` |
+| network | Body | Object | O | Network information object |
+| network.subnetId | Body | UUID | O | Subnet identifier |
+| network.usePublicAccess | Body | Boolean | X | External access availability<br/>- Default: `false` |
+| network.availabilityZone | Body | Enum | X | Availability zone where DB instance will be created |
+| backup | Body | Object | O | Backup information object |
+| backup.backupPeriod | Body | Number | O | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| backup.backupRetryCount | Body | Number | X | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| backup.replicationRegion | Body | Enum | X | Backup replication region<br/>- KR1: `Korea (Pangyo)`<br/>- KR2: `Korea (Pyeongchon)` |
+| backup.backupSchedules | Body | Array | O | Backup schedule list |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | O | Backup start time |
+| backup.backupSchedules.backupWndDuration | Body | Enum | O | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1 hour 30 minutes`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2 hours 30 minutes`<br/>- THREE_HOURS: `3 hours` |
+| restore | Body | Object | O | Restoration information object |
+| restore.tenantId | Body | String | O | Tenant ID of the object storage where the backup is stored |
+| restore.username | Body | String | O | NHN Cloud account or IAM member ID |
+| restore.password | Body | String | O | API password for the object storage where the backup is stored |
+| restore.targetContainer | Body | String | O | Container of the object storage where the backup is stored |
+| restore.objectPath | Body | String | O | Path of the backup stored in the container |
+| useDefaultNotification | Body | Boolean | X | Whether to use default notifications<br/>- Default: `false` |
+| parameterGroupId | Body | UUID | O | Parameter group identifier |
+| dbSecurityGroupIds | Body | Array | X | List of DB security group identifiers |
+| userGroupIds | Body | Array | X | List of user group identifiers |
+| useDeletionProtection | Body | Boolean | X | Whether deletion protection is enabled<br/>- Default: `false` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName",
+    "dbInstanceCandidateName": "dbInstanceCandidateName-example",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "dbVersion": "POSTGRESQL_V14_17",
+    "useHighAvailability": false,
+    "imageId": "550e8400-e29b-41d4-a716-446655440000",
+    "pingInterval": 3,
+    "failoverReplWaitingTime": 60,
+    "storage": {
+        "storageType": "General SSD",
+        "storageSize": 20
+    },
+    "network": {
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
+        "availabilityZone": "kr-pub-a"
+    },
+    "backup": {
+        "backupPeriod": 0,
+        "backupRetryCount": 0,
+        "replicationRegion": "KR1",
+        "backupSchedules": [
+            {
+                "backupWndBgnTime": "00:00:00",
+                "backupWndDuration": "HALF_AN_HOUR"
+            }
+        ]
+    },
+    "restore": {
+        "tenantId": "0123456789abcdef0123456789abcdef",
+        "username": "username-example",
+        "password": "password-example",
+        "targetContainer": "targetContainer-example",
+        "objectPath": "objectPath-example"
+    },
+    "useDefaultNotification": false,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useDeletionProtection": false
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Delete DB Instance
+
+```http
+DELETE /v1.0/db-instances/{dbInstanceId}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Delete | Delete DB Instance |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### List DB Instance Details
+
+```http
+GET /v1.0/db-instances/{dbInstanceId}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Get | List DB Instance Details |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| dbInstanceId | Body | UUID | DB instance identifier |
+| dbInstanceGroupId | Body | UUID | DB instance group identifier |
+| dbInstanceName | Body | String | Name to identify DB instances |
+| description | Body | String | Additional information on DB instances |
+| dbVersion | Body | Enum | DB engine type |
+| dbPort | Body | Number | DB port |
+| dbInstanceType | Body | Enum | DB instance role type<br/>- MASTER: `Master`<br/>- FAILED_MASTER: `Failed over master`<br/>- CANDIDATE_MASTER: `Candidate master`<br/>- READ_ONLY_SLAVE: `Read replica` |
+| dbInstanceStatus | Body | Enum | DB instance current status<br/>- BEFORE_CREATE: `Before creation (gray)`<br/>- AVAILABLE: `Available (green)`<br/>- STORAGE_FULL: `Storage full (red)`<br/>- FAIL_TO_CREATE: `Failed to create (red)`<br/>- FAIL_TO_CONNECT: `Failed to connect (red)`<br/>- REPLICATION_STOP: `Replication stopped (red)`<br/>- REPLICATION_DELAY: `Replication delayed (yellow)`<br/>- FAILOVER: `Failover completed (red)`<br/>- SHUTDOWN: `Stopped (gray)`<br/>- DELETED: `Deleted (gray)` |
+| progressStatus | Body | String | Current task status of DB instance |
+| dbFlavorId | Body | UUID | Identifier of DB instance specifications |
+| parameterGroupId | Body | UUID | Identifier of the parameter group applied to the DB instance |
+| dbSecurityGroupIds | Body | Array | List of DB security group identifiers applied to the DB instance |
+| notificationGroupIds | Body | Array | List of identifiers of notification groups applied to the DB instance |
+| useDeletionProtection | Body | Boolean | Whether deletion protection is enabled for the DB instance |
+| needToApplyParameterGroup | Body | Boolean | Whether the latest parameter group needs to be applied |
+| needMigration | Body | Boolean | Whether migration is required |
+| osVersion | Body | String | OS version |
+| createdYmdt | Body | DateTime | Created date and time |
+| updatedYmdt | Body | DateTime | Modified date and time |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbInstanceName": "dbInstanceName-example",
+    "description": "description-example",
+    "dbVersion": "POSTGRESQL_V14_17",
+    "dbPort": 1,
+    "dbInstanceType": "MASTER",
+    "dbInstanceStatus": "BEFORE_CREATE",
+    "progressStatus": "progressStatus-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [
+        "550e8400-e29b-41d4-a716-446655440000"
+    ],
+    "notificationGroupIds": [
+        "550e8400-e29b-41d4-a716-446655440000"
+    ],
+    "useDeletionProtection": false,
+    "needToApplyParameterGroup": false,
+    "needMigration": false,
+    "osVersion": "osVersion-example",
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+```
+
+</p>
+</details>
+
+---
 
 ### Modify DB Instance
 
@@ -1058,43 +1297,59 @@ PUT /v1.0/db-instances/{dbInstanceId}
 
 #### Required permissions
 
-| Permission Name                                | Description           |
-|------------------------------------|--------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforPostgreSQL:DbInstance.Modify | Modify DB Instance |
 
 #### Request
 
-| Name                 | Type   | Format      | Required | Description                                                                        |
-|--------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId       | URL  | UUID    | O  | DB instance identifier                                                              |
-| dbInstanceName     | Body | String  | X  | Name to identify DB instances                                                      |
-| description        | Body | String  | X  | Additional information on DB instances                                                         |
-| dbPort             | Body | Number  | X  | DB port<br/>- Minimum value: `0`<br/>- Maximum value: 65535                                |
-| dbFlavorId         | Body | UUID    | X  | Identifier of DB instance specifications                                                           |
-| parameterGroupId   | Body | UUID    | X  | Parameter group identifier                                                              |
-| dbSecurityGroupIds | Body | Array   | X  | DB security group identifiers                                                          |
-| executeBackup      | Body | Boolean | X  | Whether to execute backup at this time<br/>Default: `false`                                         |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceName | Body | String | X | Name to identify DB instances |
+| dbInstanceCandidateName | Body | String | X | Candidate master name to identify the DB instance |
+| description | Body | String | X | Additional information on DB instances<br/>- Maximum length: `100` |
+| dbPort | Body | Number | X | DB port<br/>- Minimum value: 5432, Maximum value: 45432 |
+| dbFlavorId | Body | UUID | X | Identifier of DB instance specifications |
+| parameterGroupId | Body | UUID | X | Parameter group identifier |
+| dbVersion | Body | Enum | X | DB engine version code |
+| dbSecurityGroupIds | Body | Array | X | List of DB security group identifiers |
+| executeBackup | Body | Boolean | X | Whether to execute backup at this time<br/>- Default: `false` |
+| useOnlineFailover | Body | Boolean | X | Whether to restart using failover<br/>- Default: `false` |
+| waitReplicationDelay | Body | Boolean | X | Whether to wait for replication delay to resolve<br/>- Default: `false` |
+| useReadOnly | Body | Boolean | X | Whether to block write workloads<br/>- Default: `false` |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
-    "dbInstanceName": "db-instance2",
-    "description": "description2",
-    "dbPort": 10001,
+    "dbInstanceName": "dbInstanceName-example",
+    "dbInstanceCandidateName": "dbInstanceCandidateName-example",
+    "description": "description-example",
+    "dbPort": 1,
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbVersion": "POSTGRESQL_V14_17",
     "dbSecurityGroupIds": [],
-    "executeBackup": true
+    "executeBackup": false,
+    "useOnlineFailover": false,
+    "waitReplicationDelay": false,
+    "useReadOnly": false
 }
 ```
+
+</p>
 </details>
 
 #### Response
 
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | Identifier of requested task |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -1103,124 +1358,43 @@ PUT /v1.0/db-instances/{dbInstanceId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
+---
 
-### Get high availability information
+### Apply Latest Parameter Group to DB Instance
 
 ```http
-GET /v1.0/db-instances/{dbInstanceId}/high-availability
+POST /v1.0/db-instances/{dbInstanceId}/apply-recent-parameter-group
 ```
 
 #### Required permissions
 
-| Permission Name                                   | Description         |
-|---------------------------------------|------------|
-| RDSforPostgreSQL:HighAvailability.Get | Get high availability information |
-
-#### Request
-
-| Name                  | Type   | Format      | Required | Description                                                   |
-|---------------------|------|---------|----|------------------------------------------------------|
-| dbInstanceId        | URL  | UUID    | O  | DB instance identifier                                         |
-
-#### Response
-
-| Name                      | Type   | Format      | Description                                                                                                                                                                                                                                                                                                                             |
-|-------------------------|------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| haStatus                | Body | Boolean | High Availability Status<br/>- `CREATED: Created`<br/>- `STABLE`: Normal<br/>- `DISABLE_REPLICATION_DELAY`: Failover stops due to replication delay<br/>- `PAUSING`: Pausing<br/>- `PAUSED`: Paused<br/>- `PAUSED_DUE_TO_TASK`: Paused `due to task`<br/>- `FAILOVER_STARTED`: Failover started<br/>- `FAILOVER_FAILED`: Failover failed<br/>- `FAILOVER_COMPLETED`: Failover complete<br/>- `DELETED`: Deleted |
-| pingInterval            | Body | Number  | Ping interval (sec) when using high availability<br/>- Minimum value: `1`<br/>- Maximum value: `600`                                                                                                                                                                                                                                                                           |
-| failoverReplWaitingTime | Body | Number  | Failover latency when using high availability<br/>- Minimum value: `0`<br/>- If set to -1, it will continue to wait for the replication delay to resolve.                                                                                                                                                                                                                                                   |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "useHighAvailability": true,
-    "haStatus": "STABLE",
-    "pingInterval": 3,
-    "failoverReplWaitingTime": 60
-}
-```
-</details>
-
-
-### Modify High Availability
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/high-availability
-```
-
-#### Required permissions
-
-| Permission Name                                      | Description        |
-|------------------------------------------|-----------|
-| RDSforPostgreSQL:HighAvailability.Modify | Modify High Availability |
-
-#### Request
-
-| Name                      | Type   | Format      | Required | Description                                                                           |
-|-------------------------|------|---------|----|------------------------------------------------------------------------------|
-| dbInstanceId            | URL  | UUID    | O  | DB instance identifier                                                                 |
-| useHighAvailability     | Body | Boolean | O  | Whether to use high availability                                                                   |
-| pingInterval            | Body | Number  | X  | Ping interval (sec) when using high availability<br/>- Minimum value: `1`<br/>- Maximum value: `600`                         |
-| failoverReplWaitingTime | Body | Number  | X  | Failover latency when using high availability<br/>- Minimum value: `0`<br/>- If set to -1, it will continue to wait for the replication delay to resolve. |
-
-#### Response
-
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### Restart High Availability
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/high-availability/resume
-```
-
-#### Required permissions
-
-| Permission Name                                      | Description           |
-|------------------------------------------|--------------|
-| RDSforPostgreSQL:HighAvailability.Resume | Restart High Availability |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Modify | Apply Latest Parameter Group to DB Instance |
 
 #### Request
 
 This API does not require a request body.
 
-| Name           | Type  | Format   | Required | Description           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB instance identifier |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
 
 #### Response
 
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | Identifier of requested task |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -1229,754 +1403,14 @@ This API does not require a request body.
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-
-### Pause High Availability
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/high-availability/pause
-```
-
-#### Required permissions
-
-| Permission Name                                     | Description           |
-|-----------------------------------------|--------------|
-| RDSforPostgreSQL:HighAvailability.Pause | Pause High Availability |
-
-#### Request
-
-This API does not require a request body.
-
-| Name           | Type  | Format   | Required | Description           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB instance identifier |
-
-#### Response
-
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-
-### Recover High Availability
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/high-availability/repair
-```
-
-#### Required permissions
-
-| Permission Name                                      | Description        |
-|------------------------------------------|-----------|
-| RDSforPostgreSQL:HighAvailability.Repair | Recover High Availability |
-
-#### Request
-
-This API does not require a request body.
-
-| Name           | Type  | Format   | Required | Description           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB instance identifier |
-
-#### Response
-
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-
-### Separate High Availability
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/high-availability/split
-```
-
-#### Required permissions
-
-| Permission Name                                     | Description        |
-|-----------------------------------------|-----------|
-| RDSforPostgreSQL:HighAvailability.Split | Separate High Availability |
-
-#### Request
-
-This API does not require a request body.
-
-| Name           | Type  | Format   | Required | Description           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB instance identifier |
-
-#### Response
-
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-
-### Get DB instance storage information
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}/storage-info
-```
-
-#### Required permissions
-
-| Permission Name                             | Description            |
-|---------------------------------|---------------|
-| RDSforPostgreSQL:DbInstance.Get | List DB Instance Details |
-
-#### Request
-
-This API does not require a request body.
-
-| Name           | Type  | Format   | Required | Description           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB instance identifier |
-
-#### Response
-
-| Name               | Type   | Format      | Description                                                                                   |
-|------------------|------|---------|--------------------------------------------------------------------------------------|
-| storageType      | Body | Enum    | Data storage types                                                                          |
-| storageSize      | Body | Number  | Block Storage Size (GB)                                                                      |
-| storageStatus    | Body | Enum    | Data Storage Current Status<br/>- `DETACHED`: Detached<br/>- `ATTACHED`: Attached<br/>- `DELETED`: Deleted |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "storageType": "General SSD",
-    "storageSize": 20,
-    "storageStatus": "ATTACHED"
-}
-```
-</details>
-
-
-### Modifying DB instance storage information
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/storage-info
-```
-
-#### Required permissions
-
-| Permission Name                                | Description           |
-|------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Modify | Modify DB Instance |
-
-#### Request
-
-| Name                | Type   | Format      | Required | Description                                                                        |
-|-------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID    | O  | DB instance identifier                                                              |
-| storageSize       | Body | Number  | O  | Block Storage Size (GB)<br/>- Minimum value: Current value<br/>- Maximum value: `2048`                          |
-
-#### Response
-
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### Get DB instance network information
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}/network-info
-```
-
-#### Required permissions
-
-| Permission Name                             | Description            |
-|---------------------------------|---------------|
-| RDSforPostgreSQL:DbInstance.Get | List DB Instance Details |
-
-#### Request
-
-This API does not require a request body.
-
-| Name           | Type  | Format   | Required | Description           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB instance identifier |
-
-#### Response
-
-| Name                      | Type   | Format      | Description                                                                                                                                      |
-|-------------------------|------|---------|-----------------------------------------------------------------------------------------------------------------------------------------|
-| availabilityZone        | Body | Enum    | Availability zone where DB instance will be created                                                                                                                     |
-| subnet                  | Body | Object  | Subnet object                                                                                                                                  |
-| subnet.subnetId         | Body | UUID    | Subnet identifier                                                                                                                                |
-| subnet.subnetName       | Body | UUID    | Name to identify subnets                                                                                                                        |
-| subnet.subnetCidr       | Body | UUID    | CIDR of subnet                                                                                                                               |
-| subnet.publicAccessible | Body | Boolean | External access is available or not                                                                                                                             |
-| endPoints               | Body | Array   | List of access information                                                                                                                                |
-| endPoints.domain        | Body | String  | Domain                                                                                                                                     |
-| endPoints.ipAddress     | Body | String  | IP address                                                                                                                                   |
-| endPoints.endPointType  | Body | Enum    | Types of access information<br>-`EXTERNAL`: External access domain<br>-`INTERNAL`: Internal access domain<br>-`PUBLIC`: (Deprecated) External access domain<br>-`PRIVATE`: (Deprecated) Internal access domain |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "availabilityZone": "kr-pub-a",
-    "subnet": {
-        "subnetId": "bd453789-34ae-416c-9f78-05b9e43a46be",
-        "subnetName": "Default Network",
-        "subnetCidr": "192.168.0.0/16",
-        "publicAccessible": true
-    },
-    "endPoints": [
-        {
-            "domain": "ea548a78-d85f-43b4-8ddf-c88d999b9905.internal.kr1.postgres.rds.nhncloudservice.com",
-            "ipAddress": "192.168.0.2",
-            "endPointType": "INTERNAL"
-        }
-    ]
-}
-```
-</details>
-
-### Modifying DB instance network information
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/network-info
-```
-
-#### Required permissions
-
-| Permission Name                                | Description           |
-|------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Modify | Modify DB Instance |
-
-#### Request
-
-| Name              | Type   | Format      | Required | Description           |
-|-----------------|------|---------|----|--------------|
-| dbInstanceId    | URL  | UUID    | O  | DB instance identifier |
-| usePublicAccess | Body | Boolean | O  | External access is available or not  |
-
-#### Response
-
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### Get DB instance backup information
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}/backup-info
-```
-
-#### Required permissions
-
-| Permission Name                             | Description            |
-|---------------------------------|---------------|
-| RDSforPostgreSQL:DbInstance.Get | List DB Instance Details |
-
-#### Request
-
-This API does not require a request body.
-
-| Name           | Type  | Format   | Required | Description           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB instance identifier |
-
-#### Response
-
-| Name                                    | Type   | Format     | Description                                                                                                                                                                                                                   |
-|---------------------------------------|------|--------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| backupPeriod                          | Body | Number | Backup retention period                                                                                                                                                                                                          |
-| backupRetryCount                      | Body | Number | Number of backup retries                                                                                                                                                                                                            |
-| backupSchedules                       | Body | Array  | Backup schedules                                                                                                                                                                                                            |
-| backupSchedules.backupWndBgnTime      | Body | String | Backup Start Time                                                                                                                                                                                                             |
-| backupSchedules.backupWndDuration     | Body | Enum   | Backup Window<br/>Auto backup is executed within the set duration from the backup start time.<br/>- `HALF_AN_HOUR`: 30 minutes<br/>- `ONE_HOUR`: 1 hour<br/>- `ONE_HOUR_AND_HALF`: 1.5 hour<br/>- `TWO_HOURS`: 2 hour<br/>- `TWO_HOURS_AND_HALF`: 2.5 hour<br/>- `THREE_HOURS`: 3 hour |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "backupPeriod": 1,
-    "backupRetryCount": 0,
-    "backupSchedules": [
-        {
-            "backupWndBgnTime": "00:00:00",
-            "backupWndDuration": "ONE_HOUR_AND_HALF",
-            "backupRetryExpireTime": "01:30:00"
-        }
-    ]
-}
-```
-</details>
-
-### Modifying DB instance backup information
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/backup-info
-```
-
-#### Required permissions
-
-| Permission Name                                | Description           |
-|------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Modify | Modify DB Instance |
-
-#### Request
-
-| Name                                    | Type   | Format     | Required | Description                                                                                                                                                                                                                   |
-|---------------------------------------|------|--------|----|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                          | URL  | UUID   | O  | DB instance identifier                                                                                                                                                                                                         |
-| backupPeriod                          | Body | Number | X  | Backup retention period<br/>- Minimum value: `0`<br/>- Maximum value: `730`                                                                                                                                                                          |
-| backupRetryCount                      | Body | Number | X  | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10`                                                                                                                                                                             |
-| backupSchedules                       | Body | Array  | X  | Backup schedules                                                                                                                                                                                                            |
-| backupSchedules.backupWndBgnTime      | Body | String | O  | Backup Start Time<br/>- Example: `00:00:00`                                                                                                                                                                                        |
-| backupSchedules.backupWndDuration     | Body | Enum   | O  | Backup Window<br/>Auto backup is executed within the set duration from the backup start time.<br/>- `HALF_AN_HOUR`: 30 minutes<br/>- `ONE_HOUR`: 1 hour<br/>- `ONE_HOUR_AND_HALF`: 1.5 hour<br/>- `TWO_HOURS`: 2 hour<br/>- `TWO_HOURS_AND_HALF`: 2.5 hour<br/>- `THREE_HOURS`: 3 hour |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "backupPeriod": 5,
-    "backupSchedules": [
-        {
-            "backupWndBgnTime": "01:00:00",
-            "backupWndDuration": "TWO_HOURS",
-            "backupRetryExpireTime": "03:00:00"
-        }
-    ]
-}
-```
-</details>
-
-#### Response
-
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### Get DB instance restore information
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}/restoration-info
-```
-
-#### Required permissions
-
-| Permission Name                             | Description            |
-|---------------------------------|---------------|
-| RDSforPostgreSQL:DbInstance.Get | List DB Instance Details |
-
-#### Request
-
-| Name           | Type  | Format   | Required | Description           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB instance identifier |
-
-#### Response
-
-| Name                                      | Type   | Format       | Description                                                                                                                                                    |
-|-----------------------------------------|------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
-| oldestRestorableYmdt                    | Body | DateTime | Oldest restoreable time                                                                                                                                      |
-| latestRestorableYmdt                    | Body | DateTime | Most recent restoreable time                                                                                                                                      |
-| restorableBackups                       | Body | Array    | List of restoreable backups                                                                                                                                          |
-| restorableBackups.backup                | Body | Object   | Backup information objects                                                                                                                                              |
-| restorableBackups.backup.backupId       | Body | UUID     | Backup identifier                                                                                                                                               |
-| restorableBackups.backup.backupName     | Body | String   | Backup name                                                                                                                                                 |
-| restorableBackups.backup.backupSize     | Body | Number   | Backup size                                                                                                                                                 |
-| restorableBackups.backup.backupType     | Body | Enum     | Backup type<br/>- `AUTO`: Automatic<br/>`MANUAL: Manual`                                                                                                             |
-| restorableBackups.backup.backupStatus   | Body | Enum     | Backup Status<br/>`BACKING_UP`: Backup in progress<br/>`COMPLETED`: Backup completed<br/>`DELETING`: Backup being deleted<br/>`DELETED`: Backup deleted<br/>`ERROR`: Error occurred |
-| restorableBackups.backup.dbInstanceId   | Body | UUID     | Original DB instance identifier                                                                                                                                       |
-| restorableBackups.backup.dbInstanceName | Body | String   | Original DB instance name                                                                                                                                        |
-| restorableBackups.backup.dbVersion      | Body | String   | DB version information                                                                                                                                              |
-| restorableBackups.backup.failoverCount  | Body | Number   | Number of failovers                                                                                                                                              |
-| restorableBackups.backup.walFileName    | Body | String   | WAL log file name                                                                                                                                          |
-| restorableBackups.backup.createdYmdt    | Body | DateTime | Date and time of backup creation                                                                                                                                              |
-| restorableBackups.backup.updatedYmdt    | Body | DateTime | Date and time of backup renewal                                                                                                                                              |
-| restorableBackups.backup.startYmdt      | Body | DateTime | When backups start                                                                                                                                              |
-| restorableBackups.backup.completedYmdt  | Body | DateTime | Backup completion date                                                                                                                                              |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "oldestRestorableYmdt": "2023-07-09T16:33:33+09:00",
-    "latestRestorableYmdt": "2023-07-10T15:44:44+09:00",
-    "restorableBackups": [
-        {
-            "backup": {
-                "backupId": "145d889a-fe08-474f-8f58-bde576ff96a9",
-                "backupName": "example-backup-name",
-                "backupStatus": "COMPLETED",
-                "dbInstanceId": "dba1be25-9429-4589-9716-7fb6daad7cb9",
-                "dbInstanceName": "original-db-instance-name",
-                "dbVersion": "POSTGRESQL_V17_6",
-                "backupType": "MANUAL",
-                "backupSize": 8299904,
-                "walFileName": "000000010000000000000005",
-                "createdYmdt": "2023-07-10T15:44:44+09:00",
-                "updatedYmdt": "2023-07-10T15:46:07+09:00"
-            }
-        }
-    ]
-}
-```
-</details>
-
-### Restore DB Instance
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/restore
-```
-
-#### Required permissions
-
-| Permission Name                                 | Description           |
-|-------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Restore | Restore DB Instance |
-
-#### Common Request
-
-| Name                                       | Type   | Format      | Required | Description                                                                                                                                                                                                                                                  |
-|------------------------------------------|------|---------|----|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                             | URL  | UUID    | O  | DB instance identifier                                                                                                                                                                                                                                        |
-| restore                                  | Body | Object  | O  | Restoration information object                                                                                                                                                                                                                                            |
-| restore.restoreType                      | Body | Enum    | O  | Restoration type<br/>`TIMESTAMP`: A point-in-time restoration type using the time within the restorable time<br/>- `BACKUP`: Restore type using a previously created backup                                                                                                                                                    |
-| dbInstanceName                           | Body | String  | O  | Name to identify DB instances                                                                                                                                                                                                                                |
-| description                              | Body | String  | X  | Additional information on DB instances                                                                                                                                                                                                                                   |
-| dbFlavorId                               | Body | UUID    | O  | Identifier of DB instance specifications                                                                                                                                                                                                                                     |
-| dbPort                                   | Body | Number  | O  | DB port<br/>- Minimum value: `3306`<br/>- Maximum value: `43306`                                                                                                                                                                                                          |
-| parameterGroupId                         | Body | UUID    | O  | Parameter group identifier                                                                                                                                                                                                                                        |
-| dbSecurityGroupIds                       | Body | Array   | X  | DB security group identifiers                                                                                                                                                                                                                                    |
-| userGroupIds                             | Body | Array   | X  | User group identifiers                                                                                                                                                                                                                                      |
-| useDefaultNotification                   | Body | Boolean | X  | Whether to use default notification<br/>Default: `false`                                                                                                                                                                                                                      |
-| useDeletionProtection                    | Body | Boolean | X  | Whether to protect against deletion<br>Default: `false`                                                                                                                                                                                                                            |                                                                                                                                                                                                                                                                                                                                                                                                                                        |
-| useHighAvailability                      | Body | Boolean | X  | Whether to use high availability<br/>Default: `false`                                                                                                                                                                                                                       |
-| pingInterval                             | Body | Number  | X  | Ping interval (sec) when using high availability<br/>- Default: `3Minimum` `:` 1<br/>- Maximum value: `600`                                                                                                                                                                                        |
-| failoverReplWaitingTime                  | Body | Number  | X  | Failover latency when using high availability<br/>- Minimum value: `0`<br/>- If set to -1, it will continue to wait for the replication delay to resolve.                                                                                                                                                                        |                                                                                                                                                                                                                      | userGroupIds                             | Body | Array   | X  | List of identifiers for user groups that receive default notifications                                                                                                                                                                                             |
-| network                                  | Body | Object  | O  | Network information objects                                                                                                                                                                                                                                          |
-| network.subnetId                         | Body | UUID    | O  | Subnet identifier                                                                                                                                                                                                                                            |
-| network.usePublicAccess                  | Body | Boolean | X  | External access is available or not<br/>Default: `false`</li></ul>                                                                                                                                                                                                            |
-| network.availabilityZone                 | Body | Enum    | X  | Availability zone where DB instance will be created<br/>- Example: `kr-pub-a`<br/>- Default: `Any availability` zone                                                                                                                                                                                    |
-| storage                                  | Body | Object  | O  | Storage information objects                                                                                                                                                                                                                                          |
-| storage.storageType                      | Body | Enum    | O  | Block Storage Type<br/>- Example: `General SSD`                                                                                                                                                                                                                 |
-| storage.storageSize                      | Body | Number  | O  | Block Storage Size (GB)<br/>- Minimum value: `20`<br/>- Maximum value: `2048`                                                                                                                                                                                                   |
-| backup                                   | Body | Object  | O  | Backup information objects                                                                                                                                                                                                                                            |
-| backup.backupPeriod                      | Body | Number  | O  | Backup retention period<br/>- Minimum value: `0`<br/>- Maximum value: `730`                                                                                                                                                                                                         |
-| backup.backupRetryCount                  | Body | Number  | X  | Number of backup retries<br/>Default: `6`<br/>- Minimum value: `0`<br/>- Maximum value: `10`                                                                                                                                                                                             |
-| backup.backupSchedules                   | Body | Array   | O  | Backup schedules                                                                                                                                                                                                                                           |
-| backup.backupSchedules.backupWndBgnTime  | Body | String  | X  | Backup started time<br/>- Example: `00:00:00`<br/>- Default: Original DB instance value                                                                                                                                                                                               |
-| backup.backupSchedules.backupWndDuration | Body | Enum    | X  | Backup duration<br/>Auto backup proceeds within duration from backup start time.<br/>- `HALF_AN_HOUR`: 30 minutes<br/>- `ONE_HOUR`: 1 hour<br/>- `ONE_HOUR_AND_HALF`: 1.5 hour<br/>- `TWO_HOURS`: 2 hour<br/>- `TWO_HOURS_AND_HALF`: 2.5 hour<br/>- `THREE_HOURS`: 3 hour<br/>- Default: Original DB instance value |
-
-#### Request when restoring a point in time restoration using Timestamp (if restoreType is `TIMESTAMP`)
-
-| Name                  | Type   | Format       | Required | Description                                                                                              |
-|---------------------|------|----------|----|-------------------------------------------------------------------------------------------------|
-| restore.restoreYmdt | Body | DateTime | O  | DB instance restore time. (YYYY-MM-DDThh:mm:ss.SSSTZD)<br>Restoration is possible only before the most recent restorable time, which is queried through restoration information inquiry. |
-
-<details><summary>Example</summary>
-
-```json
-{
-  "dbInstanceName": "db-instance",
-  "description": "description",
-  "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-  "dbPort": 10000,
-  "dbUserName": "db-user",
-  "dbPassword": "password",
-  "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-  "dbSecurityGroupIds": [
-    "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-  ],
-  "userGroupIds": [],
-  "network": {
-    "subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36"
-  },
-  "storage": {
-    "storageType": "General SSD",
-    "storageSize": 20
-  },
-  "restore": {
-    "restoreType": "TIMESTAMP",
-    "restoreYmdt": "2023-07-10T15:44:44+09:00"
-  },
-  "backup": {
-    "backupPeriod": 1,
-    "backupSchedules": [
-      {
-        "backupWndBgnTime": "00:00:00",
-        "backupWndDuration": "ONE_HOUR_AND_HALF"
-      }
-    ]
-  }
-}
-```
-</details>
-
-#### Response
-
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-
-### Change DB Instance Deletion Protection Settings
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/deletion-protection
-```
-
-#### Required permissions
-
-| Permission Name                                | Description           |
-|------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Modify | Modify DB Instance |
-
-#### Request
-
-| Name                    | Type   | Format      | Required | Description           |
-|-----------------------|------|---------|----|--------------|
-| dbInstanceId          | URL  | UUID    | O  | DB instance identifier |
-| useDeletionProtection | Body | Boolean | O  | Whether to protect against deletion     |
-
-#### Response
-
-This API does not return a response body.
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
-
-
-### Get DB instance maintenance information
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}/maintenance-info
-```
-
-#### Required permissions
-
-| Permission Name                                | Description           |
-|------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Get | List DB Instance Details |
-
-#### Request
-
-| Name                    | Type   | Format      | Required | Description           |
-|-----------------------|------|---------|----|--------------|
-| dbInstanceId          | URL  | UUID    | O  | DB instance identifier |
-
-#### Response
-
-| Name                  | Type | Format  | Description                                                                                                                          |
-|-----------------------|------|---------|--------------------------------------------------------------------------------------------------------------------------------------|
-| allowAutoMaintenance  | Body | Boolean | Whether to allow automatic maintenance                                                                                               |
-| useAutoStorageCleanup | Body | Boolean | Whether to enable automatic storage cleanup                                                                                          |
-| maintWndBgnTime       | Body | String  | Automatic maintenance start time <br/>- Example: `00:00:00`                                                                          |
-| maintWndDuration      | Body | ENUM    | Maintenance window <br/> Examples: `half_an_hour`, `one_hour`, `one_hour_and_half`, `two_hours`, `two_hours_and_half`, `three_hours` |
-| logRetentionPeriod    | Body | Number  | Log retention period (days)                                                                                                                          |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "allowAutoMaintenance": true,
-    "useAutoStorageCleanup": true,
-    "maintWndBgnTime": "00:00:00",
-    "maintWndDuration": "HALF_AN_HOUR",
-    "logRetentionPeriod": 7
-}
-```
-</details>
-
-
-### Modify DB instance maintenance information
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/maintenance-info
-```
-
-#### Required permissions
-
-| Permission Name                                | Description           |
-|------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Modify | Modify DB Instance |
-
-#### Request
-
-| Name                  | Type | Format  | Required | Description                                                                                                                          |
-|-----------------------|------|---------|----------|--------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId          | URL  | UUID    | O        | DB instance identifier                                                                                                               |
-| allowAutoMaintenance  | Body | Boolean | O        | Whether to allow automatic maintenance                                                                                               |
-| useAutoStorageCleanup | Body | Boolean | O        | Whether to enable automatic storage cleanup                                                                                          |
-| maintWndBgnTime       | Body | String  | O        | Automatic maintenance start time <br/>- Example: `00:00:00`                                                                          |
-| maintWndDuration      | Body | ENUM    | O        | Maintenance window <br/> Examples: `half_an_hour`, `one_hour`, `one_hour_and_half`, `two_hours`, `two_hours_and_half`, `three_hours` |
-| logRetentionPeriod    | Body | Number  | X        | Log retention period (days)                                                                                                                          |
-
-<details><summary>Example</summary>
-
-```json
-{
-  "allowAutoMaintenance": true,
-  "useAutoStorageCleanup": true,
-  "logRetentionPeriod": 7
-}
-```
-</details>
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
-<details><summary>Example</summary>
-
-```json
-{
-  "header": {
-    "resultCode": 0,
-    "resultMessage": "SUCCESS",
-    "isSuccessful": true
-  },
-  "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-
+---
 ### Get selectable DB versions in the current DB instance
 
 ```http
@@ -1985,26 +1419,30 @@ GET /v1.0/db-instances/{dbInstanceId}/available-db-versions
 
 #### Required permissions
 
-| Permission Name                                | Description           |
-|------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Get | List DB Instance Details |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Get | Get selectable DB versions in the current DB instance |
 
 #### Request
 
-| Name                    | Type   | Format      | Required | Description           |
-|-----------------------|------|---------|----|--------------|
-| dbInstanceId          | URL  | UUID    | O  | DB instance identifier |
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
 
 #### Response
 
-| Name                           | Type   | Format      | Description                    |
-|------------------------------|------|---------|-----------------------|
-| dbVersions                   | Body | Array   | DB version list              |
-| dbVersions.dbVersion         | Body | String  | DB version                 |
-| dbVersions.dbVersionName     | Body | String  | DB version name                |
-| dbVersions.restorableFromObs | Body | Boolean | Restoring backup from object storage available or not |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| availableDbVersions | Body | Array | DB version information |
+| availableDbVersions.dbVersionCode | Body | Enum | DB version code<br/>- MYSQL_V5633<br/>- MYSQL_V5715<br/>- MYSQL_V5719<br/>- MYSQL_V5726<br/>- MYSQL_V5731<br/>- MYSQL_V5733<br/>- MYSQL_V5737<br/>- MYSQL_V8018<br/>- MYSQL_V8023<br/>- MYSQL_V8028<br/>- MYSQL_V8032<br/>- MYSQL_V8033<br/>- MYSQL_V8034<br/>- MYSQL_V8035<br/>- MYSQL_V8036<br/>- MYSQL_V8040<br/>- MYSQL_V8041<br/>- MYSQL_V8042<br/>- MYSQL_V8043<br/>- MYSQL_V8044<br/>- MYSQL_V8045<br/>- MYSQL_V8405<br/>- MYSQL_V8406<br/>- MYSQL_V8407<br/>- MYSQL_V8408<br/>- MYSQL_V8409<br/>- MARIADB_V10330<br/>- MARIADB_V10611<br/>- MARIADB_V10612<br/>- MARIADB_V10616<br/>- MARIADB_V10622<br/>- MARIADB_V10625<br/>- MARIADB_V101107<br/>- MARIADB_V101108<br/>- MARIADB_V101113<br/>- MARIADB_V101116<br/>- MARIADB_V11407<br/>- MARIADB_V11410<br/>- MARIADB_V11806<br/>- POSTGRESQL_V14_6<br/>- POSTGRESQL_V14_15<br/>- POSTGRESQL_V14_17<br/>- POSTGRESQL_V14_19<br/>- POSTGRESQL_V17_2<br/>- POSTGRESQL_V17_4<br/>- POSTGRESQL_V17_6 |
+| availableDbVersions.dbMajorVersionCode | Body | Enum | DB major version code<br/>- MYSQL_V56<br/>- MYSQL_V57<br/>- MYSQL_V80<br/>- MYSQL_V84<br/>- MARIADB_V103<br/>- MARIADB_V106<br/>- MARIADB_V1011<br/>- MARIADB_V114<br/>- MARIADB_V118<br/>- POSTGRES_V14<br/>- POSTGRES_V17 |
+| availableDbVersions.name | Body | String | DB version name |
+| availableDbVersions.canCreate | Body | Boolean | Whether creation is available |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -2013,222 +1451,21 @@ GET /v1.0/db-instances/{dbInstanceId}/available-db-versions
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "dbVersions": [
+    "availableDbVersions": [
         {
-            "dbVersion": "POSTGRESQL_V17_6",
-            "dbVersionName": "PostgreSQL V17.6",
-            "restorableFromObs": true
+            "dbVersionCode": "MYSQL_V5633",
+            "dbMajorVersionCode": "MYSQL_V56",
+            "name": "PostgreSQL V14.6",
+            "canCreate": false
         }
     ]
 }
 ```
+
+</p>
 </details>
 
-
-### Delete DB instance
-
-```http
-DELETE /v1.0/db-instances/{dbInstanceId}
-```
-
-#### Required permissions
-
-| Permission Name                                | Description           |
-|------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Delete | Delete DB instance |
-
-#### Request
-
-This API does not require a request body.
-
-| Name           | Type  | Format   | Required | Description           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB instance identifier |
-
-#### Response
-
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### Restart DB Instance
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/restart
-```
-
-#### Required permissions
-
-| Permission Name                                 | Description            |
-|-------------------------------------|---------------|
-| RDSforPostgreSQL:DbInstance.Restart | Restart DB Instance |
-
-#### Request
-
-| Name                | Type   | Format      | Required | Description                                                                        |
-|-------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID    | O  | DB instance identifier                                                              |
-| useOnlineFailover | Body | Boolean | X  | Whether to restart using failover<br/>Available only for DB instance using high availability<br/>Default: `false` |
-| executeBackup     | Body | Boolean | X  | Whether to execute backup at this time<br/>Default: `false`                                         |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "executeBackup": true
-}
-```
-</details>
-
-#### Response
-
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### Force Restart DB instance
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/force-restart
-```
-
-#### Required permissions
-
-| Permission Name                                      | Description               |
-|------------------------------------------|------------------|
-| RDSforPostgreSQL:DbInstance.ForceRestart | Force Restart DB instance |
-
-#### Request
-
-| Name           | Type  | Format   | Required | Description           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB instance identifier |
-
-#### Response
-
-This API does not return a response body.
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
-
-
-### Start DB Instance
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/start
-```
-
-#### Required permissions
-
-| Permission Name                               | Description           |
-|-----------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Start | Start DB Instance |
-
-#### Request
-
-This API does not require a request body.
-
-| Name           | Type  | Format   | Required | Description           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB instance identifier |
-
-#### Response
-
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### Stop DB Instance
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/stop
-```
-
-#### Required permissions
-
-| Permission Name                               | Description           |
-|-----------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Start | Start DB Instance |
-
-#### Request
-
-This API does not require a request body.
-
-| Name           | Type  | Format   | Required | Description           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB instance identifier |
-
-#### Response
-
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
+---
 
 ### Backup DB Instance
 
@@ -2238,33 +1475,37 @@ POST /v1.0/db-instances/{dbInstanceId}/backup
 
 #### Required permissions
 
-| Permission Name                                | Description           |
-|------------------------------------|--------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforPostgreSQL:DbInstance.Backup | Backup DB Instance |
 
 #### Request
 
-| Name           | Type   | Format     | Required | Description              |
-|--------------|------|--------|----|-----------------|
-| dbInstanceId | URL  | UUID   | O  | DB instance identifier    |
-| backupName   | Body | String | O  | Name to identify backups |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| backupName | Body | String | O | Name to identify backups |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
-    "backupName": "backup"
+    "backupName": "backupName-example"
 }
 ```
+
+</p>
 </details>
 
 #### Response
 
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | Identifier of requested task |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -2273,12 +1514,147 @@ POST /v1.0/db-instances/{dbInstanceId}/backup
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-### Export after Backing up DB Instance
+---
+
+### Get DB Instance Backup Information
+
+```http
+GET /v1.0/db-instances/{dbInstanceId}/backup-info
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Get | Get DB Instance Backup Information |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| allowAutoBackup | Body | Boolean | Whether automatic backup is allowed |
+| usePeriodicAutoBackup | Body | Boolean | Whether scheduled automatic backup is used |
+| backupPeriod | Body | Number | Backup retention period (days) |
+| backupRetryCount | Body | Number | Number of backup retries |
+| backupSchedules | Body | Array | Backup schedules |
+| backupSchedules.backupWndBgnTime | Body | Time | Backup start time |
+| backupSchedules.backupWndDuration | Body | Enum | Backup Window<br/>Auto backup is executed within the set duration from the backup start time.<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hour`<br/>- TWO_HOURS: `2 hour`<br/>- TWO_HOURS_AND_HALF: `2.5 hour`<br/>- THREE_HOURS: `3 hour` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "allowAutoBackup": false,
+    "usePeriodicAutoBackup": false,
+    "backupPeriod": 1,
+    "backupRetryCount": 1,
+    "backupSchedules": [
+        {
+            "backupWndBgnTime": "00:00:00",
+            "backupWndDuration": "HALF_AN_HOUR"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### Modify DB Instance Backup Information
+
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/backup-info
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Modify | Modify DB Instance Backup Information |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| allowAutoBackup | Body | Boolean | X | Whether automatic backup is allowed |
+| usePeriodicAutoBackup | Body | Boolean | X | Whether scheduled automatic backup is used |
+| backupPeriod | Body | Number | X | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| backupRetryCount | Body | Number | X | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| backupSchedules | Body | Array | X | Backup schedules |
+| backupSchedules.backupWndBgnTime | Body | Time | O | Backup start time |
+| backupSchedules.backupWndDuration | Body | Enum | O | Backup Window<br/>Auto backup is executed within the set duration from the backup start time.<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hour`<br/>- TWO_HOURS: `2 hour`<br/>- TWO_HOURS_AND_HALF: `2.5 hour`<br/>- THREE_HOURS: `3 hour` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "allowAutoBackup": false,
+    "usePeriodicAutoBackup": false,
+    "backupPeriod": 0,
+    "backupRetryCount": 0,
+    "backupSchedules": [
+        {
+            "backupWndBgnTime": "00:00:00",
+            "backupWndDuration": "HALF_AN_HOUR"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Export after Backing up DB Instance to Object Storage
 
 ```http
 POST /v1.0/db-instances/{dbInstanceId}/backup-to-object-storage
@@ -2286,41 +1662,45 @@ POST /v1.0/db-instances/{dbInstanceId}/backup-to-object-storage
 
 #### Required permissions
 
-| Permission Name                                               | Description                         |
-|---------------------------------------------------|----------------------------|
-| RDSforPostgreSQL:DbInstance.BackupToObjectStorage | Export Backup Files to Object Storage After Backup |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.BackupToObjectStorage | Export after Backing up DB Instance to Object Storage |
 
 #### Request
 
-| Name              | Type   | Format     | Required | Description                          |
-|-----------------|------|--------|----|-----------------------------|
-| dbInstanceId    | URL  | UUID   | O  | DB instance identifier                |
-| tenantId        | Body | String | O  | Tenant ID of object storage to store backup   |
-| username        | Body | String | O  | ID of NHN Cloud Account or IAM Account   |
-| password        | Body | String | O  | API password for object storage where backup is stored |
-| targetContainer | Body | String | O  | Object storage container where backup is stored     |
-| objectPath      | Body | String | O  | Backup path to be stored in container            |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| tenantId | Body | String | O | Tenant ID of object storage to store backup<br/>- Minimum length: `32`<br/>- Maximum length: `32` |
+| username | Body | String | O | ID of NHN Cloud Account or IAM Account |
+| password | Body | String | O | API password for object storage where backup is stored |
+| targetContainer | Body | String | O | Object storage container where backup is stored |
+| objectPath | Body | String | O | Backup path to be stored in container |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
-    "tenantId": "399631c404744dbbb18ce4fa2dc71a5a",
-    "username": "gildong.hong@nhn.com",
-    "password": "password",
-    "targetContainer": "/container",
-    "objectPath": "/backups/backup_file"
+    "tenantId": "0123456789abcdef0123456789abcdef",
+    "username": "username-example",
+    "password": "password-example",
+    "targetContainer": "targetContainer-example",
+    "objectPath": "objectPath-example"
 }
 ```
+
+</p>
 </details>
 
 #### Response
 
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | Identifier of requested task |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -2329,172 +1709,14 @@ POST /v1.0/db-instances/{dbInstanceId}/backup-to-object-storage
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-### Applying DB instance latest parameter groups
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/apply-recent-parameter-group
-```
-
-#### Required permissions
-
-| Permission Name                                | Description           |
-|------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Modify | Modify DB Instance |
-
-#### Request
-
-| Name                | Type   | Format      | Required | Description                                                                        |
-|-------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID    | O  | DB instance identifier                                                              |
-| executeBackup     | Body | Boolean | X  | Whether to execute backup at this time<br/>Default: `false`                                         |
-
-<details><summary>Example</summary>
-
-```json
-{
-  "executeBackup": true
-}
-```
-</details>
-
-#### Response
-
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### Replicate DB Instance
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/replicate
-```
-
-#### Required permissions
-
-| Permission Name                                   | Description           |
-|---------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Replicate | Replicate DB Instance |
-
-#### Request
-
-| Name                                           | Type   | Format      | Required | Description                                                                                                                                                                                                                                                  |
-|----------------------------------------------|------|---------|----|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                                 | URL  | UUID    | O  | DB instance identifier                                                                                                                                                                                                                                        |
-| dbInstanceName                               | Body | String  | O  | Name to identify DB instances                                                                                                                                                                                                                                |
-| description                                  | Body | String  | X  | Additional information on DB instances                                                                                                                                                                                                                                   |
-| dbFlavorId                                   | Body | UUID    | X  | Identifier of DB instance specifications<br/>- Default: Original DB instance value                                                                                                                                                                                                             |
-| dbPort                                       | Body | Number  | X  | DB port<br/>- Default: Original DB instance value<br/>- Minimum value: `0`<br/>- Maximum value: 65535                                                                                                                                                                                  |
-| parameterGroupId                             | Body | UUID    | X  | Parameter group identifier<br/>- Default: Original DB instance value                                                                                                                                                                                                                |
-| dbSecurityGroupIds                           | Body | Array   | X  | DB security group identifiers<br/>- Default: Original DB instance value                                                                                                                                                                                                            |
-| userGroupIds                                 | Body | Array   | X  | User group identifiers                                                                                                                                                                                                                                      |
-| useDefaultNotification                       | Body | Boolean | X  | Whether to use default notification<br/>Default: `false`                                                                                                                                                                                                                      |
-| useDeletionProtection                        | Body | Boolean | X  | Whether to protect against deletion<br/>Default: `false`                                                                                                                                                                                                                         |
-| network                                      | Body | Object  | X  | Network information objects                                                                                                                                                                                                                                          |
-| network.usePublicAccess                      | Body | Boolean | X  | External access is available or not<br/>Default: `false`                                                                                                                                                                                                                      |
-| network.availabilityZone                     | Body | Enum    | X  | Availability zone where DB instance will be created<br/>- Example: `kr-pub-a`<br/>- Default: `Any availability` zone                                                                                                                                                                                    |  
-| storage                                      | Body | Object  | X  | Storage information objects                                                                                                                                                                                                                                          |    
-| storage.storageType                          | Body | Enum    | X  | Data storage types<br>- Example: `General SSD`                                                                                                                                                                                                                  |
-| storage.storageSize                          | Body | Number  | X  | Block Storage Size (GB)<br/>- Default: Original DB instance value<br/>- Minimum value: `20`<br/>- Maximum value: `2048`                                                                                                                                                                           |
-| backup                                       | Body | Object  | X  | Backup information objects                                                                                                                                                                                                                                            |
-| backup.backupPeriod                          | Body | Number  | X  | Backup retention period<br/>- Default: Original DB instance value<br/>- Minimum value: `0`<br/>- Maximum value: `730`                                                                                                                                                                                 |
-| backup.backupRetryCount                      | Body | Number  | X  | Number of backup retries<br/>- Default: Original DB instance value<br/>- Minimum value: `0`<br/>- Maximum value: `10`                                                                                                                                                                                    |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "dbInstanceName": "db-instance-replicate",
-    "description": "description",
-    "dbPort": 15432,
-    "storage": {
-        "storageSize": 100
-    }
-}
-```
-</details>
-
-#### Response
-
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### Promote DB Instance
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/promote
-```
-
-#### Required permissions
-
-| Permission Name                                 | Description           |
-|-------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Promote | Promote DB Instance |
-
-#### Request
-
-This API does not require a request body.
-
-| Name           | Type  | Format   | Required | Description           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB instance identifier |
-
-#### Response
-
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-
-## DB Instances > Databases
-
+---
 ### View the list of databases
 
 ```http
@@ -2503,32 +1725,34 @@ GET /v1.0/db-instances/{dbInstanceId}/databases
 
 #### Required permissions
 
-| Permission Name                                      | Description                     |
-|------------------------------------------|------------------------|
-| RDSforPostgreSQL:DbInstanceDatabase.List | View a list of databases in a DB instance |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceDatabase.List | View the list of databases |
 
 #### Request
 
 This API does not require a request body.
 
-| Name           | Type  | Format   | Required | Description           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB instance identifier |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
 
 #### Response
 
-| Name                           | Type   | Format       | Description                                                                                                                                                  |
-|------------------------------|------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| databases                    | Body | Array    | List of databases                                                                                                                                           |
-| databases.databaseId         | Body | UUID     | Identifiers in the database                                                                                                                                         |
-| databases.databaseName       | Body | String   | Database Name                                                                                                                                           |
-| databases.databaseStatus     | Body | Enum     | Current state of the database<br/>- `STABLE`: Created<br/>(CREATING: Creating,<br/>- `MODIFYING`: Modifying<br/>- `SYNCING`: Synchronizing<br/>DELETING: Deleting,<br/>- `DELETED`: Deleted |
-| databases.createdYmdt        | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                   |
-| databases.updatedYmdt        | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                   |
-| databases.schemas            | Body | Array    | List of schemas in the database                                                                                                                                     |
-| databases.schemas.schemaName | Body | String   | Schema name                                                                                                                                              |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| databases | Body | Array | Database information |
+| databases.databaseId | Body | UUID | Database identifier |
+| databases.databaseName | Body | String | Database name |
+| databases.databaseStatus | Body | Enum | Current state of the database<br/>- STABLE: `Available`<br/>- CREATING: `Creating`<br/>- MODIFYING: `Modifying`<br/>- DELETING: `Deleting`<br/>- DELETED: `Deleted`<br/>- SYNCING: `Synchronizing`<br/>- DELETE_ERROR: `Deletion failed` |
+| databases.createdYmdt | Body | DateTime | Created date and time |
+| databases.updatedYmdt | Body | DateTime | Modified date and time |
+| databases.schemas | Body | Array | Schema information |
+| databases.schemas.schemaName | Body | String | Schema name |
+| databases.errorReason | Body | String | Reason for deletion failure |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -2539,21 +1763,26 @@ This API does not require a request body.
     },
     "databases": [
         {
-            "databaseId": "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4",
-            "databaseName": "database",
+            "databaseId": "550e8400-e29b-41d4-a716-446655440000",
+            "databaseName": "databaseName-example",
             "databaseStatus": "STABLE",
-            "createdYmdt": "2023-03-20T13:37:45+09:00",
-            "updatedYmdt": "2023-03-20T13:37:45+09:00",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00",
             "schemas": [
                 {
-                    "schemaName": "rds"
+                    "schemaName": "schemaName-example"
                 }
-            ]
+            ],
+            "errorReason": "errorReason-example"
         }
     ]
 }
 ```
+
+</p>
 </details>
+
+---
 
 ### Create a database
 
@@ -2563,33 +1792,37 @@ POST /v1.0/db-instances/{dbInstanceId}/databases
 
 #### Required permissions
 
-| Permission Name                                        | Description                    |
-|--------------------------------------------|-----------------------|
-| RDSforPostgreSQL:DbInstanceDatabase.Create | Creating a database within a DB instance |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceDatabase.Create | Create a database |
 
 #### Request
 
-| Name           | Type   | Format     | Required | Description           |
-|--------------|------|--------|----|--------------|
-| dbInstanceId | URL  | UUID   | O  | DB instance identifier |
-| databaseName | Body | String | O  | Database Name    |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| databaseName | Body | String | O | Database name |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
-    "databaseName": "database"
+    "databaseName": "databaseName-example"
 }
 ```
+
+</p>
 </details>
 
 #### Response
 
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of the requested task |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -2598,62 +1831,16 @@ POST /v1.0/db-instances/{dbInstanceId}/databases
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-### Modifying the database
+---
 
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/databases/{databaseId}
-```
-
-#### Required permissions
-
-| Permission Name                                        | Description                    |
-|--------------------------------------------|-----------------------|
-| RDSforPostgreSQL:DbInstanceDatabase.Modify | Modifying databases within a DB instance |
-
-#### Request
-
-| Name                       | Type   | Format      | Required | Description                                                                                          |
-|--------------------------|------|---------|----|---------------------------------------------------------------------------------------------|
-| dbInstanceId             | URL  | UUID    | O  | DB instance identifier                                                                                |
-| databaseId               | URL  | UUID    | O  | Identifiers in the database                                                                                 |
-| databaseName             | Body | String  | O  | Database Name                                                                                   |
-| applyHbaRulesImmediately | Body | Boolean | X  | Whether to apply associated access control rules immediately<br/>- When you change the database name, any access control rules set under the old database name are reflected with the changed name. |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "databaseName": "database-1"
-}
-```
-</details>
-
-#### Response
-
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### Deleting a database
+### Delete a database
 
 ```http
 DELETE /v1.0/db-instances/{dbInstanceId}/databases/{databaseId}
@@ -2661,26 +1848,27 @@ DELETE /v1.0/db-instances/{dbInstanceId}/databases/{databaseId}
 
 #### Required permissions
 
-| Permission Name                                        | Description                    |
-|--------------------------------------------|-----------------------|
-| RDSforPostgreSQL:DbInstanceDatabase.Delete | Deleting a database within a DB instance |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceDatabase.Delete | Delete a database |
 
 #### Request
 
 This API does not require a request body.
 
-| Name           | Type  | Format   | Required | Description           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB instance identifier |
-| databaseId   | URL | UUID | O  | Identifiers in the database  |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| databaseId | URL | UUID | O | Database identifier |
 
 #### Response
 
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of the requested task |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -2689,13 +1877,73 @@ This API does not require a request body.
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-## DB Instances > Users
+---
 
+### Modify a database
+
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/databases/{databaseId}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceDatabase.Modify | Modify a database |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| databaseId | URL | UUID | O | Database identifier |
+| applyHbaRulesImmediately | Body | Boolean | X | Whether to apply associated access control rules immediately<br/>- Default: `false` |
+| databaseName | Body | String | O | Database name |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "applyHbaRulesImmediately": false,
+    "databaseName": "databaseName-example"
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of the requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
 ### View the list of users
 
 ```http
@@ -2704,31 +1952,32 @@ GET /v1.0/db-instances/{dbInstanceId}/db-users
 
 #### Required permissions
 
-| Permission Name                                  | Description                  |
-|--------------------------------------|---------------------|
-| RDSforPostgreSQL:DbInstanceUser.List | Viewing a list of users in a DB instance |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceUser.List | View the list of users |
 
 #### Request
 
 This API does not require a request body.
 
-| Name           | Type  | Format   | Required | Description           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB instance identifier |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
 
 #### Response
 
-| Name                    | Type   | Format       | Description                                                                                                                                                  |
-|-----------------------|------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbUsers               | Body | Array    | DB users                                                                                                                                           |
-| dbUsers.dbUserId      | Body | UUID     | DB user identifier                                                                                                                                         |
-| dbUsers.dbUserName    | Body | String   | DB user account name                                                                                                                                        |
-| dbUsers.authorityType | Body | Enum     | DB user permission types<br/>- `CRUD`: Permission to execute DML query<br/>- `DDL`: Permission to execute DDL query                                                                           |
-| dbUsers.dbUserStatus  | Body | Enum     | DB user current status<br/>- `STABLE`: Created<br/>(CREATING: Creating,<br/>- `MODIFYING`: Modifying<br/>- `SYNCING`: Synchronizing<br/>DELETING: Deleting,<br/>- `DELETED`: Deleted |
-| dbUsers.createdYmdt   | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                   |
-| dbUsers.updatedYmdt   | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                   |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| dbUsers | Body | Array | DB user list |
+| dbUsers.dbUserId | Body | UUID | DB user identifier |
+| dbUsers.dbUserName | Body | String | DB user account name |
+| dbUsers.authorityType | Body | Enum | DB user permission types<br/>- CUSTOM: `Custom permission`<br/>- READ: `READ permission (read-only permission)`<br/>- CRUD: `CRUD permission (includes read permission)`<br/>- DDL: `DDL permission (includes CRUD permission)` |
+| dbUsers.dbUserStatus | Body | Enum | DB user current status<br/>- STABLE: `Available`<br/>- CREATING: `Creating`<br/>- MODIFYING: `Modifying`<br/>- DELETING: `Deleting`<br/>- DELETED: `Deleted`<br/>- SYNCING: `Synchronizing`<br/>- DELETE_ERROR: `Deletion failed` |
+| dbUsers.createdYmdt | Body | DateTime | Created date and time |
+| dbUsers.updatedYmdt | Body | DateTime | Modified date and time |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -2737,17 +1986,23 @@ This API does not require a request body.
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "databases": [
+    "dbUsers": [
         {
-            "databaseId": "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4",
-            "databaseName": "database",
-            "databaseStatus": "STABLE",
-            "createdYmdt": "2023-03-20T13:37:45+09:00"
+            "dbUserId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbUserName": "dbUserName-example",
+            "authorityType": "CUSTOM",
+            "dbUserStatus": "STABLE",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
+
+</p>
 </details>
+
+---
 
 ### Create a user
 
@@ -2757,39 +2012,45 @@ POST /v1.0/db-instances/{dbInstanceId}/db-users
 
 #### Required permissions
 
-| Permission Name                                    | Description                 |
-|----------------------------------------|--------------------|
-| RDSforPostgreSQL:DbInstanceUser.Create | Creating a user in a DB instance |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceUser.Create | Create a user |
 
 #### Request
 
-| Name                    | Type   | Format      | Required | Description                                                                        |
-|-----------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId          | URL  | UUID    | O  | DB instance identifier                                                              |
-| dbUserName            | Body | String  | O  | DB user account name<br/>- Minimum length: `1`<br/>- Maximum length: `32`                           |
-| dbPassword            | Body | String  | O  | DB user account password<br/>- Minimum length: `1`<br/>- Maximum length: `32`                          |
-| authorityType         | Body | Enum    | O  | DB user permission types<br/>- `CRUD`: Permission to execute DML query<br/>- `DDL`: Permission to execute DDL query |
-| createDefaultHbaRules | Body | Boolean | X  | Whether to create default access control rules                                                         |
-| address               | Body | String  | X  | Connection address to use when creating default access control rules                                                |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbUserName | Body | String | O | DB user account name |
+| dbPassword | Body | String | O | DB user account password |
+| authorityType | Body | Enum | O | DB user permission types<br/>- CUSTOM: `Custom permission`<br/>- READ: `Read permission`<br/>- CRUD: `CRUD permission`<br/>- DDL: `DDL permission` |
+| createDefaultHbaRules | Body | Boolean | X | Whether to create default access control rules<br/>- Default: `false` |
+| address | Body | String | X | Connection address |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "authorityType": "CRUD"
+    "dbUserName": "dbUserName-example",
+    "dbPassword": "dbPassword-example",
+    "authorityType": "CUSTOM",
+    "createDefaultHbaRules": false,
+    "address": "address-example"
 }
 ```
+
+</p>
 </details>
 
 #### Response
 
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | Identifier of requested task |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -2798,10 +2059,60 @@ POST /v1.0/db-instances/{dbInstanceId}/db-users
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
+
+---
+
+### Delete a user
+
+```http
+DELETE /v1.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceUser.Delete | Delete a user |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbUserId | URL | UUID | O | DB user identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
 
 ### Edit a user
 
@@ -2811,38 +2122,44 @@ PUT /v1.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
 
 #### Required permissions
 
-| Permission Name                                    | Description                 |
-|----------------------------------------|--------------------|
-| RDSforPostgreSQL:DbInstanceUser.Modify | Modifying users in a DB instance |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceUser.Modify | Edit a user |
 
 #### Request
 
-| Name                       | Type   | Format      | Required | Description                                                                                          |
-|--------------------------|------|---------|----|---------------------------------------------------------------------------------------------|
-| dbInstanceId             | URL  | UUID    | O  | DB instance identifier                                                                                |
-| dbUserId                 | URL  | UUID    | O  | DB user identifier                                                                                 |
-| dbUserName               | Body | String  | X  | DB user account name<br/>- Minimum length: `1`<br/>- Maximum length: `32`                                             |
-| dbPassword               | Body | String  | X  | DB user account password<br/>- Minimum length: `1`<br/>- Maximum length: `32`                                            |
-| authorityType            | Body | Enum    | X  | DB user permission types<br/>- `CRUD`: Permission to execute DML query<br/>- `DDL`: Permission to execute DDL query                   |
-| applyHbaRulesImmediately | Body | Boolean | X  | Whether to apply associated access control rules immediately<br/>- When you change a user account name, any access control rules set under the old user account name are reflected with the changed name. |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbUserId | URL | UUID | O | DB user identifier |
+| dbUserName | Body | String | X | DB user account name |
+| dbPassword | Body | String | X | DB user account password |
+| authorityType | Body | Enum | X | DB user permission<br/>- CUSTOM: `Custom permission`<br/>- READ: `Read permission`<br/>- CRUD: `CRUD permission`<br/>- DDL: `DDL permission` |
+| applyHbaRulesImmediately | Body | Boolean | X | Whether to apply access control changes immediately<br/>- Default: `false` |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
-    "dbUserName": "db-user-1",
-    "dbPassword": "new-password"
+    "dbUserName": "dbUserName-example",
+    "dbPassword": "dbPassword-example",
+    "authorityType": "CUSTOM",
+    "applyHbaRulesImmediately": false
 }
 ```
+
+</p>
 </details>
 
 #### Response
 
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | Identifier of requested task |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -2851,54 +2168,77 @@ PUT /v1.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-### Deleting a user
+---
+
+### Change DB Instance Deletion Protection Settings
 
 ```http
-DELETE /v1.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
+PUT /v1.0/db-instances/{dbInstanceId}/deletion-protection
 ```
 
 #### Required permissions
 
-| Permission Name                                    | Description                 |
-|----------------------------------------|--------------------|
-| RDSforPostgreSQL:DbInstanceUser.Delete | Deleting a user in a DB instance |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Modify | Change DB instance deletion protection settings |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| useDeletionProtection | Body | Boolean | O | Whether to enable deletion protection |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "useDeletionProtection": false
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+This API does not return a response body.
+
+---
+
+### Force Restart DB Instance
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/force-restart
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.ForceRestart | Force Restart DB Instance |
 
 #### Request
 
 This API does not require a request body.
 
-| Name           | Type  | Format   | Required | Description           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB instance identifier |
-| dbUserId     | URL | UUID | O  | DB user identifier  |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
 
 #### Response
 
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
+This API does not return a response body.
 
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-## DB Instances > Access Control
-
+---
 ### View a list of access control rules
 
 ```http
@@ -2907,41 +2247,42 @@ GET /v1.0/db-instances/{dbInstanceId}/hba-rules
 
 #### Required permissions
 
-| Permission Name                                 | Description                       |
-|-------------------------------------|--------------------------|
-| RDSforPostgreSQL:DbInstanceHba.List | View a list of access control rules in a DB instance |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceHba.List | View a list of access control rules |
 
 #### Request
 
 This API does not require a request body.
 
-| Name           | Type  | Format   | Required | Description           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB instance identifier |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
 
 #### Response
 
-| Name                              | Type   | Format      | Description                                                                                                                                                   |
-|---------------------------------|------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------|
-| hbaRules                        | Body | Array   | List of access control rules                                                                                                                                          |
-| hbaRules.hbaRuleId              | Body | UUID    | Identifiers for access control rules                                                                                                                                        |
-| hbaRules.hbaRuleStatus          | Body | Enum    | Current status of access control rules<br/>- `CREATED: Created`<br/>- `APPLIED`: Applied<br/>(CREATING: Creating,<br/>- `MODIFYING`: Modifying<br/>DELETING: Deleting,<br/>- `DELETED`: Deleted |
-| hbaRules.databaseApplyType      | Body | String  | How database rules are applied<br/>- `ENTIRE`: All<br/>- `USER_CUSTOM`: Customize                                                                                       |
-| hbaRules.dbUserApplyType        | Body | Enum    | How DB user rules are applied<br/>- `ENTIRE`: All<br/>- `USER_CUSTOM`: Customize                                                                                       |
-| hbaRules.databases              | Body | Array   | List of custom databases                                                                                                                                     |
-| hbaRules.databases.databaseId   | Body | UUID    | Identifiers for custom databases                                                                                                                                   |
-| hbaRules.databases.databaseName | Body | String  | Custom database name                                                                                                                                     |
-| hbaRules.dbUsers                | Body | Array   | Custom DB user list                                                                                                                                     |
-| hbaRules.dbUsers.dbUserId       | Body | UUID    | Identifier of the custom DB user                                                                                                                                   |
-| hbaRules.dbUsers.dbUserName     | Body | String  | Custom DB user account name                                                                                                                                  |
-| hbaRules.address                | Body | String  | Access Address                                                                                                                                                |
-| hbaRules.authMethod             | Body | Enum    | Authentication Method<br/>- `TRUST`: Trust (no password required)<br/>- `REJECT`: Block access<br/>- `SCRAM_SHA_256`: Password (SCRAM-SHA-256)                                                 |
-| hbaRules.reservedAction         | Body | Enum    | Preliminaries<br/>- `NONE`: None<br/>- `CREATE`: Schedule a creation (requires application)<br/>- `MODIFY`: Schedule a modification (requires application)<br/>- `DELETE`: Schedule a delete (requires enforcement)                                        |
-| hbaRules.order                  | Body | Number  | Application order                                                                                                                                                |
-| hbaRules.applicable             | Body | Boolean | Applicability<br/>- Rules with an inapplicable status are ignored                                                                                                                     |
-| needToApply                     | Body | Boolean | Whether changes need to be made                                                                                                                                       |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| hbaRules | Body | Array | List of access control rules |
+| hbaRules.hbaRuleId | Body | UUID | Identifier of the access control rule |
+| hbaRules.hbaRuleStatus | Body | Enum | Current status of the access control rule<br/>- CREATED: `Created`<br/>- APPLIED: `Applied`<br/>- CREATING: `Creating`<br/>- MODIFYING: `Modifying`<br/>- DELETING: `Deleting`<br/>- DELETED: `Deleted` |
+| hbaRules.databaseApplyType | Body | Enum | Database apply type<br/>- ENTIRE: `All`<br/>- USER_CUSTOM: `Customize` |
+| hbaRules.dbUserApplyTypeCode | Body | Enum | DB user apply type<br/>- ENTIRE: `All`<br/>- USER_CUSTOM: `Customize` |
+| hbaRules.databases | Body | Array | List of custom databases |
+| hbaRules.databases.databaseId | Body | UUID | Database identifier |
+| hbaRules.databases.databaseName | Body | String | Database name |
+| hbaRules.dbUsers | Body | Array | Custom DB user list |
+| hbaRules.dbUsers.dbUserId | Body | UUID | DB user identifier |
+| hbaRules.dbUsers.dbUserName | Body | String | DB user account name |
+| hbaRules.address | Body | String | Connection address |
+| hbaRules.authMethod | Body | Enum | Authentication method<br/>- TRUST: `Trust (no password required)`<br/>- REJECT: `Block access`<br/>- SCRAM_SHA_256: `Password (SCRAM-SHA-256)` |
+| hbaRules.reservedAction | Body | Enum | Scheduled task<br/>- NONE: `None`<br/>- CREATE: `Schedule a creation (requires application)`<br/>- MODIFY: `Schedule a modification (requires application)`<br/>- DELETE: `Schedule a deletion (requires application)` |
+| hbaRules.order | Body | Number | Application order |
+| hbaRules.applicable | Body | Boolean | Whether the rule is applicable |
+| needToApply | Body | Boolean | Whether changes need to be applied |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -2952,27 +2293,37 @@ This API does not require a request body.
     },
     "hbaRules": [
         {
-            "hbaRuleId": "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4",
-            "hbaRuleStatus": "APPLIED",
-            "databaseApplyType": "USER_CUSTOM",
-            "dbUserApplyType": "ENTIRE",
+            "hbaRuleId": "550e8400-e29b-41d4-a716-446655440000",
+            "hbaRuleStatus": "CREATED",
+            "databaseApplyType": "ENTIRE",
+            "dbUserApplyTypeCode": "ENTIRE",
             "databases": [
                 {
-                    "databaseId": "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4",
-                    "databaseName": "database"
+                    "databaseId": "550e8400-e29b-41d4-a716-446655440000",
+                    "databaseName": "databaseName-example"
                 }
             ],
-            "dbUsers": [],
-            "address": "0.0.0.0/0",
+            "dbUsers": [
+                {
+                    "dbUserId": "550e8400-e29b-41d4-a716-446655440000",
+                    "dbUserName": "dbUserName-example"
+                }
+            ],
+            "address": "address-example",
             "authMethod": "TRUST",
             "reservedAction": "NONE",
-            "order": 0,
-            "applicable": true
+            "order": 1,
+            "applicable": false
         }
-    ]
+    ],
+    "needToApply": false
 }
 ```
+
+</p>
 </details>
+
+---
 
 ### Add an access control rule
 
@@ -2982,45 +2333,49 @@ POST /v1.0/db-instances/{dbInstanceId}/hba-rules
 
 #### Required permissions
 
-| Permission Name                                   | Description                      |
-|---------------------------------------|-------------------------|
-| RDSforPostgreSQL:DbInstanceHba.Create | Adding access control rules within a DB instance |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceHba.Create | Add an access control rule to a DB instance |
 
 #### Request
 
-| Name                | Type   | Format     | Required | Description                                                                                                   |
-|-------------------|------|--------|----|------------------------------------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID   | O  | DB instance identifier                                                                                         |
-| databaseApplyType | Body | String | O  | How database rules are applied<br/>- `ENTIRE`: All<br/>- `USER_CUSTOM`: Customize                                       |
-| dbUserApplyType   | Body | Enum   | O  | How DB user rules are applied<br/>- `ENTIRE`: All<br/>- `USER_CUSTOM`: Customize                                       |
-| databaseIds       | Body | Array  | X  | List of identifiers for a custom database                                                                                |
-| dbUserIds         | Body | Array  | X  | List of identifiers for custom DB users                                                                                |
-| address           | Body | String | O  | Access Address<br/>- Enter in CIDR format, hostname, or domain format                                                             |
-| authMethod        | Body | Enum   | O  | Authentication Method<br/>- `TRUST`: Trust (no password required)<br/>- `REJECT`: Block access<br/>- `SCRAM_SHA_256`: Password (SCRAM-SHA-256) |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| connectionTypeCode | Body | Enum | X | Access control record type<br/>- HOST: `Valid for TCP/IP connections`<br/>- HOST_NO_SSL: `Valid only for connections without SSL encryption` |
+| databaseApplyType | Body | Enum | O | Database apply type<br/>- ENTIRE: `All`<br/>- USER_CUSTOM: `Customize` |
+| dbUserApplyType | Body | Enum | O | DB user apply type<br/>- ENTIRE: `All`<br/>- USER_CUSTOM: `Customize` |
+| databaseIds | Body | Array | X | List of database identifiers |
+| dbUserIds | Body | Array | X | List of DB user identifiers |
+| address | Body | String | O | Connection address |
+| authMethod | Body | Enum | O | Authentication method<br/>- TRUST: `Trust (no password required)`<br/>- REJECT: `Block access`<br/>- SCRAM_SHA_256: `Password (SCRAM-SHA-256)` |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
+    "connectionTypeCode": "HOST",
     "databaseApplyType": "ENTIRE",
-    "dbUserApplyType": "USER_CUSTOM",
-    "databaseIds": [], 
-    "dbUserIds": [
-        "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4"
-    ],
-    "address": "0.0.0.0/0",
+    "dbUserApplyType": "ENTIRE",
+    "databaseIds": [],
+    "dbUserIds": [],
+    "address": "address-example",
     "authMethod": "TRUST"
 }
 ```
+
+</p>
 </details>
 
 #### Response
 
-| Name        | Type   | Format   | Description            |
-|-----------|------|------|---------------|
-| hbaRuleId | Body | UUID | Identifiers for access control rules |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| hbaRuleId | Body | UUID | Identifier of the access control rule |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -3029,93 +2384,43 @@ POST /v1.0/db-instances/{dbInstanceId}/hba-rules
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "hbaRuleId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "hbaRuleId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-### Modify an access control rule
+---
+
+### Apply access control rules
 
 ```http
-PUT /v1.0/db-instances/{dbInstanceId}/hba-rules/{hbaRuleId}
+POST /v1.0/db-instances/{dbInstanceId}/hba-rules/apply
 ```
 
 #### Required permissions
 
-| Permission Name                                   | Description                      |
-|---------------------------------------|-------------------------|
-| RDSforPostgreSQL:DbInstanceHba.Modify | Modifying access control rules within a DB instance |
-
-#### Request
-
-| Name                | Type   | Format     | Required | Description                                                                                                   |
-|-------------------|------|--------|----|------------------------------------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID   | O  | DB instance identifier                                                                                         |
-| hbaRuleId         | URL  | UUID   | O  | Identifiers for access control rules                                                                                        |
-| databaseApplyType | Body | String | O  | How database rules are applied<br/>- `ENTIRE`: All<br/>- `USER_CUSTOM`: Customize                                       |
-| dbUserApplyType   | Body | Enum   | O  | How DB user rules are applied<br/>- `ENTIRE`: All<br/>- `USER_CUSTOM`: Customize                                       |
-| databaseIds       | Body | Array  | X  | List of identifiers for a custom database                                                                                |
-| dbUserIds         | Body | Array  | X  | List of identifiers for custom DB users                                                                                |
-| address           | Body | String | O  | Access Address<br/>- Enter in CIDR format, hostname, or domain format                                                             |
-| authMethod        | Body | Enum   | O  | Authentication Method<br/>- `TRUST`: Trust (no password required)<br/>- `REJECT`: Block access<br/>- `SCRAM_SHA_256`: Password (SCRAM-SHA-256) |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "databaseApplyType": "ENTIRE",
-    "dbUserApplyType": "ENTIRE",
-    "databaseIds": [], 
-    "dbUserIds": [],
-    "address": "0.0.0.0/0",
-    "authMethod": "REJECT"
-}
-```
-</details>
-
-#### Response
-
-This API does not return a response body.
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
-
-### Deleting an access control rule
-
-```http
-DELETE /v1.0/db-instances/{dbInstanceId}/hba-rules/{hbaRuleId}
-```
-
-#### Required permissions
-
-| Permission Name                                   | Description                      |
-|---------------------------------------|-------------------------|
-| RDSforPostgreSQL:DbInstanceHba.Delete | Deleting an access control rule in a DB instance |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Modify | Modify DB Instance |
 
 #### Request
 
 This API does not require a request body.
 
-| Name           | Type  | Format   | Required | Description            |
-|--------------|-----|------|----|---------------|
-| dbInstanceId | URL | UUID | O  | DB instance identifier  |
-| hbaRuleId    | URL | UUID | O  | Identifiers for access control rules |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
 
 #### Response
 
-This API does not return a response body.
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of the requested task |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -3123,10 +2428,15 @@ This API does not return a response body.
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
+
+---
 
 ### Reorder access control rules
 
@@ -3136,72 +2446,141 @@ PUT /v1.0/db-instances/{dbInstanceId}/hba-rules/orders
 
 #### Required permissions
 
-| Permission Name                                   | Description                      |
-|---------------------------------------|-------------------------|
-| RDSforPostgreSQL:DbInstanceHba.Modify | Modifying access control rules within a DB instance |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceHba.Modify | Modify access control rules in a DB instance |
 
 #### Request
 
-| Name           | Type  | Format   | Required | Description                                  |
-|--------------|-----|------|----|-------------------------------------|
-| dbInstanceId | URL | UUID | O  | DB instance identifier                        |
-| hbaRuleIds   | URL | Body | O  | List of identifiers for access control rules<br/>- Adjusted in the order you requested |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| hbaRuleIds | Body | Array | O | Sorted list of access control rule identifiers (saved in the order requested) |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
-    "hbaRuleIds": [
-        "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4"
-    ]
+    "hbaRuleIds": []
 }
 ```
+
+</p>
 </details>
 
 #### Response
 
 This API does not return a response body.
 
-<details><summary>Example</summary>
+---
 
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
-
-### Applying access control rules
+### Delete an access control rule
 
 ```http
-POST /v1.0/db-instances/{dbInstanceId}/hba-rules/apply
+DELETE /v1.0/db-instances/{dbInstanceId}/hba-rules/{hbaRuleId}
 ```
 
 #### Required permissions
 
-| Permission Name                                   | Description           |
-|---------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Modify    | Modify DB Instance |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceHba.Delete | Delete an access control rule from a DB instance |
 
 #### Request
 
 This API does not require a request body.
 
-| Name           | Type  | Format   | Required | Description           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB instance identifier |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| hbaRuleId | URL | UUID | O | Identifier of the access control rule |
 
 #### Response
 
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
+This API does not return a response body.
+
+---
+
+### Modify an access control rule
+
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/hba-rules/{hbaRuleId}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceHba.Modify | Modify access control rules in a DB instance |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| hbaRuleId | URL | UUID | O | Identifier of the access control rule |
+| connectionTypeCode | Body | Enum | X | Access control record type<br/>- HOST: `Valid for TCP/IP connections`<br/>- HOST_NO_SSL: `Valid only for connections without SSL encryption` |
+| databaseApplyType | Body | Enum | O | Database apply type<br/>- ENTIRE: `All`<br/>- USER_CUSTOM: `Customize` |
+| dbUserApplyType | Body | Enum | O | DB user apply type<br/>- ENTIRE: `All`<br/>- USER_CUSTOM: `Customize` |
+| databaseIds | Body | Array | X | List of database identifiers |
+| dbUserIds | Body | Array | X | List of DB user identifiers |
+| address | Body | String | O | Connection address |
+| authMethod | Body | Enum | O | Authentication method<br/>- TRUST: `Trust (no password required)`<br/>- REJECT: `Block access`<br/>- SCRAM_SHA_256: `Password (SCRAM-SHA-256)` |
 
 <details><summary>Example</summary>
+<p>
+
+```json
+{
+    "connectionTypeCode": "HOST",
+    "databaseApplyType": "ENTIRE",
+    "dbUserApplyType": "ENTIRE",
+    "databaseIds": [],
+    "dbUserIds": [],
+    "address": "address-example",
+    "authMethod": "TRUST"
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+This API does not return a response body.
+
+---
+### Get high availability information
+
+```http
+GET /v1.0/db-instances/{dbInstanceId}/high-availability
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:HighAvailability.Get | Get high availability information |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| haStatus | Body | Enum | High availability status<br/>- CREATED: `Created`<br/>- STABLE: `Normal`<br/>- PAUSING: `Pausing`<br/>- DISABLE: `Stopped`<br/>- DISABLE_MASTER_IN_REPLICATION: `High availability stopped due to abnormal master replication detected`<br/>- DISABLE_MHA_PROCESS: `High availability process stopped`<br/>- DISABLE_REPLICATION_STOP: `High availability stopped due to replication stop`<br/>- DISABLE_REPLICATION_DELAY: `High availability stopped due to replication delay`<br/>- FAILOVER_STARTED: `Failover started`<br/>- FAILOVER_FAILED: `Failover failed`<br/>- FAILOVER_COMPLETED: `Failover completed`<br/>- DELETED: `Deleted`<br/>- PAUSED: `Paused`<br/>- PAUSED_DUE_TO_TASK: `Paused due to task`<br/>- MASTER_FAILURE_DETECTION: `Master failure detected` |
+| pingInterval | Body | Number | Ping interval (sec) when using high availability |
+| failoverReplWaitingTime | Body | Number | Failover replication delay waiting time (sec) when using high availability |
+
+<details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -3210,12 +2589,1079 @@ This API does not require a request body.
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "haStatus": "CREATED",
+    "pingInterval": 1,
+    "failoverReplWaitingTime": 1
 }
 ```
+
+</p>
 </details>
 
+---
+
+### Modify High Availability
+
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/high-availability
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:HighAvailability.Modify | Modify High Availability |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| useHighAvailability | Body | Boolean | O | Whether to use high availability |
+| pingInterval | Body | Number | X | Ping interval (sec)<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
+| failoverReplWaitingTime | Body | Number | X | Failover replication delay waiting time (sec)<br/>- Minimum value: `-1` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "useHighAvailability": false,
+    "pingInterval": 1,
+    "failoverReplWaitingTime": 1
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Pause High Availability
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/high-availability/pause
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:HighAvailability.Pause | Pause High Availability |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Recover High Availability
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/high-availability/repair
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:HighAvailability.Repair | Recover High Availability |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Restart High Availability
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/high-availability/resume
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:HighAvailability.Resume | Restart High Availability |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Separate High Availability
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/high-availability/split
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:HighAvailability.Split | Separate High Availability |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+### Get DB instance maintenance information
+
+```http
+GET /v1.0/db-instances/{dbInstanceId}/maintenance-info
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Get | Get DB instance maintenance information |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| allowAutoMaintenance | Body | Boolean | Whether to allow automatic maintenance |
+| useAutoStorageCleanup | Body | Boolean | Whether to enable automatic storage cleanup |
+| maintWndBgnTime | Body | Time | Automatic maintenance start time |
+| maintWndDuration | Body | Enum | Maintenance window<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1 hour 30 minutes`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2 hours 30 minutes`<br/>- THREE_HOURS: `3 hours` |
+| logRetentionPeriod | Body | Number | Log retention period (days) |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "allowAutoMaintenance": false,
+    "useAutoStorageCleanup": false,
+    "maintWndBgnTime": "00:00:00",
+    "maintWndDuration": "HALF_AN_HOUR",
+    "logRetentionPeriod": 1
+}
+```
+
+</p>
+</details>
+
+---
+
+### Modify DB instance maintenance information
+
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/maintenance-info
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Modify | Modify DB instance maintenance information |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| allowAutoMaintenance | Body | Boolean | X | Whether to allow automatic maintenance |
+| useAutoStorageCleanup | Body | Boolean | X | Whether to enable automatic storage cleanup |
+| maintWndBgnTime | Body | Time | X | Automatic maintenance start time |
+| maintWndDuration | Body | Enum | X | Maintenance window<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1 hour 30 minutes`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2 hours 30 minutes`<br/>- THREE_HOURS: `3 hours` |
+| logRetentionPeriod | Body | Number | X | Log retention period (days)<br/>- Minimum: `1`<br/>- Maximum: `30` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "allowAutoMaintenance": false,
+    "useAutoStorageCleanup": false,
+    "maintWndBgnTime": "00:00:00",
+    "maintWndDuration": "HALF_AN_HOUR",
+    "logRetentionPeriod": 1
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+### Get DB instance network information
+
+```http
+GET /v1.0/db-instances/{dbInstanceId}/network-info
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Get | Get DB instance network information |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| availabilityZone | Body | Enum | Availability zone where DB instance will be created |
+| subnet | Body | Object | Subnet object |
+| subnet.subnetId | Body | UUID | Subnet identifier |
+| subnet.subnetName | Body | String | Name to identify subnets |
+| subnet.subnetCidr | Body | String | CIDR of subnet |
+| subnet.publicAccessible | Body | Boolean | External access is available or not |
+| endPoints | Body | Array | List of access information |
+| endPoints.domain | Body | String | Domain |
+| endPoints.ipAddress | Body | String | IP address |
+| endPoints.endPointType | Body | String | Types of access information |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "availabilityZone": "kr-pub-a",
+    "subnet": {
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "subnetName": "subnetName-example",
+        "subnetCidr": "192.168.0.0/24",
+        "publicAccessible": false
+    },
+    "endPoints": [
+        {
+            "domain": "domain-example",
+            "ipAddress": "192.168.0.1",
+            "endPointType": "https://example.com"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### Modify DB instance network information
+
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/network-info
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Modify | Modify DB instance network information |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| usePublicAccess | Body | Boolean | O | External access is available or not |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "usePublicAccess": false
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Promote DB Instance
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/promote
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Promote | Promote DB Instance |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+### Create Read Replica
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/replicate
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Replicate | Create read replica |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceName | Body | String | O | Name to identify the DB instance |
+| description | Body | String | X | Additional information on the DB instance |
+| dbFlavorId | Body | UUID | X | Identifier of DB instance specifications |
+| dbPort | Body | Number | X | DB port<br/>- Minimum value: 5432, Maximum value: 45432 |
+| parameterGroupId | Body | UUID | X | Parameter group identifier |
+| dbSecurityGroupIds | Body | Array | X | List of DB security group identifiers |
+| userGroupIds | Body | Array | X | List of user group identifiers |
+| useDefaultNotification | Body | Boolean | X | Whether to use default notification<br/>- Default: `false` |
+| useDeletionProtection | Body | Boolean | X | Whether deletion protection is enabled<br/>- Default: `false` |
+| network | Body | Object | X | Network information object |
+| network.usePublicAccess | Body | Boolean | X | Whether external access is available<br/>- Default: `false` |
+| network.availabilityZone | Body | Enum | X | Availability zone where the DB instance will be created |
+| storage | Body | Object | X | Storage information object |
+| storage.storageType | Body | Enum | X | Data storage type |
+| storage.storageSize | Body | Number | X | Data storage size (GB)<br/>- Minimum value: `20`<br/>- Maximum value: `2048` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName-example",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useDefaultNotification": false,
+    "useDeletionProtection": false,
+    "network": {
+        "usePublicAccess": false,
+        "availabilityZone": "kr-pub-a"
+    },
+    "storage": {
+        "storageType": "General SSD",
+        "storageSize": 20
+    }
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of the requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Restart DB Instance
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/restart
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Restart | Restart DB Instance |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of the requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Get DB Instance Restore Information
+
+```http
+GET /v1.0/db-instances/{dbInstanceId}/restoration-info
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Get | Get DB instance restore information |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| oldestRestorableYmdt | Body | DateTime | Oldest restorable time |
+| latestRestorableYmdt | Body | DateTime | Most recent restorable time |
+| restorableBackups | Body | Array | List of restorable backups |
+| restorableBackups.backupId | Body | UUID | Backup identifier |
+| restorableBackups.backupName | Body | String | Backup name |
+| restorableBackups.backupStatus | Body | Enum | Backup status<br/>- BACKING_UP: `Backing up (spinner)`<br/>- VERIFYING: `Verifying (spinner)`<br/>- COMPLETED: `Available (green icon)`<br/>- DELETING: `Deleting (spinner)`<br/>- DELETED: `Deleted (gray icon)`<br/>- ERROR: `Error (red icon)` |
+| restorableBackups.dbInstanceId | Body | UUID | Original DB instance identifier |
+| restorableBackups.dbInstanceName | Body | String | Original DB instance name |
+| restorableBackups.dbVersion | Body | Enum | DB engine type |
+| restorableBackups.backupType | Body | Enum | Backup type<br/>- AUTO<br/>- MANUAL |
+| restorableBackups.backupSize | Body | Number | Backup size |
+| restorableBackups.failoverCount | Body | Number | Number of failovers |
+| restorableBackups.walFileName | Body | String | WAL file name |
+| restorableBackups.createdYmdt | Body | DateTime | Backup creation date and time |
+| restorableBackups.updatedYmdt | Body | DateTime | Backup update date and time |
+| restorableBackups.startYmdt | Body | DateTime | Backup start date and time |
+| restorableBackups.completedYmdt | Body | DateTime | Backup completion date and time |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "oldestRestorableYmdt": "2023-12-31T15:00:00+09:00",
+    "latestRestorableYmdt": "2023-12-31T15:00:00+09:00",
+    "restorableBackups": [
+        {
+            "backupId": "550e8400-e29b-41d4-a716-446655440000",
+            "backupName": "backupName-example",
+            "backupStatus": "BACKING_UP",
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbInstanceName": "dbInstanceName-example",
+            "dbVersion": "POSTGRESQL_V14_17",
+            "backupType": "AUTO",
+            "backupSize": 1,
+            "failoverCount": 1,
+            "walFileName": "walFileName-example",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00",
+            "startYmdt": "2023-12-31T15:00:00+09:00",
+            "completedYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### Restore DB Instance
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/restore
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Restore | Restore DB Instance |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceName | Body | String | X | Name to identify the DB instance |
+| dbInstanceCandidateName | Body | String | X | Candidate master name to identify the DB instance |
+| description | Body | String | X | Additional information on the DB instance<br/>- Maximum length: `100` |
+| dbFlavorId | Body | UUID | O | Identifier of DB instance specifications |
+| dbPort | Body | Number | X | DB port<br/>- Minimum value: 5432, Maximum value: 45432 |
+| useHighAvailability | Body | Boolean | X | Whether to use high availability<br/>- Default: `false` |
+| imageId | Body | UUID | X | Image identifier |
+| pingInterval | Body | Number | X | Ping interval (sec) when using high availability<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
+| failoverReplWaitingTime | Body | Number | X | Failover replication delay wait time (sec)<br/>- Minimum value: `-1` |
+| storage | Body | Object | O | Storage information object |
+| storage.storageType | Body | Enum | O | Storage type |
+| storage.storageSize | Body | Number | O | Data storage size (GB)<br/>- Minimum value: `20` |
+| network | Body | Object | O | Network information object |
+| network.subnetId | Body | UUID | O | Subnet identifier |
+| network.usePublicAccess | Body | Boolean | X | Whether external access is available<br/>- Default: `false` |
+| network.availabilityZone | Body | Enum | X | Availability zone where the DB instance will be created |
+| backup | Body | Object | O | Backup information object |
+| backup.backupPeriod | Body | Number | O | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| backup.backupRetryCount | Body | Number | X | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| backup.replicationRegion | Body | Enum | X | Backup replication region<br/>- KR1: `Korea (Pangyo)`<br/>- KR2: `Korea (Pyeongchon)` |
+| backup.backupSchedules | Body | Array | O | Backup schedule list |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | O | Backup start time |
+| backup.backupSchedules.backupWndDuration | Body | Enum | O | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1 hour 30 minutes`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2 hours 30 minutes`<br/>- THREE_HOURS: `3 hours` |
+| restore | Body | Object | O | Restoration information object |
+| restore.restoreType | Body | Enum | O | Restoration type<br/>- BACKUP: `Restoration using a previously created backup`<br/>- TIMESTAMP: `Point-in-time recovery using a time within the restorable period` |
+| restore.restoreYmdt | Body | DateTime | X | DB instance restore date and time |
+| restore.backupId | Body | UUID | X | Identifier of the backup to use for restoration |
+| useDefaultNotification | Body | Boolean | X | Whether to use default notification<br/>- Default: `false` |
+| parameterGroupId | Body | UUID | O | Parameter group identifier |
+| dbSecurityGroupIds | Body | Array | X | List of DB security group identifiers |
+| userGroupIds | Body | Array | X | List of user group identifiers |
+| useDeletionProtection | Body | Boolean | X | Whether deletion protection is enabled<br/>- Default: `false` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName-example",
+    "dbInstanceCandidateName": "dbInstanceCandidateName-example",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "useHighAvailability": false,
+    "imageId": "550e8400-e29b-41d4-a716-446655440000",
+    "pingInterval": 3,
+    "failoverReplWaitingTime": 60,
+    "storage": {
+        "storageType": "General SSD",
+        "storageSize": 20
+    },
+    "network": {
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
+        "availabilityZone": "kr-pub-a"
+    },
+    "backup": {
+        "backupPeriod": 0,
+        "backupRetryCount": 0,
+        "replicationRegion": "KR1",
+        "backupSchedules": [
+            {
+                "backupWndBgnTime": "00:00:00",
+                "backupWndDuration": "HALF_AN_HOUR"
+            }
+        ]
+    },
+    "restore": {
+        "restoreType": "BACKUP",
+        "restoreYmdt": "2023-12-31T15:00:00+09:00",
+        "backupId": "550e8400-e29b-41d4-a716-446655440000"
+    },
+    "useDefaultNotification": false,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useDeletionProtection": false
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of the requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+### Start DB Instance
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/start
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Start | Start DB Instance |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Stop DB Instance
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/stop
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Stop | Stop DB Instance |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Get DB Instance Storage Information
+
+```http
+GET /v1.0/db-instances/{dbInstanceId}/storage-info
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Get | Get DB Instance Storage Information |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| storageType | Body | Enum | Data storage types |
+| storageSize | Body | Number | Data storage size (GB) |
+| storageStatus | Body | Enum | Data storage current status<br/>- DELETED: `Deleted`<br/>- PENDING_DELETION: `Deletion deferred`<br/>- DELETION_RESERVED: `Deletion reserved (pending snapshot cleanup)`<br/>- DETACHED: `Detached`<br/>- ATTACHED: `Attached` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "storageType": "General SSD",
+    "storageSize": 1,
+    "storageStatus": "DELETED"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Modify DB Instance Storage Information
+
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/storage-info
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Modify | Modify DB Instance Storage Information |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| storageSize | Body | Number | O | Data storage size (GB)<br/>- Maximum value: `2048` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "storageSize": 1
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
 ## Backup
+
+### Backup Status
+
+| Status         | Description                  |
+|--------------|------------------------------|
+| `BACKING_UP` | Backup in progress           |
+| `COMPLETED`  | Backup completed             |
+| `DELETING`   | Backup being deleted         |
+| `DELETED`    | Backup deleted               |
+| `ERROR`      | Error occurred               |
 
 ### Retrieve Backup List
 
@@ -3225,40 +3671,34 @@ GET /v1.0/backups
 
 #### Required permissions
 
-| Permission Name                          | Description       |
-|------------------------------|----------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforPostgreSQL:Backup.List | Retrieve Backup List |
 
 #### Request
 
 This API does not require a request body.
 
-| Name           | Type    | Format     | Required | Description                                                         |
-|--------------|-------|--------|----|------------------------------------------------------------|
-| page         | Query | Number | O  | Page to retrieve<br/>- Minimum value: `1`                                 |
-| size         | Query | Number | O  | Page size to retrieve<br/>- Minimum value: `1`<br/>- Maximum value: `100`             |
-| backupType   | Query | Enum   | X  | Backup type<br/>- `AUTO`: Automatic<br/>- `MANUAL`:  Manual<br/>- Default value: All |
-| dbInstanceId | Query | UUID   | X  | Original DB instance identifier                                            |
-| dbVersion    | Query | Enum   | X  | DB version information                                                   |
-
 #### Response
 
-| Name                   | Type   | Format       | Description                                                                                                                                                        |
-|----------------------|------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| totalCounts          | Body | Number   | Number of all backup lists                                                                                                                                                |
-| backups              | Body | Array    | Backup list                                                                                                                                                     |
-| backups.backupId     | Body | UUID     | Backup identifier                                                                                                                                                   |
-| backups.backupName   | Body | String   | Name to identify backups                                                                                                                                           |
-| backups.backupStatus | Body | Enum     | Backup current status<br/>`BACKING_UP`: Backup in progress<br/>`COMPLETED`: Backup completed<br/>`DELETING`: Backup being deleted<br/>`DELETED`: Backup deleted<br/>`ERROR`: Error occurred |
-| backups.dbInstanceId | Body | UUID     | Original DB instance identifier                                                                                                                                           |
-| backups.dbVersion    | Body | Enum     | DB version information                                                                                                                                                  |
-| backups.backupType   | Body | Enum     | Backup type<br/>- `AUTO`: Automatic<br/>- `MANUAL`:  Manual                                                                                                                |
-| backups.backupSize   | Body | Number   | Size of the backup<br/>- Unit: `Bytes`                                                                                                                                    |
-| createdYmdt          | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                         |
-| updatedYmdt          | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                         |
-| completedYmdt        | Body | DateTime | End date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                         |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | Number of all backup lists |
+| backups | Body | Array | Backup list |
+| backups.backupId | Body | UUID | Backup identifier |
+| backups.backupName | Body | String | Name to identify backups |
+| backups.backupStatus | Body | Enum | Backup current status<br/>- BACKING_UP: `Backup in progress (spinner)`<br/>- VERIFYING: `Verifying (spinner)`<br/>- COMPLETED: `Available (green icon)`<br/>- DELETING: `Deleting (spinner)`<br/>- DELETED: `Deleted (gray icon)`<br/>- ERROR: `Error (red icon)` |
+| backups.dbInstanceId | Body | UUID | Original DB instance identifier |
+| backups.dbVersion | Body | Enum | DB engine version |
+| backups.backupType | Body | Enum | Backup type<br/>- AUTO<br/>- MANUAL |
+| backups.backupSize | Body | Number | Size of the backup (Bytes) |
+| backups.startYmdt | Body | DateTime | Start date and time |
+| backups.createdYmdt | Body | DateTime | Created date and time |
+| backups.updatedYmdt | Body | DateTime | Modified date and time |
+| backups.completedYmdt | Body | DateTime | End date and time |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -3270,170 +3710,26 @@ This API does not require a request body.
     "totalCounts": 1,
     "backups": [
         {
-            "backupId": "0017f136-3e01-4530-94aa-20661afe6632",
-            "backupName": "backup",
-            "backupStatus": "COMPLETED",
-            "dbInstanceId": "142e6ccc-3bfb-4e1e-84f7-38861284fafd",
-            "dbVersion": "POSTGRESQL_V17_6",
+            "backupId": "550e8400-e29b-41d4-a716-446655440000",
+            "backupName": "backupName-example",
+            "backupStatus": "BACKING_UP",
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbVersion": "POSTGRESQL_V14_17",
             "backupType": "AUTO",
-            "backupSize": 4996786,
-            "createdYmdt": "2023-02-21T00:35:00+09:00",
-            "updatedYmdt": "2023-02-22T00:35:32+09:00",
-            "completedYmdt": "2023-02-22T00:35:32+09:00"
+            "backupSize": 1,
+            "startYmdt": "2023-12-31T15:00:00+09:00",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00",
+            "completedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
+
+</p>
 </details>
 
-### Export backup to object storage
-
-```http
-POST /v1.0/backups/{backupId}/export
-```
-
-#### Required permissions
-
-| Permission Name                            | Description                 |
-|--------------------------------|--------------------|
-| RDSforPostgreSQL:Backup.Export | Export backup to object storage |
-
-#### Request
-
-| Name              | Type   | Format     | Required | Description                          |
-|-----------------|------|--------|----|-----------------------------|
-| backupId        | URL  | UUID   | O  | Backup identifier                     |
-| tenantId        | Body | String | O  | Tenant ID of object storage to store backup   |
-| username        | Body | String | O  | ID of NHN Cloud Account or IAM Account   |
-| password        | Body | String | O  | API password for object storage where backup is stored |
-| targetContainer | Body | String | O  | Object storage container where backup is stored     |
-| objectPath      | Body | String | O  | Backup path to be stored in container            |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "tenantId": "399631c404744dbbb18ce4fa2dc71a5a",
-    "username": "gildong.hong@nhn.com",
-    "password": "password",
-    "targetContainer": "/container",
-    "objectPath": "/backups/backup_file"
-}
-```
-</details>
-
-#### Response
-
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### Restore Backup
-
-```http
-POST /v1.0/backups/{backupId}/restore
-```
-
-#### Required permissions
-
-| Permission Name                             | Description      |
-|---------------------------------|---------|
-| RDSforPostgreSQL:Backup.Restore | Restore Backup |
-
-#### Request
-
-| Name                                       | Type   | Format      | Required | Description                                                                                                                                                                                                                        |
-|------------------------------------------|------|---------|----|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| backupId                                 | URL  | UUID    | O  | Backup identifier                                                                                                                                                                                                                   |
-| dbInstanceName                           | Body | String  | O  | Name to identify DB instances                                                                                                                                                                                                      |
-| description                              | Body | String  | X  | Additional information on DB instances                                                                                                                                                                                                         |
-| dbFlavorId                               | Body | UUID    | O  | Identifier of DB instance specifications                                                                                                                                                                                                           |
-| dbPort                                   | Body | Number  | O  | DB port<br/>- Minimum value: `0`<br/>- Maximum value: 65535                                                                                                                                                                                |
-| parameterGroupId                         | Body | UUID    | O  | Parameter group identifier                                                                                                                                                                                                              |
-| dbSecurityGroupIds                       | Body | Array   | X  | DB security group identifiers                                                                                                                                                                                                          ||network|Body|Object|O|Network information objects|
-| userGroupIds                             | Body | Array   | X  | User group identifiers                                                                                                                                                                                                            |
-| useDefaultNotification                   | Body | Boolean | X  | Whether to use default notification<br/>Default: `false`                                                                                                                                                                                            |
-| useDeletionProtection                    | Body | Boolean | X  | Whether to protect against deletion<br/>Default: `false`                                                                                                                                                                                               | 
-| useHighAvailability                      | Body | Boolean | X  | Whether to use high availability                                                                                                                                                                                                                |
-| pingInterval                             | Body | Number  | X  | Ping interval (sec) when using high availability<br/>- Minimum value: `1`<br/>- Maximum value: `600`                                                                                                                                                                      |
-| failoverReplWaitingTime                  | Body | Number  | X  | Failover latency when using high availability<br/>- Minimum value: `0`<br/>- If set to -1, it will continue to wait for the replication delay to resolve.                                                                                                                                              |                                                                                                                                                                                                                      | userGroupIds                             | Body | Array   | X  | List of identifiers for user groups that receive default notifications                                                                                                                                                                                             |
-| network                                  | Body | Object  | O  | Network information objects                                                                                                                                                                                                                |
-| network.subnetId                         | Body | UUID    | O  | Subnet identifier                                                                                                                                                                                                                  |
-| network.usePublicAccess                  | Body | Boolean | X  | External access is available or not<br/>Default: `false`                                                                                                                                                                                            |
-| network.availabilityZone                 | Body | Enum    | X  | Availability zone where DB instance will be created<br/>- Example: `kr-pub-a`<br/>- Default: `Any availability` zone                                                                                                                                                          |
-| storage                                  | Body | Object  | O  | Storage information objects                                                                                                                                                                                                                |    
-| storage.storageType                      | Body | Enum    | O  | Data storage types<br/>- Example: `General SSD`                                                                                                                                                                                       |
-| storage.storageSize                      | Body | Number  | O  | Data storage size<br/>- Unit: `Gigabytes`<br/>- Minimum value: `20`<br/>- Maximum value: `2048`                                                                                                                                                           |
-| backup                                   | Body | Object  | O  | Backup information objects                                                                                                                                                                                                                  |
-| backup.backupPeriod                      | Body | Number  | O  | Backup retention period<br/>- Minimum value: `0`<br/>- Maximum value: `730`                                                                                                                                                                               |
-| backup.backupRetryCount                  | Body | Number  | X  | Number of backup retries<br/>Default: `6`<br/>- Minimum value: `0`<br/>- Maximum value: `10`                                                                                                                                                                   |
-| backup.backupSchedules                   | Body | Array   | X  | Backup schedules                                                                                                                                                                                                                 |
-| backup.backupSchedules.backupWndBgnTime  | Body | String  | O  | Backup Start Time<br/>- Example: `00:00:00`                                                                                                                                                                                             |
-| backup.backupSchedules.backupWndDuration | Body | Enum    | O  | Backup duration<br/>Auto backup is executed within the set duration from the backup start time.<br/>- `HALF_AN_HOUR`: 30 minutes<br/>- `ONE_HOUR`: 1 hour<br/>- `ONE_HOUR_AND_HALF`: 1.5 hour<br/>- `TWO_HOURS`: 2 hour<br/>- `TWO_HOURS_AND_HALF`: 2.5 hour<br/>- `THREE_HOURS`: 3 hour |
-
-<details><summary>Example</summary>
-
-```json
-
-{
-  "dbInstanceName": "db-instance-restore",
-  "dbFlavorId": "50be6d9c-02d6-4594-a2d4-12010eb65ec0",
-  "dbPort": 15432,
-  "parameterGroupId": "132d383c-38e3-468a-a826-5e9a8fff15d0",
-  "network": {
-    "subnetId": "e721a9dd-dad0-4cf0-a53b-dd654ebfc683"
-  },
-  "storage": {
-    "storageType": "General SSD",
-    "storageSize": 20
-  },
-  "backup": {
-    "backupPeriod": 1,
-    "backupSchedules": [
-      {
-        "backupWndBgnTime": "00:00:00",
-        "backupWndDuration": "HALF_AN_HOUR",
-        "backupRetryExpireTime": "00:30:00"
-      }
-    ]
-  }
-}
-```
-</details>
-
-#### Response
-
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
+---
 
 ### Delete Backup
 
@@ -3443,25 +3739,26 @@ DELETE /v1.0/backups/{backupId}
 
 #### Required permissions
 
-| Permission Name                            | Description      |
-|--------------------------------|---------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforPostgreSQL:Backup.Delete | Delete Backup |
 
 #### Request
 
 This API does not require a request body.
 
-| Name       | Type  | Format   | Required | Description      |
-|----------|-----|------|----|---------|
-| backupId | URL | UUID | O  | Backup identifier |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | O | Backup identifier |
 
 #### Response
 
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | Identifier of requested task |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -3470,12 +3767,200 @@ This API does not require a request body.
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
+---
+
+### Export Backup to Object Storage
+
+```http
+POST /v1.0/backups/{backupId}/export
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:Backup.Export | Export Backup to Object Storage |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | O | Backup identifier |
+| tenantId | Body | String | O | Tenant ID of object storage where backup will be stored<br/>- Minimum length: `32`<br/>- Maximum length: `32` |
+| username | Body | String | O | NHN Cloud account or IAM member ID |
+| password | Body | String | O | API password for object storage where backup will be stored |
+| targetContainer | Body | String | O | Object storage container where backup will be stored |
+| objectPath | Body | String | O | Path of the backup to be stored in the container |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "tenantId": "0123456789abcdef0123456789abcdef",
+    "username": "username-example",
+    "password": "password-example",
+    "targetContainer": "targetContainer-example",
+    "objectPath": "objectPath-example"
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Restore Backup
+
+```http
+POST /v1.0/backups/{backupId}/restore
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:Backup.Restore | Restore Backup |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | O | Backup identifier |
+| dbInstanceName | Body | String | O | Name to identify DB instances |
+| dbInstanceCandidateName | Body | String | X | Candidate master name to identify the DB instance |
+| description | Body | String | X | Additional information on DB instances |
+| dbFlavorId | Body | UUID | O | Identifier of DB instance specifications |
+| dbPort | Body | Number | O | DB port<br/>- Minimum value: 5432, Maximum value: 45432 |
+| parameterGroupId | Body | UUID | O | Parameter group identifier |
+| dbSecurityGroupIds | Body | Array | X | List of DB security group identifiers |
+| userGroupIds | Body | Array | X | List of user group identifiers |
+| useHighAvailability | Body | Boolean | X | Whether to use high availability<br/>- Default: `false` |
+| useDefaultNotification | Body | Boolean | X | Whether to use default notification<br/>- Default: `false` |
+| useDeletionProtection | Body | Boolean | X | Whether to use deletion protection<br/>- Default: `false` |
+| pingInterval | Body | Number | X | Ping interval (seconds)<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
+| failoverReplWaitingTime | Body | Number | X | Failover replication delay waiting time (seconds)<br/>- Minimum value: `-1` |
+| network | Body | Object | O | Network information objects |
+| network.subnetId | Body | UUID | O | Subnet identifier |
+| network.usePublicAccess | Body | Boolean | X | Whether external access is available<br/>- Default: `false` |
+| network.availabilityZone | Body | Enum | X | Availability zone where DB instance will be created |
+| storage | Body | Object | O | Storage information objects |
+| storage.storageType | Body | Enum | O | Storage type |
+| storage.storageSize | Body | Number | O | Data storage size (GB)<br/>- Minimum value: `20` |
+| backup | Body | Object | O | Backup information objects |
+| backup.backupPeriod | Body | Number | O | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| backup.backupRetryCount | Body | Number | X | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| backup.backupSchedules | Body | Array | O | Backup schedules |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | O | Backup start time |
+| backup.backupSchedules.backupWndDuration | Body | Enum | O | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hours`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2.5 hours`<br/>- THREE_HOURS: `3 hours` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName-example",
+    "dbInstanceCandidateName": "dbInstanceCandidateName-example",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useHighAvailability": false,
+    "useDefaultNotification": false,
+    "useDeletionProtection": false,
+    "pingInterval": 1,
+    "failoverReplWaitingTime": 1,
+    "network": {
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
+        "availabilityZone": "kr-pub-a"
+    },
+    "storage": {
+        "storageType": "General SSD",
+        "storageSize": 20
+    },
+    "backup": {
+        "backupPeriod": 0,
+        "backupRetryCount": 0,
+        "backupSchedules": [
+            {
+                "backupWndBgnTime": "00:00:00",
+                "backupWndDuration": "HALF_AN_HOUR"
+            }
+        ]
+    }
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
 ## DB Security Group
+
+### DB Security Group Progress Status
+
+| Status          | Description                  |
+|-----------------|------------------------------|
+| `NONE`          | No work in progress          |
+| `CREATING_RULE` | Creating rule policy         |
+| `UPDATING_RULE` | Modifying rule policy        |
+| `DELETING_RULE` | Deleting rule policy         |
 
 ### List DB Security Groups
 
@@ -3485,8 +3970,8 @@ GET /v1.0/db-security-groups
 
 #### Required permissions
 
-| Permission Name                                   | Description             |
-|---------------------------------------|----------------|
+| Permission Name                       | Description             |
+|---------------------------------------|-------------------------|
 | RDSforPostgreSQL:DbSecurityGroup.List | List DB Security Groups |
 
 #### Request
@@ -3495,18 +3980,19 @@ This API does not require a request body.
 
 #### Response
 
-| Name                                     | Type   | Format       | Description                                                                                                                                                                                             |
-|----------------------------------------|------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroups                       | Body | Array    | DB security groups                                                                                                                                                                                    |
-| dbSecurityGroups.dbSecurityGroupId     | Body | UUID     | DB security group identifier                                                                                                                                                                                  |
-| dbSecurityGroups.dbSecurityGroupName   | Body | String   | Name to identify DB instances                                                                                                                                                                          |
-| dbSecurityGroups.dbSecurityGroupStatus | Body | Enum     | Current status of DB security groups<br/>- `CREATED: Created`<br/>- `DELETED`: Deleted                                                                                                                                      |
-| dbSecurityGroups.description           | Body | String   | Additional information on DB security group                                                                                                                                                                             |
-| dbSecurityGroups.progressStatus        | Body | Enum     | Current status of DB security group<br/>- `NONE`: No work in progress<br/>- `CREATING_RULE`: Creating rule policy<br/>- `UPDATING_RULE`: Modifying rule policy<br/>- `DELETING_RULE`: Deleting rule policy<br/>- `APPLYING_DEFAULT_RULE`: Applying default rule  |
-| dbSecurityGroups.createdYmdt           | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                              |
-| dbSecurityGroups.updatedYmdt           | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                              |
+| Name                                   | Type | Format   | Description                                                                                                                                                                                                                                                         |
+|----------------------------------------|------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| dbSecurityGroups                       | Body | Array    | DB security groups                                                                                                                                                                                                                                                  |
+| dbSecurityGroups.dbSecurityGroupId     | Body | UUID     | DB security group identifier                                                                                                                                                                                                                                        |
+| dbSecurityGroups.dbSecurityGroupName   | Body | String   | Name to identify the DB security group                                                                                                                                                                                                                              |
+| dbSecurityGroups.dbSecurityGroupStatus | Body | Enum     | Current status of the DB security group<br/>- CREATED: `Created`<br/>- DELETED: `Deleted`                                                                                                                                                                          |
+| dbSecurityGroups.description           | Body | String   | Additional information on the DB security group                                                                                                                                                                                                                     |
+| dbSecurityGroups.progressStatus        | Body | Enum     | Current progress status of the DB security group<br/>- NONE: `No work in progress`<br/>- CREATING_RULE: `Creating rule policy`<br/>- UPDATING_RULE: `Modifying rule policy`<br/>- DELETING_RULE: `Deleting rule policy`<br/>- APPLYING_DEFAULT_RULE: `Applying default rule` |
+| dbSecurityGroups.createdYmdt           | Body | DateTime | Created date and time                                                                                                                                                                                                                                               |
+| dbSecurityGroups.updatedYmdt           | Body | DateTime | Modified date and time                                                                                                                                                                                                                                              |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -3517,100 +4003,22 @@ This API does not require a request body.
     },
     "dbSecurityGroups": [
         {
-            "dbSecurityGroupId": "fe4f2aee-afbb-4c19-a5e9-eb2eab394708",
-            "dbSecurityGroupName": "dbSecurityGroup",
+            "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbSecurityGroupName": "dbSecurityGroupName-example",
             "dbSecurityGroupStatus": "CREATED",
-            "description": "description",
+            "description": "description-example",
             "progressStatus": "NONE",
-            "createdYmdt": "2023-02-19T19:18:13+09:00",
-            "updatedYmdt": "2022-02-19T19:18:13+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
+
+</p>
 </details>
 
-### List DB Security Group Details
-
-```http
-GET /v1.0/db-security-groups/{dbSecurityGroupId}
-```
-
-#### Required permissions
-
-| Permission Name                                  | Description             |
-|--------------------------------------|----------------|
-| RDSforPostgreSQL:DbSecurityGroup.Get | List DB Security Group Details |
-
-#### Request
-
-This API does not require a request body.
-
-| Name                | Type  | Format   | Required | Description            |
-|-------------------|-----|------|----|---------------|
-| dbSecurityGroupId | URL | UUID | O  | DB security group identifier |
-
-#### Response
-
-| Name                    | Type   | Format       | Description                                                                                                                                                                                            |
-|-----------------------|------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId     | Body | UUID     | DB security group identifier                                                                                                                                                                                 |
-| dbSecurityGroupName   | Body | String   | Name to identify DB instances                                                                                                                                                                         |
-| dbSecurityGroupStatus | Body | Enum     | Current status of DB security groups<br/>- `CREATED: Created`<br/>- `DELETED`: Deleted                                                                                                                                     |
-| description           | Body | String   | Additional information on DB security group                                                                                                                                                                            |
-| progressStatus        | Body | Enum     | Current status of DB security group<br/>- `NONE`: No work in progress<br/>- `CREATING_RULE`: Creating rule policy<br/>- `UPDATING_RULE`: Modifying rule policy<br/>- `DELETING_RULE`: Deleting rule policy<br/>- `APPLYING_DEFAULT_RULE`: Applying default rule |
-| rules                 | Body | Array    | DB security group rules                                                                                                                                                                                |
-| rules.ruleId          | Body | UUID     | DB security group rule identifier                                                                                                                                                                              |
-| rules.description     | Body | String   | Additional information on DB security group rule                                                                                                                                                                         |
-| rules.direction       | Body | Enum     | Communication direction<br/>- `INGRESS`: Inbound<br/>- `EGRESS`: Outbound                                                                                                                                                  |
-| rules.etherType       | Body | Enum     | Ether type<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                                |
-| rules.port            | Body | Object   | Port object                                                                                                                                                                                         |
-| rules.port.portType   | Body | Enum     | Port type<br/>- `DB_PORT`: Sets to DB instance port value.<br/>- `PORT`: Sets to specified port value.<br/>- `PORT_RANGE`: Sets to specified port range.                                                                            |
-| rules.port.minPort    | Body | Number   | Minimum port range                                                                                                                                                                                      |
-| rules.port.maxPort    | Body | Number   | Maximum port range                                                                                                                                                                                      |
-| rules.cidr            | Body | String   | Remote source for traffic to allow                                                                                                                                                                                |
-| rules.createdYmdt     | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                             |
-| rules.updatedYmdt     | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                             |
-| createdYmdt           | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                             |
-| updatedYmdt           | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                             |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbSecurityGroup": {
-        "dbSecurityGroupId": "fe4f2aee-afbb-4c19-a5e9-eb2eab394708",
-        "dbSecurityGroupName": "dbSecurityGroup",
-        "dbSecurityGroupStatus": "CREATED",
-        "description": "description",
-        "progressStatus": "NONE",
-        "rules": [
-            {
-                "ruleId": "17c88ef6-95f1-4678-84f9-fee1b22e250d",
-                "description": "description",
-                "direction": "INGRESS",
-                "etherType": "IPV4",
-                "port": {
-                    "portType": "PORT_RANGE",
-                    "minPort": 10000,
-                    "maxPort": 10005
-                },
-                "cidr": "0.0.0.0/0",
-                "createdYmdt": "2023-02-19T19:18:13+09:00",
-                "updatedYmdt": "2023-02-19T19:18:13+09:00"
-            }
-        ],
-        "createdYmdt": "2023-02-19T19:18:13+09:00",
-        "updatedYmdt": "2023-02-19T19:18:13+09:00"
-    }
-}
-```
-</details>
+---
 
 ### Create DB Security Group
 
@@ -3620,55 +4028,60 @@ POST /v1.0/db-security-groups
 
 #### Required permissions
 
-| Permission Name                                     | Description            |
-|-----------------------------------------|---------------|
+| Permission Name                         | Description              |
+|-----------------------------------------|--------------------------|
 | RDSforPostgreSQL:DbSecurityGroup.Create | Create DB Security Group |
 
 #### Request
 
-| Name                  | Type   | Format     | Required | Description                                                                                                                                                                                       |
-|---------------------|------|--------|----|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupName | Body | String | O  | Name to identify DB instances                                                                                                                                                                    |
-| description         | Body | String | X  | Additional information on DB security group                                                                                                                                                                       |
-| rules               | Body | Array  | O  | DB security group rules                                                                                                                                                                           |
-| rules.description   | Body | String | X  | Additional information on DB security group rule                                                                                                                                                                    |
-| rules.direction     | Body | Enum   | O  | Communication direction<br/>- `INGRESS`: Inbound<br/>- `EGRESS`: Outbound                                                                                                                                             |
-| rules.etherType     | Body | Enum   | O  | Ether type<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                           |
-| rules.cidr          | Body | String | O  | Remote source for traffic to allow<br/>- Example: `1.1.1.1/32`                                                                                                                                                    |
-| rules.port          | Body | Object | O  | Port object                                                                                                                                                                                    |
-| rules.port.portType | Body | Enum   | O  | Port type<br/>- `DB_PORT`: Sets to DB instance port value. Values for `minPort` 값과 `maxPort` are not required.<br/>- `PORT`: 지정된 포트값으로 설정됩니다. `minPort`값과 `maxPort`값이 같아야 합니다.<br/>- `PORT_RANGE`: Sets to specified port range. |
-| rules.port.minPort  | Body | Number | X  | Minimum port range<br/>- Minimum value received: 5432<br/>- Transmit minimum: 1                                                                                                                                              |
-| rules.port.maxPort  | Body | Number | X  | Maximum port range<br/>- Maximum received: 45432<br/>- Send maximum: 65535                                                                                                                                         |
+| Name                | Type | Format | Required | Description                                                                                                                                                                                                                                                                                                                              |
+|---------------------|------|--------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| dbSecurityGroupName | Body | String | O        | Name to identify the DB security group                                                                                                                                                                                                                                                                                                   |
+| description         | Body | String | X        | Additional information on the DB security group                                                                                                                                                                                                                                                                                          |
+| rules               | Body | Array  | O        | DB security group rule information                                                                                                                                                                                                                                                                                                       |
+| rules.direction     | Body | Enum   | O        | Communication direction<br/>- INGRESS: `Inbound`<br/>- EGRESS: `Outbound`                                                                                                                                                                                                                                                               |
+| rules.etherType     | Body | Enum   | O        | Ether type<br/>- IPV4: `IPv4`<br/>- IPV6: `IPv6`                                                                                                                                                                                                                                                                                        |
+| rules.port          | Body | Object | O        | Port object                                                                                                                                                                                                                                                                                                                              |
+| rules.port.portType | Body | Enum   | O        | Port type<br/>- ALL: `All port ranges (not used in the user console)`<br/>- PORT: `Specific port`<br/>- DB_PORT: `DB listening port`<br/>- PORT_RANGE: `Port range`                                                                                                                                                                      |
+| rules.port.minPort  | Body | Number | X        | Minimum port range<br/>- Minimum value: `1`                                                                                                                                                                                                                                                                                              |
+| rules.port.maxPort  | Body | Number | X        | Maximum port range<br/>- Maximum value: `65535`                                                                                                                                                                                                                                                                                          |
+| rules.cidr          | Body | String | O        | CIDR                                                                                                                                                                                                                                                                                                                                     |
+| rules.description   | Body | String | X        | Additional information on the DB security group rule                                                                                                                                                                                                                                                                                     |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
-    "dbSecurityGroupName": "dbSecurityGroup",
-    "description": "description",
+    "dbSecurityGroupName": "dbSecurityGroupName-example",
+    "description": "description-example",
     "rules": [
         {
             "direction": "INGRESS",
             "etherType": "IPV4",
             "port": {
-                "portType": "PORT_RANGE",
-                "minPort": 10000,
-                "maxPort": 10005
+                "portType": "ALL",
+                "minPort": 1,
+                "maxPort": 1
             },
-            "cidr": "0.0.0.0/0"
+            "cidr": "192.168.0.0/24",
+            "description": "description-example"
         }
     ]
 }
 ```
+
+</p>
 </details>
 
 #### Response
 
-| Name                | Type   | Format   | Description            |
-|-------------------|------|------|---------------|
-| dbSecurityGroupId | Body | UUID | DB security group identifier |
+| Name              | Type | Format | Description                  |
+|-------------------|------|--------|------------------------------|
+| dbSecurityGroupId | Body | UUID   | DB security group identifier |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -3677,57 +4090,14 @@ POST /v1.0/db-security-groups
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "dbSecurityGroupId": "fe4f2aee-afbb-4c19-a5e9-eb2eab394708"
+    "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-### Modify DB Security Group
-
-```http
-PUT /v1.0/db-security-groups/{dbSecurityGroupId}
-```
-
-#### Required permissions
-
-| Permission Name                                     | Description            |
-|-----------------------------------------|---------------|
-| RDSforPostgreSQL:DbSecurityGroup.Modify | Modify DB Security Group |
-
-#### Request
-
-| Name                  | Type   | Format     | Required | Description                    |
-|---------------------|------|--------|----|-----------------------|
-| dbSecurityGroupId   | URL  | UUID   | O  | DB security group identifier         |
-| dbSecurityGroupName | Body | String | X  | Name to identify DB instances |
-| description         | Body | String | X  | Additional information on DB security group    |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "dbSecurityGroupName": "dbSecurityGroup",
-    "description": "description"
-}
-```
-</details>
-
-#### Response
-
-This API does not return a response body.
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
+---
 
 ### Delete DB Security Group
 
@@ -3737,23 +4107,71 @@ DELETE /v1.0/db-security-groups/{dbSecurityGroupId}
 
 #### Required permissions
 
-| Permission Name                                     | Description            |
-|-----------------------------------------|---------------|
+| Permission Name                         | Description              |
+|-----------------------------------------|--------------------------|
 | RDSforPostgreSQL:DbSecurityGroup.Delete | Delete DB Security Group |
 
 #### Request
 
 This API does not require a request body.
 
-| Name                | Type  | Format   | Required | Description            |
-|-------------------|-----|------|----|---------------|
-| dbSecurityGroupId | URL | UUID | O  | DB security group identifier |
+| Name              | Type | Format | Required | Description |
+|-------------------|------|--------|----------|-------------|
+| dbSecurityGroupId | URL  | UUID   | O        |             |
 
 #### Response
 
 This API does not return a response body.
 
+---
+
+### List DB Security Group Details
+
+```http
+GET /v1.0/db-security-groups/{dbSecurityGroupId}
+```
+
+#### Required permissions
+
+| Permission Name                      | Description                    |
+|--------------------------------------|--------------------------------|
+| RDSforPostgreSQL:DbSecurityGroup.Get | List DB Security Group Details |
+
+#### Request
+
+This API does not require a request body.
+
+| Name              | Type | Format | Required | Description                  |
+|-------------------|------|--------|----------|------------------------------|
+| dbSecurityGroupId | URL  | UUID   | O        |                              |
+
+#### Response
+
+| Name                          | Type | Format   | Description                                                                                                                                                                                                                                                              |
+|-------------------------------|------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| dbSecurityGroup               | Body | Object   | DB security group                                                                                                                                                                                                                                                        |
+| dbSecurityGroup.dbSecurityGroupId     | Body | UUID     | DB security group identifier                                                                                                                                                                                                                                             |
+| dbSecurityGroup.dbSecurityGroupName   | Body | String   | Name to identify the DB security group                                                                                                                                                                                                                                   |
+| dbSecurityGroup.dbSecurityGroupStatus | Body | Enum     | Current status of the DB security group<br/>- CREATED: `Created`<br/>- DELETED: `Deleted`                                                                                                                                                                               |
+| dbSecurityGroup.description           | Body | String   | Additional information on the DB security group                                                                                                                                                                                                                          |
+| dbSecurityGroup.progressStatus        | Body | Enum     | Current progress status of the DB security group<br/>- NONE: `No work in progress`<br/>- CREATING_RULE: `Creating rule policy`<br/>- UPDATING_RULE: `Modifying rule policy`<br/>- DELETING_RULE: `Deleting rule policy`<br/>- APPLYING_DEFAULT_RULE: `Applying default rule` |
+| dbSecurityGroup.rules                 | Body | Array    | DB security group rule list                                                                                                                                                                                                                                              |
+| dbSecurityGroup.rules.ruleId          | Body | UUID     | DB security group rule identifier                                                                                                                                                                                                                                        |
+| dbSecurityGroup.rules.description     | Body | String   | Additional information on the DB security group rule                                                                                                                                                                                                                     |
+| dbSecurityGroup.rules.direction       | Body | Enum     | Communication direction<br/>- INGRESS: `Inbound`<br/>- EGRESS: `Outbound`                                                                                                                                                                                               |
+| dbSecurityGroup.rules.etherType       | Body | Enum     | Ether type<br/>- IPV4: `IPv4`<br/>- IPV6: `IPv6`                                                                                                                                                                                                                        |
+| dbSecurityGroup.rules.port            | Body | Object   | Port object                                                                                                                                                                                                                                                              |
+| dbSecurityGroup.rules.port.portType   | Body | Enum     | Port type<br/>- ALL: `All port ranges (not used in the user console)`<br/>- PORT: `Specific port`<br/>- DB_PORT: `DB listening port`<br/>- PORT_RANGE: `Port range`                                                                                                      |
+| dbSecurityGroup.rules.port.minPort    | Body | Number   | Minimum port range                                                                                                                                                                                                                                                       |
+| dbSecurityGroup.rules.port.maxPort    | Body | Number   | Maximum port range                                                                                                                                                                                                                                                       |
+| dbSecurityGroup.rules.cidr            | Body | String   | CIDR                                                                                                                                                                                                                                                                     |
+| dbSecurityGroup.rules.createdYmdt     | Body | DateTime | Created date and time                                                                                                                                                                                                                                                    |
+| dbSecurityGroup.rules.updatedYmdt     | Body | DateTime | Modified date and time                                                                                                                                                                                                                                                   |
+| dbSecurityGroup.createdYmdt           | Body | DateTime | Created date and time                                                                                                                                                                                                                                                    |
+| dbSecurityGroup.updatedYmdt           | Body | DateTime | Modified date and time                                                                                                                                                                                                                                                   |
+
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -3761,133 +4179,78 @@ This API does not return a response body.
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
+    },
+    "dbSecurityGroup": {
+        "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
+        "dbSecurityGroupName": "dbSecurityGroupName-example",
+        "dbSecurityGroupStatus": "CREATED",
+        "description": "description-example",
+        "progressStatus": "NONE",
+        "rules": [
+            {
+                "ruleId": "550e8400-e29b-41d4-a716-446655440000",
+                "description": "description-example",
+                "direction": "INGRESS",
+                "etherType": "IPV4",
+                "port": {
+                    "portType": "ALL",
+                    "minPort": 1,
+                    "maxPort": 1
+                },
+                "cidr": "192.168.0.0/24",
+                "createdYmdt": "2023-12-31T15:00:00+09:00",
+                "updatedYmdt": "2023-12-31T15:00:00+09:00"
+            }
+        ],
+        "createdYmdt": "2023-12-31T15:00:00+09:00",
+        "updatedYmdt": "2023-12-31T15:00:00+09:00"
     }
 }
 ```
+
+</p>
 </details>
 
-### Create DB Security Group
+---
+
+### Modify DB Security Group
 
 ```http
-POST /v1.0/db-security-groups/{dbSecurityGroupId}/rules
+PUT /v1.0/db-security-groups/{dbSecurityGroupId}
 ```
 
 #### Required permissions
 
-| Permission Name                                         | Description               |
-|---------------------------------------------|------------------|
-| RDSforPostgreSQL:DbSecurityGroupRule.Create | Create DB Security Group |
+| Permission Name                         | Description              |
+|-----------------------------------------|--------------------------|
+| RDSforPostgreSQL:DbSecurityGroup.Modify | Modify DB Security Group |
 
 #### Request
 
-| Name                | Type   | Format     | Required | Description                                                                                                                                                                                       |
-|-------------------|------|--------|----|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId | URL  | UUID   | O  | DB security group identifier                                                                                                                                                                            |
-| description       | Body | String | X  | Additional information on DB security group rule                                                                                                                                                                    |
-| direction         | Body | Enum   | O  | Communication direction<br/>- `INGRESS`: Inbound<br/>- `EGRESS`: Outbound                                                                                                                                             |
-| etherType         | Body | Enum   | O  | Ether type<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                           |
-| port              | Body | Object | O  | Port object                                                                                                                                                                                    |
-| port.portType     | Body | Enum   | O  | Port type<br/>- `DB_PORT`: Sets to DB instance port value. Values for `minPort` 값과 `maxPort` are not required.<br/>- `PORT`: 지정된 포트값으로 설정됩니다. `minPort`값과 `maxPort`값이 같아야 합니다.<br/>- `PORT_RANGE`: Sets to specified port range. |
-| port.minPort      | Body | Number | X  | Minimum port range<br/>- Minimum value received: 5432<br/>- Transmit minimum: 1                                                                                                                                              |
-| port.maxPort      | Body | Number | X  | Maximum port range<br/>- Maximum received: 45432<br/>- Send maximum: 65535                                                                                                                                         |
-| cidr              | Body | String | O  | Remote source for traffic to allow<br/>- Example: `1.1.1.1/32`                                                                                                                                                    |
+| Name                | Type | Format | Required | Description                                     |
+|---------------------|------|--------|----------|-------------------------------------------------|
+| dbSecurityGroupId   | URL  | UUID   | O        |                                                 |
+| dbSecurityGroupName | Body | String | O        | Name to identify the DB security group          |
+| description         | Body | String | X        | Additional information on the DB security group |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
-    "direction": "INGRESS",
-    "etherType": "IPV4",
-    "port": {
-        "portType": "PORT",
-        "minPort": 10000,
-        "maxPort": 10000
-    },
-    "cidr": "0.0.0.0/0"
+    "dbSecurityGroupName": "dbSecurityGroupName-example",
+    "description": "description-example"
 }
 ```
+
+</p>
 </details>
 
 #### Response
 
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
+This API does not return a response body.
 
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### Modify DB Security Group Rule
-
-```http
-PUT /v1.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
-```
-
-#### Required permissions
-
-| Permission Name                                         | Description               |
-|---------------------------------------------|------------------|
-| RDSforPostgreSQL:DbSecurityGroupRule.Modify | Modify DB Security Group Rule |
-
-#### Request
-
-| Name                | Type   | Format     | Required | Description                                                                                                                                                                                       |
-|-------------------|------|--------|----|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId | URL  | UUID   | O  | DB security group identifier                                                                                                                                                                            |
-| ruleId            | URL  | UUID   | O  | DB security group rule identifier                                                                                                                                                                         |
-| description       | Body | String | X  | Additional information on DB security group rule                                                                                                                                                                    |
-| direction         | Body | Enum   | O  | Communication direction<br/>- `INGRESS`: Inbound<br/>- `EGRESS`: Outbound                                                                                                                                             |
-| etherType         | Body | Enum   | O  | Ether type<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                           |
-| port              | Body | Object | O  | Port object                                                                                                                                                                                    |
-| port.portType     | Body | Enum   | O  | Port type<br/>- `DB_PORT`: Sets to DB instance port value. Values for `minPort` 값과 `maxPort` are not required.<br/>- `PORT`: 지정된 포트값으로 설정됩니다. `minPort`값과 `maxPort`값이 같아야 합니다.<br/>- `PORT_RANGE`: Sets to specified port range. |
-| port.minPort      | Body | Number | X  | Minimum port range<br/>- Minimum value received: 5432<br/>- Transmit minimum: 1                                                                                                                                              |
-| port.maxPort      | Body | Number | X  | Maximum port range<br/>- Maximum received: 45432<br/>- Send maximum: 65535                                                                                                                                         |
-| cidr              | Body | String | O  | Remote source for traffic to allow<br/>- Example: `1.1.1.1/32`                                                                                                                                                    |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "direction": "INGRESS",
-    "etherType": "IPV4",
-    "port": {
-        "portType": "DB_PORT"
-    },
-    "cidr": "0.0.0.0/0"
-}
-```
-</details>
-
-#### Response
-
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
+---
 
 ### Delete DB Security Group Rule
 
@@ -3897,26 +4260,27 @@ DELETE /v1.0/db-security-groups/{dbSecurityGroupId}/rules
 
 #### Required permissions
 
-| Permission Name                                         | Description               |
-|---------------------------------------------|------------------|
-| RDSforPostgreSQL:DbSecurityGroupRule.Create | Delete DB Security Group Rule |
+| Permission Name                             | Description                  |
+|---------------------------------------------|------------------------------|
+| RDSforPostgreSQL:DbSecurityGroupRule.Delete | Delete DB Security Group Rule |
 
 #### Request
 
 This API does not require a request body.
 
-| Name                | Type    | Format    | Required | Description                  |
-|-------------------|-------|-------|----|---------------------|
-| dbSecurityGroupId | URL   | UUID  | O  | DB security group identifier       |
-| ruleIds           | Query | Array | O  | DB security group rule identifiers |
+| Name              | Type  | Format | Required | Description                        |
+|-------------------|-------|--------|----------|------------------------------------|
+| dbSecurityGroupId | URL   | UUID   | O        |                                    |
+| ruleIds           | Query | String | O        | DB security group rule ID list     |
 
 #### Response
 
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
+| Name  | Type | Format | Description                  |
+|-------|------|--------|------------------------------|
+| jobId | Body | UUID   | Identifier of requested task |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -3925,11 +4289,157 @@ This API does not require a request body.
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
+---
+
+### Create DB Security Group Rule
+
+```http
+POST /v1.0/db-security-groups/{dbSecurityGroupId}/rules
+```
+
+#### Required permissions
+
+| Permission Name                             | Description                  |
+|---------------------------------------------|------------------------------|
+| RDSforPostgreSQL:DbSecurityGroupRule.Create | Create DB Security Group Rule |
+
+#### Request
+
+| Name              | Type | Format | Required | Description                                                                                                                                                                                                          |
+|-------------------|------|--------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| dbSecurityGroupId | URL  | UUID   | O        |                                                                                                                                                                                                                      |
+| direction         | Body | Enum   | O        | Communication direction<br/>- INGRESS: `Inbound`<br/>- EGRESS: `Outbound`                                                                                                                                            |
+| etherType         | Body | Enum   | O        | Ether type<br/>- IPV4: `IPv4`<br/>- IPV6: `IPv6`                                                                                                                                                                     |
+| port              | Body | Object | O        | Port information                                                                                                                                                                                                     |
+| port.portType     | Body | Enum   | O        | Port type<br/>- ALL: `All port ranges (not used in the user console)`<br/>- PORT: `Specific port`<br/>- DB_PORT: `DB listening port`<br/>- PORT_RANGE: `Port range`                                                   |
+| port.minPort      | Body | Number | X        | Minimum port range<br/>- Minimum value: `1`                                                                                                                                                                          |
+| port.maxPort      | Body | Number | X        | Maximum port range<br/>- Maximum value: `65535`                                                                                                                                                                      |
+| cidr              | Body | String | O        | CIDR                                                                                                                                                                                                                 |
+| description       | Body | String | X        | Additional information on the DB security group rule                                                                                                                                                                 |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "direction": "INGRESS",
+    "etherType": "IPV4",
+    "port": {
+        "portType": "ALL",
+        "minPort": 1,
+        "maxPort": 1
+    },
+    "cidr": "192.168.0.0/24",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name  | Type | Format | Description                  |
+|-------|------|--------|------------------------------|
+| jobId | Body | UUID   | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Modify DB Security Group Rule
+
+```http
+PUT /v1.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
+```
+
+#### Required permissions
+
+| Permission Name                             | Description                  |
+|---------------------------------------------|------------------------------|
+| RDSforPostgreSQL:DbSecurityGroupRule.Modify | Modify DB Security Group Rule |
+
+#### Request
+
+| Name              | Type | Format | Required | Description                                                                                                                                                                                                          |
+|-------------------|------|--------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| dbSecurityGroupId | URL  | UUID   | O        |                                                                                                                                                                                                                      |
+| ruleId            | URL  | UUID   | O        |                                                                                                                                                                                                                      |
+| direction         | Body | Enum   | O        | Communication direction<br/>- INGRESS: `Inbound`<br/>- EGRESS: `Outbound`                                                                                                                                            |
+| etherType         | Body | Enum   | O        | Ether type<br/>- IPV4: `IPv4`<br/>- IPV6: `IPv6`                                                                                                                                                                     |
+| port              | Body | Object | O        | Port information                                                                                                                                                                                                     |
+| port.portType     | Body | Enum   | O        | Port type<br/>- ALL: `All port ranges (not used in the user console)`<br/>- PORT: `Specific port`<br/>- DB_PORT: `DB listening port`<br/>- PORT_RANGE: `Port range`                                                   |
+| port.minPort      | Body | Number | X        | Minimum port range<br/>- Minimum value: `1`                                                                                                                                                                          |
+| port.maxPort      | Body | Number | X        | Maximum port range<br/>- Maximum value: `65535`                                                                                                                                                                      |
+| cidr              | Body | String | O        | CIDR                                                                                                                                                                                                                 |
+| description       | Body | String | X        | Additional information on the DB security group rule                                                                                                                                                                 |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "direction": "INGRESS",
+    "etherType": "IPV4",
+    "port": {
+        "portType": "ALL",
+        "minPort": 1,
+        "maxPort": 1
+    },
+    "cidr": "192.168.0.0/24",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name  | Type | Format | Description                  |
+|-------|------|--------|------------------------------|
+| jobId | Body | UUID   | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
 ## Parameter group
 
 ### List Parameter Groups
@@ -3940,32 +4450,29 @@ GET /v1.0/parameter-groups
 
 #### Required permissions
 
-| Permission Name                                  | Description            |
-|--------------------------------------|---------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforPostgreSQL:ParameterGroup.List | List Parameter Groups |
 
 #### Request
 
 This API does not require a request body.
 
-| Name        | Type    | Format   | Required | Description       |
-|-----------|-------|------|----|----------|
-| dbVersion | Query | Enum | X  | DB version information |
-
 #### Response
 
-| Name                                   | Type   | Format       | Description                                                                |
-|--------------------------------------|------|----------|-------------------------------------------------------------------|
-| parameterGroups                      | Body | Array    | Parameter groups                                                        |
-| parameterGroups.parameterGroupId     | Body | UUID     | Parameter group identifier                                                      |
-| parameterGroups.parameterGroupName   | Body | String   | Name to identify parameter groups                                              |
-| parameterGroups.parameterGroupStatus | Body | Enum     | Parameter group current status<br/>- `STABLE`: Applied<br/>- `NEED_TO_APPLY`: Need to apply |
-| parameterGroups.description          | Body | String   | Additional information on parameter group                                                 |
-| parameterGroups.dbVersion            | Body | Enum     | DB version information                                                          |
-| parameterGroups.createdYmdt          | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                 |
-| parameterGroups.updatedYmdt          | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                 |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| parameterGroups | Body | Array | Parameter groups |
+| parameterGroups.parameterGroupId | Body | UUID | Parameter group identifier |
+| parameterGroups.parameterGroupName | Body | String | Name to identify parameter groups |
+| parameterGroups.description | Body | String | Additional information on parameter group |
+| parameterGroups.dbVersion | Body | Enum | DB version information |
+| parameterGroups.parameterGroupStatus | Body | Enum | Parameter group current status<br/>- STABLE: `Applied`<br/>- NEED_TO_APPLY: `Need to apply`<br/>- DELETED: `Deleted` |
+| parameterGroups.createdYmdt | Body | DateTime | Created date and time |
+| parameterGroups.updatedYmdt | Body | DateTime | Modified date and time |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -3976,96 +4483,22 @@ This API does not require a request body.
     },
     "parameterGroups": [
         {
-            "parameterGroupId": "404e8a89-ca4d-4fca-96c2-1518754d50b7",
-            "parameterGroupName": "parameter-group",
+            "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "parameterGroupName": "parameterGroupName-example",
+            "description": "description-example",
+            "dbVersion": "POSTGRESQL_V14_17",
             "parameterGroupStatus": "STABLE",
-            "description": null,
-            "dbVersion": "POSTGRESQL_V17_6",
-            "createdYmdt": "2023-02-31T15:28:17+09:00",
-            "updatedYmdt": "2023-02-31T15:28:17+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
+
+</p>
 </details>
 
-
-### List Parameter Group Details
-
-```http
-GET /v1.0/parameter-groups/{parameterGroupId}
-```
-
-#### Required permissions
-
-| Permission Name                                 | Description            |
-|-------------------------------------|---------------|
-| RDSforPostgreSQL:ParameterGroup.Get | List Parameter Group Details |
-
-#### Request
-
-This API does not require a request body.
-
-| Name               | Type  | Format   | Required | Description           |
-|------------------|-----|------|----|--------------|
-| parameterGroupId | URL | UUID | O  | Parameter group identifier |
-
-#### Response
-
-| Name                           | Type   | Format       | Description                                                                                                                                                                                                                                                                                                                                                 |
-|------------------------------|------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| parameterGroupId             | Body | UUID     | Parameter group identifier                                                                                                                                                                                                                                                                                                                                       |
-| parameterGroupName           | Body | String   | Name to identify parameter groups                                                                                                                                                                                                                                                                                                                               |
-| description                  | Body | String   | Additional information on parameter group                                                                                                                                                                                                                                                                                                                                  |
-| dbVersion                    | Body | Enum     | DB version information                                                                                                                                                                                                                                                                                                                                           |
-| parameterGroupStatus         | Body | Enum     | Parameter group current status<br/>- `STABLE`: Applied<br/>- `NEED_TO_APPLY`: Need to apply<br/>- `DELETED`: Deleted                                                                                                                                                                                                                                                             |
-| parameters                   | Body | Array    | Parameter list                                                                                                                                                                                                                                                                                                                                            |
-| parameters.parameterCategory | Body | String   | Parameter Categories                                                                                                                                                                                                                                                                                                                                          |
-| parameters.parameterName     | Body | String   | Parameter name                                                                                                                                                                                                                                                                                                                                            |
-| parameters.value             | Body | String   | Current value                                                                                                                                                                                                                                                                                                                                           |
-| parameters.valueUnit         | Body | Enum     | The units of the currently set value<br/>- `B`: Bytes<br/>- `kB`: Kilobyte<br/>- `MB`: Megabytes<br/>- `GB`: Gigabyte<br/>- `TB`: Terabyte<br/>- `us`: Microseconds<br/>- `ms`: milliseconds<br/>- `s`: seconds<br/>- `min`: Minutes<br/>- `h`: hour<br/>- `d`: day                                                                                                                                                        |
-| parameters.defaultValue      | Body | String   | Default value                                                                                                                                                                                                                                                                                                                                                |
-| parameters.allowedValue      | Body | String   | Permitted values                                                                                                                                                                                                                                                                                                                                              |
-| parameters.valueType         | Body | Enum     | Value type<br/>- `BOOLEAN: Boolean` type<br/>- `STRING`: String type<br/>- `NUMERIC`: Integer and floating-point types<br/>- `NUMERIC_WITH_BYTE_UNIT`: Numeric type with byte unit (e.g. 120 KB, 100 MB)<br/>- `NUMERIC_WITH_TIME_UNIT`: Numeric type with time unit (e.g. 120ms, 100s, 1d)<br/>- `ENUMERATED`: Enter one of the values declared in Allowed Values<br/>- `MULTI_ENUMERATED`: Enter multiple of the values declared in Allowed values (separated by commas (,))<br/>- `TIMEZONE`: Timezone type |
-| parameters.updateType        | Body | Enum     | Modification type<br/>- `VARIABLE`: Modifiable any time<br/>- `CONSTANT`: Not modifiable                                                                                                                                                                                                                                                                                         |
-| parameters.applyType         | Body | Enum     | Applied type<br/>- `SESSION`: Apply session<br/>- `FILE`: Apply setting file (restart required)<br/>- `BOTH`: All                                                                                                                                                                                                                                                                       | 
-| createdYmdt                  | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                                                                                                                                                                                  |
-| updatedYmdt                  | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                                                                                                                                                                                  |
-| expressionAvailable          | Body | Boolean  | Allow formulas or not                                                                                                                                                                                                                                                                                                                                           |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroupId": "404e8a89-ca4d-4fca-96c2-1518754d50b7",
-    "parameterGroupName": "parameter-group",
-    "description": null,
-    "dbVersion": "POSTGRESQL_V17_6",
-    "parameterGroupStatus": "STABLE",
-    "parameters": [
-        {
-            "parameterCategory": "Write-Ahead Log / Checkpoints",
-            "parameterName": "checkpoint_timeout",
-            "value": "300s",
-            "defaultValue": "300s",
-            "allowedValue": "30~86400s",
-            "valueType": "NUMERIC_WITH_TIME_UNIT",
-            "updateType": "VARIABLE",
-            "applyType": "BOTH",
-            "expressionAvailable": true
-        }
-    ],
-    "createdYmdt": "2023-03-13T11:02:28+09:00",
-    "updatedYmdt": "2023-03-13T11:02:28+09:00"
-}
-```
-</details>
-
+---
 
 ### Create Parameter Group
 
@@ -4075,36 +4508,40 @@ POST /v1.0/parameter-groups
 
 #### Required permissions
 
-| Permission Name                                    | Description           |
-|----------------------------------------|--------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforPostgreSQL:ParameterGroup.Create | Create Parameter Group |
 
 #### Request
 
-| Name                 | Type   | Format     | Required | Description                   |
-|--------------------|------|--------|----|----------------------|
-| parameterGroupName | Body | String | O  | Name to identify parameter groups |
-| description        | Body | String | X  | Additional information on parameter group    |
-| dbVersion          | Body | Enum   | O  | DB version information             |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupName | Body | String | O | Name to identify parameter groups |
+| description | Body | String | X | Additional information on parameter group |
+| dbVersion | Body | Enum | O | DB version information |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
-    "parameterGroupName": "parameter-group",
-    "description": "description",
-    "dbVersion": "POSTGRESQL_V17_6"
+    "parameterGroupName": "parameterGroupName-example",
+    "description": "description-example",
+    "dbVersion": "POSTGRESQL_V14_17"
 }
 ```
+
+</p>
 </details>
 
 #### Response
 
-| Name               | Type   | Format   | Description           |
-|------------------|------|------|--------------|
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
 | parameterGroupId | Body | UUID | Parameter group identifier |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -4113,194 +4550,14 @@ POST /v1.0/parameter-groups
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "parameterGroupId": "404e8a89-ca4d-4fca-96c2-1518754d50b7"
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-### Copy Parameter Group
-
-```http
-POST /v1.0/parameter-groups/{parameterGroupId}/copy
-```
-
-#### Required permissions
-
-| Permission Name                                  | Description           |
-|--------------------------------------|--------------|
-| RDSforPostgreSQL:ParameterGroup.Copy | Copy Parameter Group |
-
-#### Request
-
-| Name                 | Type   | Format     | Required | Description                   |
-|--------------------|------|--------|----|----------------------|
-| parameterGroupId   | URL  | UUID   | O  | Parameter group identifier         |
-| parameterGroupName | Body | String | O  | Name to identify parameter groups |
-| description        | Body | String | X  | Additional information on parameter group    |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "parameterGroupName": "parameter-group-copy",
-    "description": "copy"
-}
-```
-</details>
-
-#### Response
-
-| Name               | Type   | Format   | Description           |
-|------------------|------|------|--------------|
-| parameterGroupId | Body | UUID | Parameter group identifier |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroupId": "404e8a89-ca4d-4fca-96c2-1518754d50b7"
-}
-```
-</details>
-
-### Modify Parameter Group
-
-```http
-PUT /v1.0/parameter-groups/{parameterGroupId}
-```
-
-#### Required permissions
-
-| Permission Name                                    | Description           |
-|----------------------------------------|--------------|
-| RDSforPostgreSQL:ParameterGroup.Modify | Modify Parameter Group |
-
-#### Request
-
-| Name                 | Type   | Format     | Required | Description                   |
-|--------------------|------|--------|----|----------------------|
-| parameterGroupId   | URL  | UUID   | O  | Parameter group identifier         |
-| parameterGroupName | Body | String | X  | Name to identify parameter groups |
-| description        | Body | String | X  | Additional information on parameter group    |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "parameterGroupName": "parameter-group",
-    "description": "description"
-}
-```
-</details>
-
-#### Response
-
-This API does not return a response body.
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
-
-### Modify Parameter
-
-```http
-PUT /v1.0/parameter-groups/{parameterGroupId}/parameters
-```
-
-#### Required permissions
-
-| Permission Name                                    | Description           |
-|----------------------------------------|--------------|
-| RDSforPostgreSQL:ParameterGroup.Modify | Modify Parameter Group |
-
-#### Request
-
-| Name                               | Type   | Format     | Required | Description           |
-|----------------------------------|------|--------|----|--------------|
-| parameterGroupId                 | URL  | UUID   | O  | Parameter group identifier |
-| modifiedParameters               | Body | Array  | O  | Parameters to change  |
-| modifiedParameters.parameterName | Body | UUID   | O  | Parameter name      |
-| modifiedParameters.value         | Body | String | O  | Parameter value to change   |
-
-<details><summary>Example</summary>
-
-```json
-{
-   "modifiedParameters": [
-       {
-           "parameterName": "checkpoint_timeout",
-           "value": "100s"
-       }
-   ]
-}
-```
-</details>
-
-#### Response
-
-This API does not return a response body.
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
-
-### Reset Parameter Group
-
-```http
-PUT /v1.0/parameter-groups/{parameterGroupId}/reset
-```
-
-#### Required permissions
-
-| Permission Name                                   | Description            |
-|---------------------------------------|---------------|
-| RDSforPostgreSQL:ParameterGroup.Reset | Reset Parameter Group |
-
-#### Request
-
-| Name               | Type  | Format   | Required | Description           |
-|------------------|-----|------|----|--------------|
-| parameterGroupId | URL | UUID | O  | Parameter group identifier |
-
-#### Response
-
-This API does not return a response body.
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
+---
 
 ### Delete Parameter Group
 
@@ -4310,23 +4567,69 @@ DELETE /v1.0/parameter-groups/{parameterGroupId}
 
 #### Required permissions
 
-| Permission Name                                    | Description           |
-|----------------------------------------|--------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforPostgreSQL:ParameterGroup.Delete | Delete Parameter Group |
 
 #### Request
 
 This API does not require a request body.
 
-| Name               | Type  | Format   | Required | Description           |
-|------------------|-----|------|----|--------------|
-| parameterGroupId | URL | UUID | O  | Parameter group identifier |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O | Parameter group identifier |
 
 #### Response
 
 This API does not return a response body.
 
+---
+
+### List Parameter Group Details
+
+```http
+GET /v1.0/parameter-groups/{parameterGroupId}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:ParameterGroup.Get | List Parameter Group Details |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O | Parameter group identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| parameterGroupId | Body | UUID | Parameter group identifier |
+| parameterGroupName | Body | String | Name to identify parameter groups |
+| description | Body | String | Additional information on parameter group |
+| dbVersion | Body | Enum | DB version information |
+| parameterGroupStatus | Body | Enum | Parameter group current status<br/>- STABLE: `Applied`<br/>- NEED_TO_APPLY: `Need to apply`<br/>- DELETED: `Deleted` |
+| parameters | Body | Array | Parameter list |
+| parameters.parameterCategory | Body | String | Parameter category |
+| parameters.parameterName | Body | String | Parameter name |
+| parameters.value | Body | String | Current value |
+| parameters.valueUnit | Body | String | Unit of the current value (byte: B,kB,MB,GB,TB, time: us,ms,s,min,h,d) |
+| parameters.defaultValue | Body | String | Default value |
+| parameters.allowedValue | Body | String | Permitted values |
+| parameters.valueType | Body | Enum | Value type<br/>- BOOLEAN: `Boolean type`<br/> `* ex) on, off, true, false, yes, no, 1, 0`<br/>- STRING: `String type`<br/>- NUMERIC: `Integer and floating-point types`<br/>- NUMERIC_WITH_BYTE_UNIT: `Numeric type with byte unit`<br/> `* ex) 120kB, 100MB`<br/> `* Allowed byte units: B (bytes), kB (kilobytes), MB (megabytes), GB (gigabytes), and TB (terabytes)`<br/>- NUMERIC_WITH_TIME_UNIT: `Numeric type with time unit`<br/> `* ex) 120ms, 100s, 1d`<br/> `* Allowed time units: us (microseconds), ms (milliseconds), s (seconds), min (minutes), h (hours), and d (days)`<br/>- ENUMERATED: `Enter one of the values declared in Allowed Values (separated by commas (,))`<br/>- MULTI_ENUMERATED: `Enter multiple of the values declared in Allowed Values (separated by commas (,))` |
+| parameters.updateType | Body | Enum | Modification type<br/>- VARIABLE: `Modifiable any time`<br/>- CONSTANT: `Not modifiable` |
+| parameters.applyType | Body | Enum | Applied type<br/>- BOTH: `Apply session and setting file`<br/>- SESSION: `Apply session only`<br/>- FILE: `Apply setting file only` |
+| parameters.expressionAvailable | Body | Boolean | Allow formulas or not |
+| createdYmdt | Body | DateTime | Created date and time |
+| updatedYmdt | Body | DateTime | Modified date and time |
+
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -4334,11 +4637,202 @@ This API does not return a response body.
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "parameterGroupName": "parameterGroupName-example",
+    "description": "description-example",
+    "dbVersion": "POSTGRESQL_V14_17",
+    "parameterGroupStatus": "STABLE",
+    "parameters": [
+        {
+            "parameterCategory": "parameterCategory-example",
+            "parameterName": "parameterName-example",
+            "value": "value-example",
+            "valueUnit": "valueUnit-example",
+            "defaultValue": "defaultValue-example",
+            "allowedValue": "allowedValue-example",
+            "valueType": "BOOLEAN",
+            "updateType": "VARIABLE",
+            "applyType": "BOTH",
+            "expressionAvailable": false
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
+
+</p>
 </details>
 
+---
+
+### Modify Parameter Group
+
+```http
+PUT /v1.0/parameter-groups/{parameterGroupId}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:ParameterGroup.Modify | Modify Parameter Group |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O | Parameter group identifier |
+| parameterGroupName | Body | String | X | Name to identify parameter groups |
+| description | Body | String | X | Additional information on parameter group |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "parameterGroupName": "parameterGroupName-example",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+This API does not return a response body.
+
+---
+
+### Copy Parameter Group
+
+```http
+POST /v1.0/parameter-groups/{parameterGroupId}/copy
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:ParameterGroup.Copy | Copy Parameter Group |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O | Parameter group identifier |
+| parameterGroupName | Body | String | O | Name to identify parameter groups |
+| description | Body | String | X | Additional information on parameter group |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "parameterGroupName": "parameterGroupName-example",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| parameterGroupId | Body | UUID | Parameter group identifier |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Modify Parameter
+
+```http
+PUT /v1.0/parameter-groups/{parameterGroupId}/parameters
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:ParameterGroup.Modify | Modify Parameter Group |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O | Parameter group identifier |
+| modifiedParameters | Body | Array | O | Parameters to change |
+| modifiedParameters.parameterName | Body | String | O | Parameter name |
+| modifiedParameters.value | Body | String | O | Parameter value to change |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "modifiedParameters": [
+        {
+            "parameterName": "parameterName-example",
+            "value": "value-example"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+This API does not return a response body.
+
+---
+
+### Reset Parameter Group
+
+```http
+PUT /v1.0/parameter-groups/{parameterGroupId}/reset
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:ParameterGroup.Reset | Reset Parameter Group |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O | Parameter group identifier |
+
+#### Response
+
+This API does not return a response body.
+
+---
 ## User Group
 
 ### List User Groups
@@ -4349,8 +4843,8 @@ GET /v1.0/user-groups
 
 #### Required permissions
 
-| Permission Name                             | Description           |
-|---------------------------------|--------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforPostgreSQL:UserGroup.List | List User Groups |
 
 #### Request
@@ -4359,16 +4853,17 @@ This API does not require a request body.
 
 #### Response
 
-| Name                       | Type   | Format       | Description                                                      |
-|--------------------------|------|----------|---------------------------------------------------------|
-| userGroups               | Body | Array    | User Groups                                               |
-| userGroups.userGroupId   | Body | UUID     | User group identifier                                             |
-| userGroups.userGroupName | Body | String   | Name to identify user groups                                     |
-| userGroupStatus          | Body | Enum     | Current status of user groups<br/>- `CREATED: Created`<br/>- `DELETED`: Deleted |
-| userGroups.createdYmdt   | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                       |
-| userGroups.updatedYmdt   | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                       |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| userGroups | Body | Array | User Groups |
+| userGroups.userGroupId | Body | UUID | User group identifier |
+| userGroups.userGroupName | Body | String | Name to identify user groups |
+| userGroupStatus | Body | Enum | Current status of user groups<br/>- CREATED<br/>- DELETED |
+| userGroups.createdYmdt | Body | DateTime | Created date and time |
+| userGroups.updatedYmdt | Body | DateTime | Modified date and time |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -4379,75 +4874,20 @@ This API does not require a request body.
     },
     "userGroups": [
         {
-            "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-            "userGroupName": "dev-team",
+            "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "userGroupName": "userGroupName-example",
             "userGroupStatus": "CREATED",
-            "createdYmdt": "2023-02-23T10:07:54+09:00",
-            "updatedYmdt": "2023-02-26T01:15:50+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
+
+</p>
 </details>
 
-
-### List User Group Details
-
-```http
-GET /v1.0/user-groups/{userGroupId}
-```
-
-#### Required permissions
-
-| Permission Name                            | Description           |
-|--------------------------------|--------------|
-| RDSforPostgreSQL:UserGroup.Get | List User Group Details |
-
-#### Request
-
-This API does not require a request body.
-
-| Name          | Type  | Format   | Required | Description          |
-|-------------|-----|------|----|-------------|
-| userGroupId | URL | UUID | O  | User group identifier |
-
-#### Response
-
-| Name                | Type   | Format       | Description                                                                                                        |
-|-------------------|------|----------|-----------------------------------------------------------------------------------------------------------|
-| userGroupId       | Body | UUID     | User group identifier                                                                                               |
-| userGroupName     | Body | String   | Name to identify user groups                                                                                       |
-| userGroupTypeCode | Body | Enum     | User group type    <br /> `ENTIRE`: User group including all project members <br /> `INDIVIDUAL_MEMBER`: User group including specific project members |
-| userGroupStatus   | Body | Enum     | Current status of user groups<br/>- `CREATED: Created`<br/>- `DELETED`: Deleted                                                   |
-| members           | Body | Array    | Project member list                                                                                                |
-| members.memberId  | Body | UUID     | Project member identifier                                                                                              |
-| createdYmdt       | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                         |
-| updatedYmdt       | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                         |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-    "userGroupName": "dev-team",
-    "userGroupStatus": "CREATED",
-    "userGroupTypeCode": "INDIVIDUAL_MEMBER",
-    "members": [
-        {
-            "memberId": "1321e759-2ef3-4b85-9921-b13e918b24b5"
-        }
-    ],
-    "createdYmdt": "2023-02-23T10:07:54+09:00",
-    "updatedYmdt": "2023-02-26T01:15:50+09:00"
-}
-```
-</details>
-
+---
 
 ### Create User Group
 
@@ -4457,78 +4897,40 @@ POST /v1.0/user-groups
 
 #### Required permissions
 
-| Permission Name                               | Description          |
-|-----------------------------------|-------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforPostgreSQL:UserGroup.Create | Create User Group |
 
 #### Request
 
-| Name            | Type   | Format      | Required | Description                                                              |
-|---------------|------|---------|----|-----------------------------------------------------------------|
-| userGroupName | Body | String  | O  | Name to identify user groups                                             |
-| memberIds     | Body | Array   | O  | Project member identifiers     <br /> Ignored when `selectAllYN` is true |
-| selectAllYN   | Body | Boolean | X  | All project members or not <br /> If true, the group is set for all members              |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| userGroupName | Body | String | O | Name to identify user groups |
+| memberIds | Body | Array | O | List of project member identifiers |
+| selectAllYN | Body | Boolean | O | All project members or not<br/>- Default: `false` |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
-    "userGroupName": "dev-team",
-    "memberIds": ["1321e759-2ef3-4b85-9921-b13e918b24b5"]
+    "userGroupName": "userGroupName-example",
+    "memberIds": [],
+    "selectAllYN": false
 }
 ```
 
-```json
-{
-    "userGroupName": "dev-team",
-    "selectAllYN":true
-}
-```
+</p>
 </details>
 
 #### Response
 
-| Name          | Type   | Format   | Description          |
-|-------------|------|------|-------------|
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
 | userGroupId | Body | UUID | User group identifier |
 
-
-### Modify User Group
-
-```http
-PUT /v1.0/user-groups/{userGroupId}
-```
-
-#### Required permissions
-
-| Permission Name                               | Description          |
-|-----------------------------------|-------------|
-| RDSforPostgreSQL:UserGroup.Modify | Modify User Group |
-
-#### Request
-
-| Name            | Type   | Format      | Required | Description                                                 |
-|---------------|------|---------|----|----------------------------------------------------|
-| userGroupId   | URL  | UUID    | O  | User group identifier                                        |
-| userGroupName | Body | String  | X  | Name to identify user groups                                |
-| memberIds     | Body | Array   | X  | Project member identifiers                                    |
-| selectAllYN   | Body | Boolean | X  | All project members or not <br /> If true, the group is set for all members |
-
 <details><summary>Example</summary>
-
-```json
-{
-    "userGroupName": "dev-team",
-    "memberIds": ["1321e759-2ef3-4b85-9921-b13e918b24b5","f9064b09-2b15-442e-a4b0-3a5a2754555e"]
-}
-```
-</details>
-
-#### Response
-
-This API does not return a response body.
-
-<details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -4536,10 +4938,15 @@ This API does not return a response body.
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "userGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
+
+---
 
 ### Delete User Group
 
@@ -4549,21 +4956,59 @@ DELETE /v1.0/user-groups/{userGroupId}
 
 #### Required permissions
 
-| Permission Name                               | Description          |
-|-----------------------------------|-------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforPostgreSQL:UserGroup.Delete | Delete User Group |
 
 #### Request
 
-| Name          | Type  | Format   | Required | Description          |
-|-------------|-----|------|----|-------------|
-| userGroupId | URL | UUID | O  | User group identifier |
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | O | User group identifier |
 
 #### Response
 
 This API does not return a response body.
 
+---
+
+### List User Group Details
+
+```http
+GET /v1.0/user-groups/{userGroupId}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:UserGroup.Get | List User Group Details |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | O | User group identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| userGroupId | Body | UUID | User group identifier |
+| userGroupName | Body | String | Name to identify user groups |
+| userGroupTypeCode | Body | Enum | User group type<br/>- ENTIRE: `All project members`<br/>- INDIVIDUAL_MEMBER: `Custom` |
+| userGroupStatus | Body | Enum | Current status of user groups<br/>- CREATED<br/>- DELETED |
+| members | Body | Array | Project member list |
+| members.memberId | Body | UUID | Project member identifier |
+| createdYmdt | Body | DateTime | Created date and time |
+| updatedYmdt | Body | DateTime | Modified date and time |
+
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -4571,12 +5016,67 @@ This API does not return a response body.
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "userGroupName": "userGroupName-example",
+    "userGroupTypeCode": "ENTIRE",
+    "userGroupStatus": "CREATED",
+    "members": [
+        {
+            "memberId": "550e8400-e29b-41d4-a716-446655440000"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
+
+</p>
 </details>
 
-## Notification Group
+---
+
+### Modify User Group
+
+```http
+PUT /v1.0/user-groups/{userGroupId}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:UserGroup.Modify | Modify User Group |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | O | User group identifier |
+| userGroupName | Body | String | X | Name to identify user groups |
+| memberIds | Body | Array | X | List of project member identifiers |
+| selectAllYN | Body | Boolean | O | All project members or not<br/>- Default: `false` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "userGroupName": "userGroupName-example",
+    "memberIds": [],
+    "selectAllYN": false
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+This API does not return a response body.
+
+---
+## Notification Groups
 
 ### List Notification Groups
 
@@ -4586,8 +5086,8 @@ GET /v1.0/notification-groups
 
 #### Required permissions
 
-| Permission Name                                     | Description          |
-|-----------------------------------------|-------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforPostgreSQL:NotificationGroup.List | List Notification Groups |
 
 #### Request
@@ -4596,19 +5096,20 @@ This API does not require a request body.
 
 #### Response
 
-| Name                                         | Type   | Format       | Description                                                     |
-|--------------------------------------------|------|----------|--------------------------------------------------------|
-| notificationGroups                         | Body | Array    | Notification Groups                                               |
-| notificationGroups.notificationGroupId     | Body | UUID     | Notification group identifier                                             |
-| notificationGroups.notificationGroupName   | Body | String   | Name to identify notification groups                                     |
-| notificationGroups.notificationGroupStatus | Body | Enum     | Current status of notification groups<br/>- `CREATED: Created`<br/>- `DELETED`: Deleted |
-| notificationGroups.notifyEmail             | Body | Boolean  | Whether to be notified by email                                              |
-| notificationGroups.notifySms               | Body | Boolean  | Whether to be notified by SMS                                              |
-| notificationGroups.isEnabled               | Body | Boolean  | Indicates whether the flavor is enabled                                                 |
-| notificationGroups.createdYmdt             | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                      |
-| notificationGroups.updatedYmdt             | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                      |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| notificationGroups | Body | Array |  |
+| notificationGroups.notificationGroupId | Body | UUID | Notification group identifier |
+| notificationGroups.notificationGroupName | Body | String | Name to identify notification groups |
+| notificationGroups.notificationGroupStatus | Body | Enum | Current status of notification groups<br/>- CREATED: `Created`<br/>- DELETED: `Deleted` |
+| notificationGroups.notifyEmail | Body | Boolean | Whether to be notified by email |
+| notificationGroups.notifySms | Body | Boolean | Whether to be notified by SMS |
+| notificationGroups.isEnabled | Body | Boolean | Whether it is enabled |
+| notificationGroups.createdYmdt | Body | DateTime | Created date and time |
+| notificationGroups.updatedYmdt | Body | DateTime | Modified date and time |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -4619,91 +5120,23 @@ This API does not require a request body.
     },
     "notificationGroups": [
         {
-            "notificationGroupId": "b3901f17-9971-4d1e-8a81-8448cf533dc7",
-            "notificationGroupName": "dev-team-noti",
-            "notifyEmail": true,
+            "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "notificationGroupName": "notificationGroupName-example",
+            "notificationGroupStatus": "CREATED",
+            "notifyEmail": false,
             "notifySms": false,
-            "isEnabled": true,
-            "createdYmdt": "2023-02-20T13:34:13+09:00",
-            "updatedYmdt": "2023-02-20T13:34:13+09:00"
+            "isEnabled": false,
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
+
+</p>
 </details>
 
-
-### List Notification Groups
-
-```http
-GET /v1.0/notification-groups/{notificationGroupId}
-```
-
-#### Required permissions
-
-| Permission Name                                    | Description          |
-|----------------------------------------|-------------|
-| RDSforPostgreSQL:NotificationGroup.Get | List Notification Groups |
-
-#### Request
-
-This API does not require a request body.
-
-| Name                  | Type  | Format   | Required | Description         |
-|---------------------|-----|------|----|------------|
-| notificationGroupId | URL | UUID | O  | Notification group identifier |
-
-#### Response
-
-| Name                         | Type   | Format       | Description                                                     |
-|----------------------------|------|----------|--------------------------------------------------------|
-| notificationGroupId        | Body | UUID     | Notification group identifier                                             |
-| notificationGroupName      | Body | String   | Name to identify notification groups                                     |
-| notificationGroupStatus    | Body | Enum     | Current status of notification groups<br/>- `CREATED: Created`<br/>- `DELETED`: Deleted |
-| notifyEmail                | Body | Boolean  | Whether to be notified by email                                              |
-| notifySms                  | Body | Boolean  | Whether to be notified by SMS                                              |
-| isEnabled                  | Body | Boolean  | Indicates whether the flavor is enabled                                                 |
-| dbInstances                | Body | Array    | DB Instances to monitor                                       |
-| dbInstances.dbInstanceId   | Body | UUID     | DB instance identifier                                           |
-| dbInstances.dbInstanceName | Body | String   | Name to identify DB instances                                   |
-| userGroups                 | Body | Array    | User Groups                                              |
-| userGroups.userGroupId     | Body | UUID     | User group identifier                                            |
-| userGroups.userGroupName   | Body | String   | Name to identify user groups                                    |
-| createdYmdt                | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                      |
-| updatedYmdt                | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                      |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "notificationGroupId": "b3901f17-9971-4d1e-8a81-8448cf533dc7",
-    "notificationGroupName": "dev-team-noti",
-    "notifyEmail": true,
-    "notifySms": false,
-    "isEnabled": true,
-    "dbInstances": [
-        {
-            "dbInstanceId": "ed5cb985-526f-4c54-9ae0-40288593de65",
-            "dbInstanceName": "database"
-        }
-    ],
-    "userGroups": [
-        {
-            "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-            "userGroupName": "dev-team"
-        }
-    ],
-    "createdYmdt": "2023-02-20T13:34:13+09:00",
-    "updatedYmdt": "2023-02-20T13:34:13+09:00"
-}
-```
-</details>
-
+---
 
 ### Create Notification Group
 
@@ -4713,80 +5146,46 @@ POST /v1.0/notification-groups
 
 #### Required permissions
 
-| Permission Name                                       | Description         |
-|-------------------------------------------|------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforPostgreSQL:NotificationGroup.Create | Create Notification Group |
 
 #### Request
 
-| Name                    | Type   | Format      | Required | Description                          |
-|-----------------------|------|---------|----|-----------------------------|
-| notificationGroupName | Body | String  | O  | Name to identify notification groups          |
-| notifyEmail           | Body | Boolean | X  | Whether to be notified by email<br/>Default: `true` |
-| notifySms             | Body | Boolean | X  | Whether to be notified by SMS<br/>Default: `true` |
-| isEnabled             | Body | Boolean | X  | Indicates whether the flavor is enabled<br/>Default: `true`    |
-| dbInstanceIds         | Body | Array   | X  | DB instance identifiers to monitor       |
-| userGroupIds          | Body | Array   | X  | User group identifiers              |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| notificationGroupName | Body | String | O | Name to identify notification groups |
+| notifyEmail | Body | Boolean | X | Whether to be notified by email<br/>- Default: `true` |
+| notifySms | Body | Boolean | X | Whether to be notified by SMS<br/>- Default: `true` |
+| isEnabled | Body | Boolean | X | Whether it is enabled<br/>- Default: `true` |
+| dbInstanceIds | Body | Array | O | List of identifiers of DB instances to monitor |
+| userGroupIds | Body | Array | O | List of user group identifiers |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
-    "notificationGroupName": "dev-team-noti",
-    "notifyEmail": false,
-    "isEnable": true,
-    "dbInstanceIds": ["ed5cb985-526f-4c54-9ae0-40288593de65"],
-    "userGroupIds": ["1aac0437-f32d-4923-ad3c-ac61c1cfdfe0"]
+    "notificationGroupName": "notificationGroupName-example",
+    "notifyEmail": true,
+    "notifySms": true,
+    "isEnabled": true,
+    "dbInstanceIds": [],
+    "userGroupIds": []
 }
 ```
+
+</p>
 </details>
 
 #### Response
 
-| Name                  | Type   | Format   | Description         |
-|---------------------|------|------|------------|
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
 | notificationGroupId | Body | UUID | Notification group identifier |
 
-
-### Modify Notification Group
-
-```http
-PUT /v1.0/notification-groups/{notificationGroupId}
-```
-
-#### Required permissions
-
-| Permission Name                                       | Description         |
-|-------------------------------------------|------------|
-| RDSforPostgreSQL:NotificationGroup.Modify | Modify Notification Group |
-
-#### Request
-
-| Name                    | Type   | Format      | Required | Description                    |
-|-----------------------|------|---------|----|-----------------------|
-| notificationGroupId   | URL  | UUID    | O  | Notification group identifier            |
-| notificationGroupName | Body | String  | X  | Name to identify notification groups    |
-| notifyEmail           | Body | Boolean | X  | Whether to be notified by email             |
-| notifySms             | Body | Boolean | X  | Whether to be notified by SMS             |
-| isEnabled             | Body | Boolean | X  | Indicates whether the flavor is enabled                |
-| dbInstanceIds         | Body | Array   | X  | DB instance identifiers to monitor |
-| userGroupIds          | Body | Array   | X  | User group identifiers        |
-
 <details><summary>Example</summary>
-
-```json
-{
-    "notifyEmail": true,
-    "dbInstanceIds": ["ed5cb985-526f-4c54-9ae0-40288593de65", "d51b7da0-682f-47ff-b588-b739f6adc740"]
-}
-```
-</details>
-
-#### Response
-
-This API does not return a response body.
-
-<details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -4794,10 +5193,15 @@ This API does not return a response body.
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
+
+---
 
 ### Delete Notification Group
 
@@ -4807,65 +5211,65 @@ DELETE /v1.0/notification-groups/{notificationGroupId}
 
 #### Required permissions
 
-| Permission Name                                       | Description         |
-|-------------------------------------------|------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforPostgreSQL:NotificationGroup.Delete | Delete Notification Group |
 
 #### Request
 
 This API does not require a request body.
 
-| Name                  | Type  | Format   | Required | Description         |
-|---------------------|-----|------|----|------------|
-| notificationGroupId | URL | UUID | O  | Notification group identifier |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O | Notification group identifier |
 
 #### Response
 
 This API does not return a response body.
 
-<details><summary>Example</summary>
+---
 
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
-
-### View the list of watch settings
+### View Notification Group Details
 
 ```http
-GET /v1.0/notification-groups/{notificationGroupId}/watchdogs
+GET /v1.0/notification-groups/{notificationGroupId}
 ```
 
 #### Required permissions
 
-| Permission Name                                        | Description          |
-|--------------------------------------------|-------------|
-| RDSforPostgreSQL:NotificationWatchdog.List | View the list of watch settings |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:NotificationGroup.Get | View Notification Group Details |
 
 #### Request
 
 This API does not require a request body.
 
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O | Notification group identifier |
+
 #### Response
 
-| Name                           | Type   | Format       | Description                                                                     |
-|------------------------------|------|----------|------------------------------------------------------------------------|
-| notificationGroupId          | URL  | UUID     | Notification group identifier                                                             | Notification group identifier                                                            |
-| watchdogs                    | Body | Array    | List of watch settings                                                               |
-| watchdogs.watchdogId         | Body | UUID     | Identifier of the watch setting                                                             |
-| watchdogs.metricName         | Body | Enum     | Performance metrics to watch<br/>- For the performance metrics you can set, see [Viewing the performance metrics list](#성능-지표-목록-보기). |
-| watchdogs.comparisonOperator | Body | Enum     | How to compare watchlists<br/>- `LE`: <=<br/>- `LT`: <<br/>- `GE`: >=<br/>- `GT`: >  |
-| watchdogs.threshold          | Body | Long     | Thresholds to watch                                                              |
-| watchdogs.duration           | Body | Long     | Watchlist duration<br/>- Unit: `minutes`                                              |
-| watchdogs.createdYmdt        | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                      |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| notificationGroupId | Body | UUID | Notification group identifier |
+| notificationGroupName | Body | String | Name to identify notification groups |
+| notificationGroupStatus | Body | Enum | Current status of notification groups<br/>- CREATED: `Created`<br/>- DELETED: `Deleted` |
+| notifyEmail | Body | Boolean | Whether to be notified by email |
+| notifySms | Body | Boolean | Whether to be notified by SMS |
+| isEnabled | Body | Boolean | Whether it is enabled |
+| dbInstances | Body | Array | List of DB instances to monitor |
+| dbInstances.dbInstanceId | Body | UUID | DB instance identifier |
+| dbInstances.dbInstanceName | Body | String | Name to identify DB instances |
+| userGroups | Body | Array | List of user groups |
+| userGroups.userGroupId | Body | UUID | User group identifier |
+| userGroups.userGroupName | Body | String | Name to identify user groups |
+| createdYmdt | Body | DateTime | Created date and time |
+| updatedYmdt | Body | DateTime | Modified date and time |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -4874,22 +5278,142 @@ This API does not require a request body.
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "watchdogs": [
+    "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "notificationGroupName": "notificationGroupName-example",
+    "notificationGroupStatus": "CREATED",
+    "notifyEmail": false,
+    "notifySms": false,
+    "isEnabled": false,
+    "dbInstances": [
         {
-            "watchdogId": "b3901f17-9971-4d1e-8a81-8448cf533dc7",
-            "metricName": "DATABASE_STATUS",
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbInstanceName": "dbInstanceName-example"
+        }
+    ],
+    "userGroups": [
+        {
+            "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "userGroupName": "userGroupName-example"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Modify Notification Group
+
+```http
+PUT /v1.0/notification-groups/{notificationGroupId}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:NotificationGroup.Modify | Modify Notification Group |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O | Notification group identifier |
+| notificationGroupName | Body | String | X | Name to identify notification groups |
+| notifyEmail | Body | Boolean | X | Whether to be notified by email<br/>- Default: `false` |
+| notifySms | Body | Boolean | X | Whether to be notified by SMS<br/>- Default: `false` |
+| isEnabled | Body | Boolean | X | Whether it is enabled<br/>- Default: `false` |
+| dbInstanceIds | Body | Array | O | List of identifiers of DB instances to monitor |
+| userGroupIds | Body | Array | O | List of user group identifiers |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "notificationGroupName": "notificationGroupName-example",
+    "notifyEmail": false,
+    "notifySms": false,
+    "isEnabled": false,
+    "dbInstanceIds": [],
+    "userGroupIds": []
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+This API does not return a response body.
+
+---
+
+### List Watch Settings
+
+```http
+GET /v1.0/notification-groups/{notificationGroupId}/watchdogs
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:NotificationWatchdog.List | List Watch Settings |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O | Notification group identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| notificationWatchdogs | Body | Array | Watch setting information |
+| notificationWatchdogs.watchdogId | Body | UUID | Watch setting identifier |
+| notificationWatchdogs.metricName | Body | String | Performance metrics to watch |
+| notificationWatchdogs.comparisonOperator | Body | Enum | Comparison method for watch target<br/>- LE: `<=`<br/>- LT: `<`<br/>- GE: `>=`<br/>- GT: `>` |
+| notificationWatchdogs.threshold | Body | Number | Threshold for watch target |
+| notificationWatchdogs.duration | Body | Number | Duration for watch target |
+| notificationWatchdogs.createdYmdt | Body | DateTime | Created date and time |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "notificationWatchdogs": [
+        {
+            "watchdogId": "550e8400-e29b-41d4-a716-446655440000",
+            "metricName": "metricName-example",
             "comparisonOperator": "LE",
-            "threshold": 0,
-            "duration": 5,
-            "createdYmdt": "2023-02-20T13:34:13+09:00",
-            "updatedYmdt": "2023-02-20T13:34:13+09:00"
+            "threshold": 1,
+            "duration": 1,
+            "createdYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
+
+</p>
 </details>
 
-### Create a watch setting
+---
+
+### Create Watch Setting
 
 ```http
 POST /v1.0/notification-groups/{notificationGroupId}/watchdogs
@@ -4897,79 +5421,43 @@ POST /v1.0/notification-groups/{notificationGroupId}/watchdogs
 
 #### Required permissions
 
-| Permission Name                                          | Description         |
-|----------------------------------------------|------------|
-| RDSforPostgreSQL:NotificationWatchdog.Create | Create a watch setting |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:NotificationWatchdog.Create | Create Watch Setting |
 
 #### Request
 
-| Name                  | Type   | Format   | Required | Description                                                                     |
-|---------------------|------|------|----|------------------------------------------------------------------------|
-| notificationGroupId | URL  | UUID | O  | Notification group identifier                                                             |
-| metricName          | Body | Enum | O  | Performance metrics to watch<br/>- For the performance metrics you can set, see [Viewing the performance metrics list](#성능-지표-목록-보기). |
-| comparisonOperator  | Body | Enum | O  | How to compare watchlists<br/>- `LE`: <=<br/>- `LT`: <<br/>- `GE`: >=<br/>- `GT`: >  |
-| threshold           | Body | Long | O  | Thresholds to watch                                                              |
-| duration            | Body | Long | O  | Watchlist duration<br/>- Unit: `minutes`                                              |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O | Notification group identifier |
+| metricName | Body | String | O | Performance metrics to watch |
+| comparisonOperator | Body | Enum | O | Comparison method for watch target<br/>- LE: `<=`<br/>- LT: `<`<br/>- GE: `>=`<br/>- GT: `>` |
+| threshold | Body | Number | O | Threshold for watch target<br/>- Minimum value: `0` |
+| duration | Body | Number | O | Duration for watch target (minutes)<br/>- Minimum value: `0` |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
-    "metricName": "DATABASE_STATUS",
+    "metricName": "metricName-example",
     "comparisonOperator": "LE",
     "threshold": 0,
-    "duration": 5
+    "duration": 0
 }
 ```
+
+</p>
 </details>
 
 #### Response
 
-| Name         | Type   | Format   | Description         |
-|------------|------|------|------------|
-| watchdogId | Body | UUID | Identifier of the watch setting |
-
-
-### Modify watch settings
-
-```http
-PUT /v1.0/notification-groups/{notificationGroupId}/watchdogs/{watchdogId}
-```
-
-#### Required permissions
-
-| Permission Name                                          | Description         |
-|----------------------------------------------|------------|
-| RDSforPostgreSQL:NotificationWatchdog.Modify | Modify watch settings |
-
-#### Request
-
-| Name                  | Type   | Format   | Required | Description                                                                     |
-|---------------------|------|------|----|------------------------------------------------------------------------|
-| notificationGroupId | URL  | UUID | O  | Notification group identifier                                                             |
-| watchdogId          | URL  | UUID | O  | Identifier of the watch setting                                                             |
-| metricName          | Body | Enum | O  | Performance metrics to watch<br/>- For the performance metrics you can set, see [Viewing the performance metrics list](#성능-지표-목록-보기). |
-| comparisonOperator  | Body | Enum | O  | How to compare watchlists<br/>- `LE`: <=<br/>- `LT`: <<br/>- `GE`: >=<br/>- `GT`: >  |
-| threshold           | Body | Long | O  | Thresholds to watch                                                              |
-| duration            | Body | Long | O  | Watchlist duration<br/>- Unit: `minutes`                                              |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| watchdogId | Body | UUID | Watch setting identifier |
 
 <details><summary>Example</summary>
-
-```json
-{
-    "metricName": "DATABASE_STATUS",
-    "comparisonOperator": "LE",
-    "threshold": 0,
-    "duration": 10
-}
-```
-</details>
-
-#### Response
-
-This API does not return a response body.
-
-<details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -4977,12 +5465,17 @@ This API does not return a response body.
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "watchdogId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-### Deleting a watch setting
+---
+
+### Delete Notification Group
 
 ```http
 DELETE /v1.0/notification-groups/{notificationGroupId}/watchdogs/{watchdogId}
@@ -4990,37 +5483,91 @@ DELETE /v1.0/notification-groups/{notificationGroupId}/watchdogs/{watchdogId}
 
 #### Required permissions
 
-| Permission Name                                          | Description         |
-|----------------------------------------------|------------|
-| RDSforPostgreSQL:NotificationWatchdog.Delete | Deleting a watch setting |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:NotificationWatchdog.Delete | Delete Notification Group |
 
 #### Request
 
 This API does not require a request body.
 
-| Name                  | Type  | Format   | Required | Description         |
-|---------------------|-----|------|----|------------|
-| notificationGroupId | URL | UUID | O  | Notification group identifier |
-| watchdogId          | URL | UUID | O  | Identifier of the watch setting |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O | Notification group identifier |
+| watchdogId | URL | UUID | O | Watch setting identifier |
 
 #### Response
 
 This API does not return a response body.
 
+---
+
+### Modify Watch Setting
+
+```http
+PUT /v1.0/notification-groups/{notificationGroupId}/watchdogs/{watchdogId}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:NotificationWatchdog.Modify | Modify Watch Setting |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O | Notification group identifier |
+| watchdogId | URL | UUID | O | Watch setting identifier |
+| metricName | Body | String | O | Performance metrics to watch |
+| comparisonOperator | Body | Enum | O | Comparison method for watch target<br/>- LE: `<=`<br/>- LT: `<`<br/>- GE: `>=`<br/>- GT: `>` |
+| threshold | Body | Number | O | Threshold for watch target<br/>- Minimum value: `0` |
+| duration | Body | Number | O | Duration for watch target (minutes)<br/>- Minimum value: `0` |
+
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
+    "metricName": "metricName-example",
+    "comparisonOperator": "LE",
+    "threshold": 0,
+    "duration": 0
 }
 ```
+
+</p>
 </details>
 
+#### Response
+
+This API does not return a response body.
+
+---
 ## Monitoring
+
+### View stats
+
+```http
+GET /v1.0/metric-statistics
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:Metric.List | View stats |
+
+#### Request
+
+This API does not require a request body.
+
+#### Response
+
+This API does not return a response body.
+
+---
 
 ### View a list of performance metrics
 
@@ -5030,9 +5577,9 @@ GET /v1.0/metrics
 
 #### Required permissions
 
-| Permission Name                          | Description       |
-|------------------------------|----------|
-| RDSforPostgreSQL:Metric.List | View stats |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:Metric.List | View a list of performance metrics |
 
 #### Request
 
@@ -5040,13 +5587,14 @@ This API does not require a request body.
 
 #### Response
 
-| Name                 | Type   | Format     | Description       |
-|--------------------|------|--------|----------|
-| metrics            | Body | Array  | List of performance metrics |
-| metrics.metricName | Body | Enum   | Performance metric types |
-| metrics.unit       | Body | String | Measure unit   |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| metrics | Body | Array | List of performance metrics |
+| metrics.metricName | Body | String | Performance metric types |
+| metrics.unit | Body | String | Measure unit |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -5057,161 +5605,34 @@ This API does not require a request body.
     },
     "metrics": [
         {
-            "metricName": "CPU_USAGE",
-            "unit": "%"
+            "metricName": "metricName-example",
+            "unit": "unit-example"
         }
     ]
 }
 ```
+
+</p>
 </details>
 
-### View stats
-
-```http
-GET /v1.0/metric-statistics
-```
-
-#### Required permissions
-
-| Permission Name                          | Description       |
-|------------------------------|----------|
-| RDSforPostgreSQL:Metric.List | View stats |
-
-#### Request
-
-| Name           | Type    | Format       | Required | Description                                                        |
-|--------------|-------|----------|----|-----------------------------------------------------------|
-| dbInstanceId | Query | UUID     | O  | DB instance identifier                                              |
-| metricNames  | Query | Array    | O  | List of performance metrics to look up<br/>- Minimum length: `1`                             |
-| from         | Query | Datetime | O  | Start date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                         |
-| to           | Query | Datetime | O  | End date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                         |
-| interval     | Query | Number   | X  | View interval<br/>- Unit: `minutes`<br/>- Default: Automatically selects the appropriate value based on start/end dates |
-
-#### Response
-
-| Name                                | Type   | Format        | Description       |
-|-----------------------------------|------|-----------|----------|
-| metricStatistics                  | Body | Array     | Statistics information list |
-| metricStatistics.metricName       | Body | Enum      | Performance metric types |
-| metricStatistics.unit             | Body | String    | Measure unit   |
-| metricStatistics.values           | Body | Array     | Measure values   |
-| metricStatistics.values.timestamp | Body | Timestamp | Measure time    |
-| metricStatistics.values.value     | Body | Object    | Measure value      |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "metricStatistics": [
-        {
-            "metricName": "DATABASE_STATUS",
-            "unit": "",
-            "values": [
-                [
-                    1679298540,
-                    "1"
-                ],
-                [
-                    1679298600,
-                    "1"
-                ],
-                [
-                    1679298660,
-                    "1"
-                ]
-            ]
-        }
-    ]
-}
-```
-</details>
+---
 
 ## Event
 
-### View the list of events
+### Event categories
 
-```
-GET /v1.0/events
-```
+Events can be classified by category as follows.
 
-#### Required permissions
+| Event category | Description |
+|-------------|---------|
+| ALL         | All |
+| BACKUP      | Backup |
+| DB_INSTANCE | DB instance |
+| JOB         | Job |
+| TENANT      | Tenant |
+| MONITORING  | Monitoring |
 
-| Permission Name                         | Description        |
-|-----------------------------|-----------|
-| RDSforPostgreSQL:Event.List | View the list of events |
-
-#### Request
-
-This API does not require a request body.
-
-| Name                | Type    | Format       | Required | Description                                                                                                                                                                               |
-|-------------------|-------|----------|----|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| page              | Query | Number   | O  | Page to retrieve<br/>- Minimum value: `1`                                                                                                                                                       |
-| size              | Query | Number   | O  | Page size to retrieve<br/>- Minimum value: `1`<br/>- Maximum value: `100`                                                                                                                                   |
-| from              | Query | Datetime | O  | Start date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                |
-| to                | Query | Datetime | O  | End date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                |
-| eventCategoryType | Query | Enum     | O  | Event category types to query<br/>ALL: All<br/>- `BACKUP`: Backup<br/>- `DB_INSTANCE`: DB instance<br/>- `DB_SECURITY_GROUP`: DB security group<br/>- `JOB: Job`<br/>- `TENANT`: Tenant<br/>- `MONITORING`: Monitoring |
-| sourceId          | Query | String   | X  | Event target resource identifier                                                                                                                                                             |
-| keyword           | Query | String   | X  | String keyword in event message                                                                                                                                                             |
-
-#### Response
-
-| Name                       | Type   | Format       | Description                                                 |
-|--------------------------|------|----------|----------------------------------------------------|
-| totalCounts              | Body | Number   | Total number of events                                        |
-| events                   | Body | Array    | Events                                             |
-| events.eventCategoryType | Body | Enum     | Event category type                                        |
-| events.eventCode         | Body | Enum     | Occurred event type<br/>- See [Events](event/) for a detailed description. |
-| events.sourceId          | Body | String   | Event source identifier                                        |
-| events.sourceName        | Body | String   | Name to identify event sources                                |
-| events.messages          | Body | Array    | Event messages                                         |
-| events.messages.langCode | Body | String   | Language code                                              |
-| events.messages.message  | Body | String   | Event Message                                            |
-| events.eventYmdt         | Body | DateTime | Event occurred date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)              |
-
-<details><summary>Example</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 28,
-    "events": [
-        {
-            "eventCategoryType": "INSTANCE",
-            "eventCode": "INSTC_02_01",
-            "sourceId": "76f00947-356e-4a20-8922-428368cc45ed",
-            "sourceName": "db-instance",
-            "messages": [
-                {
-                    "langCode": "EN",
-                    "message": "DB instance started"
-                },
-                {
-                    "langCode": "JA",
-                    "message": "DBインスタンスの起動"
-                },
-                {
-                    "langCode": "KO",
-                    "message": "DB 인스턴스 시작"
-                },
-                {
-                    "langCode": "ZH",
-                    "message": "DB instance started"
-                }
-            ],
-            "eventYmdt": "2023-03-20T16:31:59+09:00"
-        }
-    ]
-}
-```
-</details>
-
-
-### List Subscribable Event Codes
+### List subscribable event codes
 
 ```http
 GET /v1.0/event-codes
@@ -5219,9 +5640,9 @@ GET /v1.0/event-codes
 
 #### Required permissions
 
-| Permission Name                         | Description        |
-|-----------------------------|-----------|
-| RDSforPostgreSQL:Event.List | View the list of events |
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:Event.List | List subscribable event codes |
 
 #### Request
 
@@ -5229,13 +5650,14 @@ This API does not require a request body.
 
 #### Response
 
-| Name                           | Type   | Format    | Description          |
-|------------------------------|------|-------|-------------|
-| eventCodes                   | Body | Array | Event Codes   |
-| eventCodes.eventCode         | Body | Enum  | Event Code      |
-| eventCodes.eventCategoryType | Body | Enum  | Event category type |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| eventCodes | Body | Array | Event codes |
+| eventCodes.eventCode | Body | Enum | Event code |
+| eventCodes.eventCategoryType | Body | Enum | Event category type<br/>- ALL: `All`<br/>- DB_INSTANCE: `Events generated from DB instance`<br/>- DB_SECURITY_GROUP: `Events generated from DB security group`<br/>- MONITORING: `Events generated from monitoring`<br/>- JOB: `Events generated from JOB`<br/>- BACKUP: `Events generated from backup`<br/>- TENANT: `Events generated from tenant` |
 
 <details><summary>Example</summary>
+<p>
 
 ```json
 {
@@ -5246,10 +5668,79 @@ This API does not require a request body.
     },
     "eventCodes": [
         {
-            "eventCode": "DB_INSTANCE_02_01",
-            "eventCategoryType": "DB_INSTANCE"
+            "eventCode": "ENUM_VALUE",
+            "eventCategoryType": "ALL"
         }
     ]
 }
 ```
+
+</p>
 </details>
+
+---
+
+### View the list of events
+
+```http
+GET /v1.0/events
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforPostgreSQL:Event.List | View the list of events |
+
+#### Request
+
+This API does not require a request body.
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | Total number of events |
+| events | Body | Array | Events |
+| events.eventCategoryType | Body | Enum | Event category type<br/>- ALL: `All`<br/>- DB_INSTANCE: `Events generated from DB instance`<br/>- DB_SECURITY_GROUP: `Events generated from DB security group`<br/>- MONITORING: `Events generated from monitoring`<br/>- JOB: `Events generated from JOB`<br/>- BACKUP: `Events generated from backup`<br/>- TENANT: `Events generated from tenant` |
+| events.eventCode | Body | Enum | Occurred event type |
+| events.sourceId | Body | UUID | Event source identifier |
+| events.sourceName | Body | String | Name to identify event sources |
+| events.messages | Body | Array | Event messages |
+| events.messages.langCode | Body | Enum | Language code<br/>- KO<br/>- EN<br/>- JA<br/>- ZH |
+| events.messages.message | Body | String | Event message |
+| events.eventYmdt | Body | DateTime | Event occurred date and time |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "totalCounts": 1,
+    "events": [
+        {
+            "eventCategoryType": "ALL",
+            "eventCode": "ENUM_VALUE",
+            "sourceId": "550e8400-e29b-41d4-a716-446655440000",
+            "sourceName": "sourceName-example",
+            "messages": [
+                {
+                    "langCode": "KO",
+                    "message": "message-example"
+                }
+            ],
+            "eventYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---

--- a/ja/api-guide-v1.0.md
+++ b/ja/api-guide-v1.0.md
@@ -58,19 +58,6 @@ APIリクエスト時、認証に失敗または権限がない場合、次の�
 
 ## DBバージョン
 
-| DBバージョン            | 作成可否 |
-|-------------------|----------|
-| POSTGRESQL_V14_6  |          |
-| POSTGRESQL_V14_15 |          |
-| POSTGRESQL_V14_17 | O        |
-| POSTGRESQL_V14_19 | O        |
-| POSTGRESQL_V17_2  |          |
-| POSTGRESQL_V17_4  | O        |
-| POSTGRESQL_V17_6  | O        |
-
-* ENUMタイプのdbVersionフィールドに対して該当値を使用できます。
-* バージョンによっては、作成不可能な場合や復元不可能な場合があります。
-
 ### DBバージョンリストを表示
 
 ```http
@@ -79,8 +66,8 @@ GET /v1.0/db-versions
 
 #### 必要権限
 
-| 権限名                            | 説明         |
-|---------------------------------|-------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:DbVersion.List | DBバージョンリストを表示 |
 
 #### リクエスト
@@ -89,14 +76,16 @@ GET /v1.0/db-versions
 
 #### レスポンス
 
-| 名前                          | 種類  | 形式     | 説明                   |
-|------------------------------|------|---------|-----------------------|
-| dbVersions                   | Body | Array   | DBバージョンリスト             |
-| dbVersions.dbVersion         | Body | String  | DBバージョン                |
-| dbVersions.dbVersionName     | Body | String  | DBバージョン名               |
-| dbVersions.restorableFromObs | Body | Boolean | オブジェクトストレージから復元可能かどうか |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| dbVersions | Body | Array | DBバージョン情報 |
+| dbVersions.dbVersionCode | Body | Enum | DBバージョンコード<br/>- MYSQL_V5633<br/>- MYSQL_V5715<br/>- MYSQL_V5719<br/>- MYSQL_V5726<br/>- MYSQL_V5731<br/>- MYSQL_V5733<br/>- MYSQL_V5737<br/>- MYSQL_V8018<br/>- MYSQL_V8023<br/>- MYSQL_V8028<br/>- MYSQL_V8032<br/>- MYSQL_V8033<br/>- MYSQL_V8034<br/>- MYSQL_V8035<br/>- MYSQL_V8036<br/>- MYSQL_V8040<br/>- MYSQL_V8041<br/>- MYSQL_V8042<br/>- MYSQL_V8043<br/>- MYSQL_V8044<br/>- MYSQL_V8045<br/>- MYSQL_V8405<br/>- MYSQL_V8406<br/>- MYSQL_V8407<br/>- MYSQL_V8408<br/>- MYSQL_V8409<br/>- MARIADB_V10330<br/>- MARIADB_V10611<br/>- MARIADB_V10612<br/>- MARIADB_V10616<br/>- MARIADB_V10622<br/>- MARIADB_V10625<br/>- MARIADB_V101107<br/>- MARIADB_V101108<br/>- MARIADB_V101113<br/>- MARIADB_V101116<br/>- MARIADB_V11407<br/>- MARIADB_V11410<br/>- MARIADB_V11806<br/>- POSTGRESQL_V14_6<br/>- POSTGRESQL_V14_15<br/>- POSTGRESQL_V14_17<br/>- POSTGRESQL_V14_19<br/>- POSTGRESQL_V17_2<br/>- POSTGRESQL_V17_4<br/>- POSTGRESQL_V17_6 |
+| dbVersions.dbMajorVersionCode | Body | Enum | DBメジャーバージョンコード<br/>- MYSQL_V56<br/>- MYSQL_V57<br/>- MYSQL_V80<br/>- MYSQL_V84<br/>- MARIADB_V103<br/>- MARIADB_V106<br/>- MARIADB_V1011<br/>- MARIADB_V114<br/>- MARIADB_V118<br/>- POSTGRES_V14<br/>- POSTGRES_V17 |
+| dbVersions.name | Body | String | DBバージョン名 |
+| dbVersions.canCreate | Body | Boolean | 新規作成可能かどうか |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -107,14 +96,19 @@ GET /v1.0/db-versions
     },
     "dbVersions": [
         {
-            "dbVersion": "POSTGRESQL_V17_6",
-            "dbVersionName": "PostgreSQL V17.6",
-            "restorableFromObs": true
+            "dbVersionCode": "MYSQL_V5633",
+            "dbMajorVersionCode": "MYSQL_V56",
+            "name": "PostgreSQL V14.6",
+            "canCreate": false
         }
     ]
 }
 ```
+
+</p>
 </details>
+
+---
 
 ## DBインスタンス仕様
 
@@ -126,9 +120,9 @@ GET /v1.0/db-flavors
 
 #### 必要権限
 
-| 権限名                           | 説明              |
-|--------------------------------|------------------|
-| RDSforPostgreSQL:DbFlavor.List | DBインスタンス仕様リスト表示 |
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbFlavor.List | DBインスタンス仕様リストを表示 |
 
 #### リクエスト
 
@@ -136,15 +130,16 @@ GET /v1.0/db-flavors
 
 #### レスポンス
 
-| 名前                    | 種類  | 形式    | 説明             |
-|------------------------|------|--------|-----------------|
-| dbFlavors              | Body | Array  | DBインスタンス仕様リスト  |
-| dbFlavors.dbFlavorId   | Body | UUID   | DBインスタンス仕様の識別子 |
-| dbFlavors.dbFlavorName | Body | String | DBインスタンス仕様名  |
-| dbFlavors.ram          | Body | Number | メモリ容量(MB)      |
-| dbFlavors.vcpus        | Body | Number | CPUコア数       |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| dbFlavors | Body | Array | DBインスタンス仕様情報 |
+| dbFlavors.dbFlavorId | Body | UUID | DBインスタンス仕様の識別子 |
+| dbFlavors.dbFlavorName | Body | String | DBインスタンス仕様名 |
+| dbFlavors.ram | Body | Number | メモリ容量(MB) |
+| dbFlavors.vcpus | Body | Number | CPUコア数 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -155,17 +150,73 @@ GET /v1.0/db-flavors
     },
     "dbFlavors": [
         {
-            "dbFlavorId": "50be6d9c-02d6-4594-a2d4-12010eb65ec0",
-            "dbFlavorName": "m2.c1m2",
-            "ram": 2048,
-            "vcpus": 1
+            "dbFlavorId": "289e34e9-cd8a-4baf-82e3-a3d013c5186b",
+            "dbFlavorName": "r2.c2m4",
+            "ram": 4096,
+            "vcpus": 2
         }
     ]
 }
 ```
+
+</p>
 </details>
 
+---
+
 ## プロジェクト情報
+
+### プロジェクトメンバーリストを表示
+
+```http
+GET /v1.0/project/members
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:Project.Get | プロジェクトメンバーリストを表示 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| projectMembers | Body | Array | プロジェクトメンバー情報 |
+| projectMembers.memberId | Body | UUID | プロジェクトメンバーの識別子 |
+| projectMembers.memberName | Body | String | プロジェクトメンバーの名前 |
+| projectMembers.emailAddress | Body | String | プロジェクトメンバーのメールアドレス |
+| projectMembers.phoneNumber | Body | String | プロジェクトメンバーの電話番号 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "projectMembers": [
+        {
+            "memberId": "550e8400-e29b-41d4-a716-446655440000",
+            "memberName": "memberName-example",
+            "emailAddress": "user@example.com",
+            "phoneNumber": "010-1234-5678"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
 
 ### リージョンリストを表示
 
@@ -175,9 +226,9 @@ GET /v1.0/project/regions
 
 #### 必要権限
 
-| 権限名                         | 説明        |
-|------------------------------|------------|
-| RDSforPostgreSQL:Project.Get | プロジェクト情報を照会 |
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:Project.Get | リージョンリストを表示 |
 
 #### リクエスト
 
@@ -185,13 +236,14 @@ GET /v1.0/project/regions
 
 #### レスポンス
 
-| 名前                | 種類  | 形式     | 説明                          |
-|--------------------|------|---------|------------------------------|
-| regions            | Body | Array   | リージョンリスト                       |
-| regions.regionCode | Body | Enum    | リージョンコード<br/>- `KR1`:韓国(パンギョ)リージョン |
-| regions.isEnabled  | Body | Boolean | リージョンが有効かどうか                   |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| regions | Body | Array | リージョン情報 |
+| regions.regionCode | Body | Enum | リージョンコード<br/>- KR1: `韓国(パンギョ)`<br/>- KR2: `韓国(ピョンチョン)` |
+| regions.isEnabled | Body | Boolean | リージョンが有効かどうか |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -203,59 +255,16 @@ GET /v1.0/project/regions
     "regions": [
         {
             "regionCode": "KR1",
-            "isEnabled": true
+            "isEnabled": false
         }
     ]
 }
 ```
+
+</p>
 </details>
 
-### プロジェクトメンバーリストを表示
-
-```http
-GET /v1.0/project/members
-```
-
-#### 必要権限
-
-| 権限名                         | 説明        |
-|------------------------------|------------|
-| RDSforPostgreSQL:Project.Get | プロジェクト情報照会 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-#### レスポンス
-
-| 名前                  | 種類  | 形式    | 説明             |
-|----------------------|------|--------|-----------------|
-| members              | Body | Array  | プロジェクトメンバーリスト     |
-| members.memberId     | Body | UUID   | プロジェクトメンバーの識別子   |
-| members.memberName   | Body | String | プロジェクトメンバーの名前    |
-| members.emailAddress | Body | String | プロジェクトメンバーのメールアドレス |
-| members.phoneNumber  | Body | String | プロジェクトメンバーの電話番号  |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "members": [
-        {
-            "memberId": "1b1d3627-507a-49ea-8cb7-c86dfa9caa58",
-            "memberName": "ホン・ギルドン",
-            "emailAddress": "gildong.hong@nhn.com",
-            "phoneNumber": "+821012345678"
-        }
-    ]
-}
-```
-</details>
+---
 
 ## ネットワーク
 
@@ -267,8 +276,8 @@ GET /v1.0/network/subnets
 
 #### 必要権限
 
-| 権限名                          | 説明       |
-|-------------------------------|-----------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:Network.List | サブネットリストを表示 |
 
 #### リクエスト
@@ -277,17 +286,17 @@ GET /v1.0/network/subnets
 
 #### レスポンス
 
-| 名前                      | 種類  | 形式     | 説明              |
-|--------------------------|------|---------|------------------|
-| subnets                  | Body | Array   | サブネットリスト          |
-| subnets.subnetId         | Body | UUID    | サブネットの識別子        |
-| subnets.subnetName       | Body | String  | サブネットを識別できる名前 |
-| subnets.subnetCidr       | Body | String  | サブネットのCIDR        |
-| subnets.usingGateway     | Body | Boolean | ゲートウェイ使用有無      |
-| subnets.availableIpCount | Body | Number  | 使用可能なIP数      |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| subnets | Body | Array | サブネット情報 |
+| subnets.subnetId | Body | UUID | サブネットの識別子 |
+| subnets.subnetName | Body | String | サブネットを識別できる名前 |
+| subnets.subnetCidr | Body | String | サブネットのCIDR |
+| subnets.usingGateway | Body | Boolean | ゲートウェイ使用有無 |
+| subnets.availableIpCount | Body | Number | 使用可能なIP数 |
 
-<details>
-<summary>例</summary>
+<details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -298,16 +307,20 @@ GET /v1.0/network/subnets
     },
     "subnets": [
         {
-            "subnetId": "1b2a9b23-0725-4b92-8c78-35db66b8ad9f",
-            "subnetName": "Default Network",
+            "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+            "subnetName": "subnetName-example",
             "subnetCidr": "192.168.0.0/24",
-            "usingGateway": true,
-            "availableIpCount": 240
+            "usingGateway": false,
+            "availableIpCount": 1
         }
     ]
 }
 ```
+
+</p>
 </details>
+
+---
 
 ## ストレージ
 
@@ -319,8 +332,8 @@ GET /v1.0/storage-types
 
 #### 必要権限
 
-| 権限名                          | 説明           |
-|-------------------------------|---------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:Storage.List | ストレージタイプリストを表示 |
 
 #### リクエスト
@@ -329,11 +342,12 @@ GET /v1.0/storage-types
 
 #### レスポンス
 
-| 名前          | 種類  | 形式   | 説明        |
-|--------------|------|-------|------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | storageTypes | Body | Array | ストレージタイプリスト |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -348,9 +362,30 @@ GET /v1.0/storage-types
     ]
 }
 ```
+
+</p>
 </details>
 
+---
+
 ## 作業情報
+
+### 作業状態
+
+| 状態名 | 説明 |
+|--------------------|----------------------|
+| `PREPARING` | 作業が準備中の場合 |
+| `READY` | 作業が準備完了した場合 |
+| `RUNNING` | 作業が進行中の場合 |
+| `COMPLETED` | 作業が完了した場合 |
+| `REGISTERED` | 作業が登録された場合 |
+| `WAIT_TO_REGISTER` | 作業が登録待機中の場合 |
+| `INTERRUPTED` | 作業進行中に割り込みが発生した場合 |
+| `CANCELED` | 作業がキャンセルされた場合 |
+| `FAILED` | 作業が失敗した場合 |
+| `ERROR` | 作業進行中にエラーが発生した場合 |
+| `DELETED` | 作業が削除された場合 |
+| `FAIL_TO_READY` | 作業準備に失敗した場合 |
 
 ### 作業情報の詳細を表示
 
@@ -360,31 +395,32 @@ GET /v1.0/jobs/{jobId}
 
 #### 必要権限
 
-| 権限名                     | 説明         |
-|--------------------------|-------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:Job.Get | 作業情報の詳細を表示 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前   | 種類 | 形式  | 必須 | 説明     |
-|-------|-----|------|----|---------|
-| jobId | URL | UUID | O  | 作業の識別子 |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| jobId | URL | UUID | O |  |
 
 #### レスポンス
 
-| 名前                            | 種類  | 形式      | 説明                                                                                                                                                                                                                                                                                                                                                                                                             |
-|--------------------------------|------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| jobId                          | Body | UUID     | 作業の識別子                                                                                                                                                                                                                                                                                                                                                                                                        |
-| jobStatus                      | Body | Enum     | 作業の現在状態<br/>- `PREPARING`:作業が準備中の場合<br/>- `READY`:作業が準備完了した場合<br/>- `RUNNING`:作業が進行中の場合<br/>- `COMPLETED`:作業が完了した場合<br/>- `REGISTERED`:作業が登録された場合<br/>- `WAIT_TO_REGISTER`:作業が登録待機中の場合<br/>- `INTERRUPTED`:作業進行中に割り込みが発生した場合<br/>- `CANCELED`:作業がキャンセルされた場合<br/>- `FAILED`:作業が失敗した場合<br/>- `ERROR`:作業進行中にエラーが発生した場合<br/>- `DELETED`:作業が削除された場合<br/>- `FAIL_TO_READY`:作業準備に失敗した場合 |
-| resourceRelations              | Body | Array    | 関連リソースリスト                                                                                                                                                                                                                                                                                                                                                                                                      |
-| resourceRelations.resourceType | Body | Enum     | 関連リソースタイプ<br/>- `DB_INSTANCE`: DBインスタンス<br/>- `DB_INSTANCE_GROUP`: DBインスタンスグループ<br/>- `DB_SECURITY_GROUP`: DBセキュリティグループ<br/>- `PARAMETER_GROUP`:パラメータグループ<br/>- `BACKUP`:バックアップ<br/>- `TENANT`:テナント                                                                                                                                                                                                                       |
-| resourceRelations.resourceId   | Body | UUID     | 関連リソースの識別子                                                                                                                                                                                                                                                                                                                                                                                                    |
-| createdYmdt                    | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                                                                                                                                                                                                                                               |
-| updatedYmdt                    | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                                                                                                                                                                                                                                               |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 作業の識別子 |
+| jobStatus | Body | Enum | 作業の現在状態<br/>- DELETED<br/>- CANNOT_PROGRESS<br/>- FAILED<br/>- ERROR<br/>- CANCELED<br/>- INTERRUPTED<br/>- COMPLETED<br/>- COMPLETED_WITH_ERROR<br/>- RUNNING<br/>- PREPARING<br/>- READY<br/>- CREATED<br/>- FAIL_TO_READY<br/>- REGISTERED<br/>- FAIL_TO_REGISTER<br/>- WAIT_TO_REGISTER |
+| resourceRelations | Body | Array | 関連リソースリスト |
+| resourceRelations.resourceType | Body | String | 関連リソースタイプ |
+| resourceRelations.resourceId | Body | String | 関連リソースの識別子 |
+| createdYmdt | Body | DateTime | 作成日時 |
+| updatedYmdt | Body | DateTime | 修正日時 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -393,20 +429,23 @@ GET /v1.0/jobs/{jobId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c",
-    "jobStatus": "RUNNING",
+    "jobId": "550e8400-e29b-41d4-a716-446655440000",
+    "jobStatus": "DELETED",
     "resourceRelations": [
         {
-            "resourceType": "DB_INSTANCE",
-            "resourceId": "56b39dcf-65eb-47ec-9d4f-09f160ba2266"
+            "resourceType": "resourceType-example",
+            "resourceId": "resourceId-example"
         }
     ],
-    "createdYmdt": "2023-02-22T20:47:12+09:00",
-    "updatedYmdt": "2023-02-22T20:49:46+09:00"
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
+
+</p>
 </details>
 
+---
 ## DBインスタンスグループ
 
 ### DBインスタンスグループリストを表示
@@ -417,8 +456,8 @@ GET /v1.0/db-instance-groups
 
 #### 必要権限
 
-| 権限名                                  | 説明              |
-|---------------------------------------|------------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:DbInstanceGroup.List | DBインスタンスグループリストを表示 |
 
 #### リクエスト
@@ -427,16 +466,17 @@ GET /v1.0/db-instance-groups
 
 #### レスポンス
 
-| 名前                                    | 種類  | 形式      | 説明                                                         |
-|----------------------------------------|------|----------|-------------------------------------------------------------|
-| dbInstanceGroups                       | Body | Array    | DBインスタンスグループリスト                                              |
-| dbInstanceGroups.dbInstanceGroupId     | Body | UUID     | DBインスタンスグループの識別子                                            |
-| dbInstanceGroups.dbInstanceGroupStatus | Body | Enum     | DBインスタンスグループの現在状態<br/>- `CREATED`:作成済み<br/>- `DELETED`:削除済み |
-| dbInstanceGroups.replicationType       | Body | Enum     | DBインスタンスグループのレプリケーションタイプ<br/>- `STANDALONE`:単一                    |
-| dbInstanceGroups.createdYmdt           | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                           |
-| dbInstanceGroups.updatedYmdt           | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                           |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceGroups | Body | Array | DBインスタンスグループ情報 |
+| dbInstanceGroups.dbInstanceGroupId | Body | UUID | DBインスタンスグループの識別子 |
+| dbInstanceGroups.dbInstanceGroupStatus | Body | Enum | DBインスタンスグループの現在状態<br/>- CREATED: `作成済み`<br/>- DELETED: `削除済み` |
+| dbInstanceGroups.replicationType | Body | Enum | DBインスタンスグループのレプリケーションタイプ<br/>- STANDALONE: `高可用性を使用しない`<br/>- HIGH_AVAILABILITY: `高可用性を使用する` |
+| dbInstanceGroups.createdYmdt | Body | DateTime | 作成日時 |
+| dbInstanceGroups.updatedYmdt | Body | DateTime | 修正日時 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -447,17 +487,20 @@ GET /v1.0/db-instance-groups
     },
     "dbInstanceGroups": [
         {
-            "dbInstanceGroupId": "05de0746-89fd-49c8-94f9-9c5b1df97009",
+            "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
             "dbInstanceGroupStatus": "CREATED",
             "replicationType": "STANDALONE",
-            "createdYmdt": "2023-02-13T17:35:20+09:00",
-            "updatedYmdt": "2023-02-13T17:35:20+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
+
+</p>
 </details>
 
+---
 
 ### DBインスタンスグループ詳細を表示
 
@@ -467,33 +510,34 @@ GET /v1.0/db-instance-groups/{dbInstanceGroupId}
 
 #### 必要権限
 
-| 権限名                                 | 説明              |
-|--------------------------------------|------------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:DbInstanceGroup.Get | DBインスタンスグループ詳細を表示 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前               | 種類 | 形式  | 必須 | 説明             |
-|-------------------|-----|------|----|-----------------|
-| dbInstanceGroupId | URL | UUID | O  | DBインスタンスグループの識別子 |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | O |  |
 
 #### レスポンス
 
-| 名前                          | 種類  | 形式      | 説明                                                                                                                                   |
-|------------------------------|------|----------|---------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceGroupId            | Body | UUID     | DBインスタンスグループの識別子                                                                                                                      |
-| dbInstanceGroupStatus        | Body | Enum     | DBインスタンスグループの現在状態<br/>- `CREATED`:作成済み<br/>- `DELETED`:削除済み                                                                          |
-| replicationType              | Body | Enum     | DBインスタンスグループのレプリケーションタイプ<br/>- `STANDALONE`:単一<br/>- `HIGH_AVAILABILITY`:高可用性                                                             |
-| dbInstances                  | Body | Array    | DBインスタンスグループに属するDBインスタンスリスト                                                                                                            |
-| dbInstances.dbInstanceId     | Body | UUID     | DBインスタンスの識別子                                                                                                                         |
-| dbInstances.dbInstanceType   | Body | Enum     | DBインスタンスのロールタイプ<br/>- `MASTER`:マスター<br/>- `FAILED_MASTER`:フェイルオーバーされたマスター<br/>- `CANDIDATE_MASTER`:予備マスター<br/>- `READ_ONLY_SLAVE`:リードレプリカ |
-| dbInstances.dbInstanceStatus | Body | Enum     | DBインスタンスの現在状態                                                                                                                       |
-| createdYmdt                  | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-| updatedYmdt                  | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceGroupId | Body | UUID | DBインスタンスグループの識別子 |
+| dbInstanceGroupStatus | Body | Enum | DBインスタンスグループの現在状態<br/>- CREATED: `作成済み`<br/>- DELETED: `削除済み` |
+| replicationType | Body | Enum | DBインスタンスグループのレプリケーションタイプ<br/>- STANDALONE: `高可用性を使用しない`<br/>- HIGH_AVAILABILITY: `高可用性を使用する` |
+| dbInstances | Body | Array | DBインスタンスグループに属するDBインスタンスリスト |
+| dbInstances.dbInstanceId | Body | UUID | DBインスタンスの識別子 |
+| dbInstances.dbInstanceType | Body | Enum | DBインスタンスのロールタイプ<br/>- MASTER: `マスター`<br/>- FAILED_MASTER: `フェイルオーバーされたマスター`<br/>- CANDIDATE_MASTER: `予備マスター`<br/>- READ_ONLY_SLAVE: `リードレプリカ` |
+| dbInstances.dbInstanceStatus | Body | Enum | DBインスタンスの現在状態<br/>- BEFORE_CREATE: `作成前(グレー)`<br/>- AVAILABLE: `使用可能(緑)`<br/>- STORAGE_FULL: `容量不足(赤)`<br/>- FAIL_TO_CREATE: `作成失敗(赤)`<br/>- FAIL_TO_CONNECT: `接続失敗(赤)`<br/>- REPLICATION_STOP: `複製中断(赤)`<br/>- REPLICATION_DELAY: `複製遅延(黄)`<br/>- FAILOVER: `フェイルオーバー完了(赤)`<br/>- SHUTDOWN: `停止済み(グレー)`<br/>- DELETED: `削除済み(グレー)` |
+| createdYmdt | Body | DateTime | 作成日時 |
+| updatedYmdt | Body | DateTime | 修正日時 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -502,25 +546,27 @@ GET /v1.0/db-instance-groups/{dbInstanceGroupId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "dbInstanceGroupId": "36617a8e-0df8-4b16-b6ea-6306019e95da",
+    "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
     "dbInstanceGroupStatus": "CREATED",
     "replicationType": "STANDALONE",
     "dbInstances": [
         {
-            "dbInstanceId": "6d2db0ef-fe9b-4ed4-97b1-d97fcb4cf1b8",
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
             "dbInstanceType": "MASTER",
-            "dbInstanceStatus": "AVAILABLE"
+            "dbInstanceStatus": "BEFORE_CREATE"
         }
     ],
-    "createdYmdt": "2023-03-03T17:38:14+09:00",
-    "updatedYmdt": "2023-03-03T17:38:14+09:00"
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
+
+</p>
 </details>
 
-## DBインスタンスグループ > 拡張機能管理
+---
 
-### 拡張機能リスト表示
+### 拡張機能リスト照会
 
 ```http
 GET /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions
@@ -528,36 +574,37 @@ GET /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions
 
 #### 必要権限
 
-| 権限名                                          | 説明     |
-|------------------------------------------------|----------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:DbInstanceGroupExtension.List | 拡張機能リスト照会 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前              | 種類 | 形式 | 必須 | 説明            |
-|-------------------|-----|------|----|-----------------|
-| dbInstanceGroupId | URL | UUID | O  | DBインスタンスグループの識別子 |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | O | DBインスタンスグループID |
 
 #### レスポンス
 
-| 名前                                                | 種類 | 形式    | 説明                                                                                                                                                                                            |
-|-----------------------------------------------------|------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| extensions                                          | Body | Array   | 拡張機能リスト                                                                                                                                                                                         |
-| extensions.extensionId                              | Body | UUID    | 拡張機能の識別子                                                                                                                                                                                       |
-| extensions.extensionName                            | Body | String  | 拡張機能名                                                                                                                                                                                         |
-| extensions.extensionStatus                          | Body | ENUM    | 拡張機能の状態<br/>- `AVAILABLE`:使用可能<br/>- `NEED_TO_APPLY`:適用必要<br/>- `APPLYING`:適用中                                                                                                             |
-| extensions.databases                                | Body | Array   | 拡張機能がインストールされたデータベース情報                                                                                                                                                                             |
-| extensions.databases.dbInstanceGroupExtensionId     | Body | UUID    | DBインスタンスグループ内の拡張機能の識別子                                                                                                                                                                          |
-| extensions.databases.dbInstanceGroupExtensionStatus | Body | ENUM    | DBインスタンスグループ内の拡張機能の状態<br/>- `CREATED`:作成済み<br/>- `INSTALLED`:インストール済み<br/>- `INSTALLING`:インストール中<br/>- `INSTALL_ERROR`:インストールエラー<br/>- `DELETED`:削除済み<br/>- `DELETING`:削除中<br/>- `DELETE_ERROR`:削除エラー |
-| extensions.databases.databaseId                     | Body | UUID    | データベースの識別子                                                                                                                                                                                   |
-| extensions.databases.databaseName                   | Body | String  | データベース名                                                                                                                                                                                     |
-| extensions.databases.reservedAction                 | Body | ENUM    | 予約タスク<br/>- `NONE`:なし<br/>- `INSTALL`:インストール予約(適用必要)<br/>- `INSTALL_WITH_CASCADE`:強制インストール予約(適用必要)<br/>- `DELETE`:削除予約(適用必要)<br/>- `DELETE_WITH_CASCADE`:強制削除予約(適用必要)                |
-| extensions.databases.errorReason                    | Body | String  | エラー原因                                                                                                                                                                                         |
-| isNeedToApply                                       | Body | Boolean | 変更事項の適用が必要かどうか                                                                                                                                                                                |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| extensions | Body | Array | 拡張機能情報 |
+| extensions.extensionId | Body | UUID | 拡張機能の識別子 |
+| extensions.extensionName | Body | String | 拡張機能名 |
+| extensions.extensionStatus | Body | Enum | 拡張機能の状態<br/>- AVAILABLE: `使用可能`<br/>- NEED_TO_APPLY: `適用必要`<br/>- APPLYING: `適用中` |
+| extensions.databases | Body | Array | データベース情報 |
+| extensions.databases.dbInstanceGroupExtensionId | Body | UUID | DBインスタンスグループ内の拡張機能の識別子 |
+| extensions.databases.databaseId | Body | UUID | データベースの識別子 |
+| extensions.databases.databaseName | Body | String | データベース名 |
+| extensions.databases.dbInstanceGroupExtensionStatus | Body | Enum | データベースへの拡張機能インストール状態<br/>- CREATED: `作成済み`<br/>- INSTALLED: `インストール済み`<br/>- INSTALLING: `インストール中`<br/>- INSTALL_ERROR: `インストールエラー`<br/>- DELETED: `削除済み`<br/>- DELETING: `削除中`<br/>- DELETE_ERROR: `削除エラー` |
+| extensions.databases.reservedAction | Body | Enum | 予約タスク<br/>- NONE: `なし`<br/>- INSTALL: `インストール予約(適用必要)`<br/>- INSTALL_WITH_CASCADE: `強制インストール予約(適用必要)`<br/>- DELETE: `削除予約(適用必要)`<br/>- DELETE_WITH_CASCADE: `強制削除予約(適用必要)` |
+| extensions.databases.errorReason | Body | String | エラー原因 |
+| isNeedToApply | Body | Boolean | 変更事項の適用が必要かどうか |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -568,108 +615,29 @@ GET /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions
     },
     "extensions": [
         {
-            "extensionId": "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4",
-            "extensionName": "address_standardizer",
+            "extensionId": "550e8400-e29b-41d4-a716-446655440000",
+            "extensionName": "extensionName-example",
             "extensionStatus": "AVAILABLE",
             "databases": [
                 {
-                    "dbInstanceGroupExtensionId": "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4",
-                    "databaseId": "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4",
-                    "databaseName": "database-1",
-                    "dbInstanceGroupExtensionStatus": "INSTALLED",
+                    "dbInstanceGroupExtensionId": "550e8400-e29b-41d4-a716-446655440000",
+                    "databaseId": "550e8400-e29b-41d4-a716-446655440000",
+                    "databaseName": "databaseName-example",
+                    "dbInstanceGroupExtensionStatus": "CREATED",
                     "reservedAction": "NONE",
-                    "errorReason": null
+                    "errorReason": "errorReason-example"
                 }
             ]
         }
     ],
-    "isNeedToApply": true
+    "isNeedToApply": false
 }
 ```
+
+</p>
 </details>
 
-
-### 拡張機能のインストール
-
-```http
-POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{extensionId}
-```
-
-#### 必要権限
-
-| 権限名                                             | 説明  |
-|---------------------------------------------------|-------|
-| RDSforPostgreSQL:DbInstanceGroupExtension.Install | 拡張機能のインストール |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前              | 種類 | 形式    | 必須 | 説明              |
-|-------------------|------|---------|----|-------------------|
-| dbInstanceGroupId | URL  | UUID    | O  | DBインスタンスグループの識別子 |
-| extensionId       | URL  | UUID    | O  | 拡張機能の識別子         |
-| databaseId        | Body | UUID    | O  | インストール対象データベースの識別子 |
-| schemaName        | Body | String  | O  | インストール対象スキーマ名    |
-| withCascade       | Body | Boolean | X  | 依存情報を強制的にインストールするかどうか   |
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
-
-<details><summary>例</summary>
-
-```json
-{
-  "header": {
-    "resultCode": 0,
-    "resultMessage": "SUCCESS",
-    "isSuccessful": true
-  }
-}
-```
-</details>
-
-
-### 拡張機能の削除(キャンセル)
-
-```http
-DELETE /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{dbInstanceGroupExtensionId}
-```
-
-#### 必要権限
-
-| 権限名                                            | 説明      |
-|--------------------------------------------------|-----------|
-| RDSforPostgreSQL:DbInstanceGroupExtension.Delete | 拡張機能の削除(キャンセル) |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前                       | 種類  | 形式    | 必須 | 説明                 |
-|----------------------------|-------|---------|----|----------------------|
-| dbInstanceGroupId          | URL   | UUID    | O  | DBインスタンスグループの識別子    |
-| dbInstanceGroupExtensionId | URL   | UUID    | O  | DBインスタンスグループ内の拡張機能の識別子 |
-| withCascade                | Query | Boolean | O  | 依存情報を強制的に削除するかどうか      |
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
-
-<details><summary>例</summary>
-
-```json
-{
-  "header": {
-    "resultCode": 0,
-    "resultMessage": "SUCCESS",
-    "isSuccessful": true
-  }
-}
-```
-</details>
-
+---
 
 ### 拡張機能変更事項適用
 
@@ -679,38 +647,42 @@ POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/apply
 
 #### 必要権限
 
-| 権限名                                           | 説明       |
-|-------------------------------------------------|------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:DbInstanceGroupExtension.Apply | 拡張機能変更事項適用 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前                       | 種類  | 形式    | 必須 | 説明                 |
-|----------------------------|-------|---------|----|----------------------|
-| dbInstanceGroupId          | URL   | UUID    | O  | DBインスタンスグループの識別子    |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | O | DBインスタンスグループID |
 
 #### レスポンス
 
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | リクエストした作業の識別子 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
-  "header": {
-    "resultCode": 0,
-    "resultMessage": "SUCCESS",
-    "isSuccessful": true
-  },
-  "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
+---
 
 ### 拡張機能の同期
 
@@ -720,93 +692,158 @@ POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/sync
 
 #### 必要権限
 
-| 権限名                                          | 説明   |
-|------------------------------------------------|--------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:DbInstanceGroupExtension.Sync | 拡張機能の同期 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前                       | 種類  | 形式    | 必須 | 説明                 |
-|----------------------------|-------|---------|----|----------------------|
-| dbInstanceGroupId          | URL   | UUID    | O  | DBインスタンスグループの識別子    |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | O | DBインスタンスグループID |
 
 #### レスポンス
 
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | リクエストした作業の識別子 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
-  "header": {
-    "resultCode": 0,
-    "resultMessage": "SUCCESS",
-    "isSuccessful": true
-  },
-  "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
+---
 
+### 拡張機能の削除(キャンセル)
+
+```http
+DELETE /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{dbInstanceGroupExtensionId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceGroupExtension.Delete | 拡張機能の削除(キャンセル) |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | O | DBインスタンスグループID |
+| dbInstanceGroupExtensionId | URL | UUID | O | DBインスタンスグループ内の拡張機能の識別子 |
+| withCascade | Query | Boolean | O | 強制削除するかどうか |
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
+
+### 拡張機能のインストール
+
+```http
+POST /v1.0/db-instance-groups/{dbInstanceGroupId}/extensions/{extensionId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceGroupExtension.Install | 拡張機能のインストール |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | O | DBインスタンスグループID |
+| extensionId | URL | UUID | O | 拡張機能の識別子 |
+| databaseId | Body | UUID | O | データベースの識別子 |
+| schemaName | Body | String | O | スキーマ名 |
+| withCascade | Body | Boolean | X | 関連情報を自動的にインストールするかどうか<br/>- デフォルト値: `false` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "databaseId": "550e8400-e29b-41d4-a716-446655440000",
+    "schemaName": "schemaName-example",
+    "withCascade": false
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
 ## DBインスタンス
 
 ### DBインスタンスの状態
 
-| 状態                 | 説明                         |
-|---------------------|-----------------------------|
-| `AVAILABLE`         | DBインスタンスが使用可能な場合         |
-| `BEFORE_CREATE`     | DBインスタンス作成前の場合           |
-| `STORAGE_FULL`      | DBインスタンスの容量が不足している場合        |
-| `FAIL_TO_CREATE`    | DBインスタンス作成に失敗した場合         |
-| `FAIL_TO_CONNECT`   | DBインスタンス接続に失敗した場合         |
-| `REPLICATION_STOP`  | DBインスタンスの複製が中断された場合        |
-| `REPLICATION_DELAY` | DBインスタンスの複製が遅延している場合      |
-| `FAILOVER`          | 高可用性DBインスタンスのフェイルオーバーが完了した場合 |
-| `SHUTDOWN`          | DBインスタンスが中止された場合            |
-| `DELETED`           | DBインスタンスが削除された場合            |
+| 状態                  | 説明                           |
+|---------------------|------------------------------|
+| `AVAILABLE`         | DBインスタンスが使用可能な場合           |
+| `BEFORE_CREATE`     | DBインスタンス作成前の場合            |
+| `STORAGE_FULL`      | DBインスタンスの容量が不足している場合          |
+| `FAIL_TO_CREATE`    | DBインスタンス作成に失敗した場合           |
+| `FAIL_TO_CONNECT`   | DBインスタンス接続に失敗した場合           |
+| `REPLICATION_STOP`  | DBインスタンスの複製が中断された場合          |
+| `FAILOVER`          | 高可用性DBインスタンスのフェイルオーバーが完了した場合      |
+| `SHUTDOWN`          | DBインスタンスが中止された場合              |
+| `DELETED`           | DBインスタンスが削除された場合              |
 
 ### DBインスタンスの進行状態
 
-| 状態                             | 説明            |
-|---------------------------------|----------------|
-| `APPLYING_DB_INSTANCE_HBA_RULE` | アクセス制御ルール適用中 |
-| `APPLYING_PARAMETER_GROUP`      | パラメータグループ適用中  |
-| `APPLYING_EXTENSION`            | 拡張機能の適用中      |
-| `BACKING_UP`                    | バックアップ中          |
-| `CANCELING`                     | キャンセル中          |
-| `CREATING`                      | 作成中          |
-| `CREATING_DATABASE`             | データベース作成中	   |
-| `CREATING_USER`                 | ユーザー作成中	      |
-| `DELETING`                      | 削除中          |
-| `DELETING_DATABASE`             | データベース削除中   |
-| `DELETING_USER`                 | ユーザー削除中      |
-| `EXPORTING_BACKUP`              | バックアップをエクスポート中    |
-| `FAILING_OVER`                  | フェイルオーバー中       |
-| `MIGRATING`                     | マイグレーション中      |
-| `MODIFYING`                     | 修正中          |
-| `OCCUPIED`                      | 占有中           |
-| `PREPARING`                     | 準備中          |
-| `PROMOTING`                     | 昇格中          |
-| `PROMOTING_FORCIBLY`            | 強制昇格中       |
-| `REBUILDING`                    | 再構築中         |
-| `REPAIRING`                     | 復旧中          |
-| `REPLICATING`                   | 複製中          |
-| `RESTARTING`                    | 再起動中         |
-| `RESTARTING_FORCIBLY`           | 強制再起動中      |
-| `RESTORING`                     | 復元中          |
-| `STARTING`                      | 起動中          |
-| `STOPPING`                      | 停止中          |
-| `SYNCING_DATABASE`              | データベース同期中  |
-| `SYNCING_USER`                  | ユーザー同期中	     |
-| `SYNCING_EXTENSION`             | 拡張機能の同期中	      |
-| `UPDATING_USER`                 | ユーザー修正中	      |
-| `UPDATING_DATABASE`             | データベース修正中	   |
-| `WAIT_MANUAL_CONTROL`           | 手動フェイルオーバー待機中	 |
+| 状態                         | 説明           |
+|----------------------------|--------------|
+| `APPLYING_PARAMETER_GROUP` | パラメータグループ適用中 |
+| `BACKING_UP`               | バックアップ中         |
+| `CANCELING`                | キャンセル中         |
+| `CREATING`                 | 作成中         |
+| `CREATING_SCHEMA`          | スキーマ作成中  |
+| `CREATING_USER`            | ユーザー作成中     |
+| `DELETING`                 | 削除中         |
+| `DELETING_SCHEMA`          | スキーマ削除中  |
+| `DELETING_USER`            | ユーザー削除中     |
+| `EXPORTING_BACKUP`         | バックアップをエクスポート中   |
+| `FAILING_OVER`             | フェイルオーバー中      |
+| `MIGRATING`                | マイグレーション中         |
+| `MODIFYING`                | 修正中         |
+| `PREPARING`                | 準備中         |
+| `PROMOTING`                | 昇格中         |
+| `REBUILDING`               | 再構築中        |
+| `REPAIRING`                | 復旧中         |
+| `REPLICATING`              | 複製中         |
+| `RESTARTING`               | 再起動中         |
+| `RESTARTING_FORCIBLY`      | 強制再起動中     |
+| `RESTORING`                | 復元中         |
+| `STARTING`                 | 起動中         |
+| `STOPPING`                 | 停止中         |
+| `SYNCING_SCHEMA`           | スキーマ同期中 |
+| `SYNCING_USER`             | ユーザー同期中    |
+| `UPDATING_USER`            | ユーザー修正中     |
 
 ### DBインスタンスリストを表示
 
@@ -816,8 +853,8 @@ GET /v1.0/db-instances
 
 #### 必要権限
 
-| 権限名                             | 説明           |
-|----------------------------------|---------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:DbInstance.List | DBインスタンスリストを表示 |
 
 #### リクエスト
@@ -826,22 +863,23 @@ GET /v1.0/db-instances
 
 #### レスポンス
 
-| 名前                           | 種類  | 形式      | 説明                                                                                                                                   |
-|-------------------------------|------|----------|---------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstances                   | Body | Array    | DBインスタンスリスト                                                                                                                           |
-| dbInstances.dbInstanceId      | Body | UUID     | DBインスタンスの識別子                                                                                                                         |
-| dbInstances.dbInstanceGroupId | Body | UUID     | DBインスタンスグループの識別子                                                                                                                      |
-| dbInstances.dbInstanceName    | Body | String   | DBインスタンスを識別できる名前                                                                                                                 |
-| dbInstances.description       | Body | String   | DBインスタンスの追加情報                                                                                                                    |
-| dbInstances.dbVersion         | Body | Enum     | DBバージョン情報                                                                                                                             |
-| dbInstances.dbPort            | Body | Number   | DBポート                                                                                                                                |
-| dbInstances.dbInstanceType    | Body | Enum     | DBインスタンスのロールタイプ<br/>- `MASTER`:マスター<br/>- `FAILED_MASTER`:フェイルオーバーされたマスター<br/>- `CANDIDATE_MASTER`:予備マスター<br/>- `READ_ONLY_SLAVE`:リードレプリカ |
-| dbInstances.dbInstanceStatus  | Body | Enum     | DBインスタンスの現在状態                                                                                                                       |
-| dbInstances.progressStatus    | Body | Enum     | DBインスタンスの現在進行状態                                                                                                                    |
-| dbInstances.createdYmdt       | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-| dbInstances.updatedYmdt       | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| dbInstances | Body | Array | DBインスタンスリスト |
+| dbInstances.dbInstanceId | Body | UUID | DBインスタンスの識別子 |
+| dbInstances.dbInstanceGroupId | Body | UUID | DBインスタンスグループの識別子 |
+| dbInstances.dbInstanceName | Body | String | DBインスタンスを識別できる名前 |
+| dbInstances.description | Body | String | DBインスタンスの追加情報 |
+| dbInstances.dbVersion | Body | Enum | DBバージョン情報 |
+| dbInstances.dbPort | Body | Number | DBポート |
+| dbInstances.dbInstanceType | Body | Enum | DBインスタンスのロールタイプ<br/>- MASTER: `マスター`<br/>- FAILED_MASTER: `フェイルオーバーされたマスター`<br/>- CANDIDATE_MASTER: `予備マスター`<br/>- READ_ONLY_SLAVE: `リードレプリカ` |
+| dbInstances.dbInstanceStatus | Body | Enum | DBインスタンスの現在状態<br/>- BEFORE_CREATE: `作成前(グレー)`<br/>- AVAILABLE: `使用可能(グリーン)`<br/>- STORAGE_FULL: `容量不足(レッド)`<br/>- FAIL_TO_CREATE: `作成失敗(レッド)`<br/>- FAIL_TO_CONNECT: `接続失敗(レッド)`<br/>- REPLICATION_STOP: `複製中断(レッド)`<br/>- REPLICATION_DELAY: `複製遅延(イエロー)`<br/>- FAILOVER: `フェイルオーバー完了(レッド)`<br/>- SHUTDOWN: `停止済み(グレー)`<br/>- DELETED: `削除済み(グレー)` |
+| dbInstances.progressStatus | Body | String | DBインスタンスの現在進行状態 |
+| dbInstances.createdYmdt | Body | DateTime | 作成日時 |
+| dbInstances.updatedYmdt | Body | DateTime | 修正日時 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -852,98 +890,26 @@ GET /v1.0/db-instances
     },
     "dbInstances": [
         {
-            "dbInstanceId": "d067593b-1acc-4ccc-9e8a-cc72d6d79ec3",
-            "dbInstanceGroupId": "51c7d080-ff36-4025-84b1-9d9d0b4fe9e0",
-            "dbInstanceName": "db-instance",
-            "description": null,
-            "dbVersion": "POSTGRESQL_V17_6",
-            "dbPort": 15432,
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbInstanceName": "dbInstanceName-example",
+            "description": "description-example",
+            "dbVersion": "POSTGRESQL_V14_17",
+            "dbPort": 1,
             "dbInstanceType": "MASTER",
-            "dbInstanceStatus": "AVAILABLE",
-            "progressStatus": "NONE",
-            "createdYmdt": "2023-01-23T12:03:13+09:00",
-            "updatedYmdt": "2023-02-02T17:20:17+09:00"
+            "dbInstanceStatus": "BEFORE_CREATE",
+            "progressStatus": "progressStatus-example",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
+
+</p>
 </details>
 
-
-### DBインスタンス詳細を表示
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}
-```
-
-#### 必要権限
-
-| 権限名                            | 説明           |
-|---------------------------------|---------------|
-| RDSforPostgreSQL:DbInstance.Get | DBインスタンス詳細を表示 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前          | 種類 | 形式  | 必須 | 説明          |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前                       | 種類  | 形式      | 説明                                                                                                                                   |
-|---------------------------|------|----------|---------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId              | Body | UUID     | DBインスタンスの識別子                                                                                                                         |
-| dbInstanceGroupId         | Body | UUID     | DBインスタンスグループの識別子                                                                                                                      |
-| dbInstanceName            | Body | String   | DBインスタンスを識別できる名前                                                                                                                 |
-| description               | Body | String   | DBインスタンスの追加情報                                                                                                                    |
-| dbVersion                 | Body | Enum     | DBバージョン情報                                                                                                                             |
-| dbPort                    | Body | Number   | DBポート                                                                                                                                |
-| dbInstanceType            | Body | Enum     | DBインスタンスのロールタイプ<br/>- `MASTER`:マスター<br/>- `FAILED_MASTER`:フェイルオーバーされたマスター<br/>- `CANDIDATE_MASTER`:予備マスター<br/>- `READ_ONLY_SLAVE`:リードレプリカ |
-| dbInstanceStatus          | Body | Enum     | DBインスタンスの現在状態                                                                                                                       |
-| progressStatus            | Body | Enum     | DBインスタンスの現在の作業進行状態                                                                                                                 |
-| dbFlavorId                | Body | UUID     | DBインスタンス仕様の識別子                                                                                                                      |
-| parameterGroupId          | Body | UUID     | DBインスタンスに適用されたパラメータグループの識別子                                                                                                            |
-| dbSecurityGroupIds        | Body | Array    | DBインスタンスに適用されたDBセキュリティグループの識別子リスト                                                                                                        |
-| notificationGroupIds      | Body | Array    | DBインスタンスに適用された通知グループの識別子リスト                                                                                                           |
-| useDeletionProtection     | Body | Boolean  | DBインスタンス削除保護の有無                                                                                                                      |
-| needToApplyParameterGroup | Body | Boolean  | 最新パラメータグループの適用可否                                                                                                                   |
-| needMigration             | Body | Boolean  | マイグレーションの要否                                                                                                                          |
-| osVersion                 | Body | String   | OSバージョン                                                                                                                              |
-| createdYmdt               | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-| updatedYmdt               | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceId": "d067593b-1acc-4ccc-9e8a-cc72d6d79ec3",
-    "dbInstanceGroupId": "51c7d080-ff36-4025-84b1-9d9d0b4fe9e0",
-    "dbInstanceName": "db-instance",
-    "description": null,
-    "dbVersion": "POSTGRESQL_V17_6",
-    "dbPort": 15432,
-    "dbInstanceType": "MASTER",
-    "dbInstanceStatus": "AVAILABLE",
-    "progressStatus": "NONE",
-    "dbFlavorId": "e9ed4ef6-78d7-46fa-ace9-32481e97f3b7",
-    "parameterGroupId": "b03e8b13-de27-4d04-a488-ff5689589372",
-    "dbSecurityGroupIds": ["01908c35-d2c9-4852-baf0-17f06ec42c03"],
-    "notificationGroupIds": ["83a62a33-ddbf-4a04-8653-e54463d5b1ac"],
-    "useDeletionProtection": false,
-    "needToApplyParameterGroup": false,
-    "needMigration": false,
-    "createdYmdt": "2022-11-23T12:03:13+09:00",
-    "updatedYmdt": "2022-12-02T17:20:17+09:00"
-}
-```
-</details>
+---
 
 ### DBインスタンスを作成する
 
@@ -953,62 +919,70 @@ POST /v1.0/db-instances
 
 #### 必要権限
 
-| 権限名                               | 説明          |
-|------------------------------------|--------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:DbInstance.Create | DBインスタンスを作成する |
 
 #### リクエスト
 
-| 名前                                      | 種類  | 形式     | 必須 | 説明                                                                                                                                                                                                                  |
-|------------------------------------------|------|---------|----|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceName                           | Body | String  | O  | DBインスタンスを識別できる名前                                                                                                                                                                                                |
-| description                              | Body | String  | X  | DBインスタンスの追加情報                                                                                                                                                                                                   |
-| dbFlavorId                               | Body | UUID    | O  | DBインスタンス仕様の識別子                                                                                                                                                                                                     |
-| dbVersion                                | Body | Enum    | O  | DBバージョン情報                                                                                                                                                                                                            |
-| dbPort                                   | Body | Number  | O  | DBポート<br/>- 最小値:`5432`<br/>- 最大値:`45432`                                                                                                                                                                           |
-| databaseName                             | Body | String  | O  | DBエンジン内で新規作成するデータベース名                                                                                                                                                                                              |
-| dbUserName                               | Body | String  | O  | DBエンジン内で新規作成するユーザーアカウント名                                                                                                                                                                                              |
-| dbPassword                               | Body | String  | O  | DBエンジン内で新規作成するユーザーアカウントのパスワード<br/>- 最小文字数:`4`<br/>- 最大文字数:`16`                                                                                                                                                          |
-| parameterGroupId                         | Body | UUID    | O  | パラメータグループの識別子                                                                                                                                                                                                        |
-| dbSecurityGroupIds                       | Body | Array   | X  | DBセキュリティグループの識別子リスト                                                                                                                                                                                                    |
-| useDeletionProtection                    | Body | Boolean | X  | 削除保護の有無<br/>- デフォルト値:`false`                                                                                                                                                                                          |
-| useDefaultNotification                   | Body | Boolean | X  | 基本通知の使用有無<br/>- デフォルト値:`false`                                                                                                                                                                                       |
-| useHighAvailability                      | Body | Boolean | X  | 高可用性の使用有無                                                                                                                                                                                                           |
-| pingInterval                             | Body | Number  | X  | 高可用性使用時のPing間隔(秒)<br/>- 最小値:`1`<br/>- 最大値:`600`                                                                                                                                                                 |
-| failoverReplWaitingTime                  | Body | Number  | X  | 高可用性使用時のフェイルオーバー待機時間<br/>- 最小値:`-1`<br/>- -1に設定時、複製遅延が解消されるまで待機し続けます。                                                                                                                                         |                                                                                                                                                                                                                      | userGroupIds                             | Body | Array   | X  | 基本通知受信用のユーザーグループの識別子リスト                                                                                                                                                                                            |
-| network                                  | Body | Object  | O  | ネットワーク情報オブジェクト                                                                                                                                                                                                          |
-| network.subnetId                         | Body | UUID    | O  | サブネットの識別子                                                                                                                                                                                                            |
-| network.usePublicAccess                  | Body | Boolean | X  | 外部接続可否<br/>- デフォルト値:`false`                                                                                                                                                                                      |
-| network.availabilityZone                 | Body | Enum    | X  | DBインスタンスを作成するアベイラビリティゾーン<br/>- 例:`kr-pub-a`<br/>- デフォルト値:`任意のアベイラビリティゾーン`                                                                                                                                                     |
-| storage                                  | Body | Object  | O  | ストレージ情報オブジェクト                                                                                                                                                                                                          |    
-| storage.storageType                      | Body | Enum    | O  | データストレージタイプ<br/>- 例:`General SSD`                                                                                                                                                                                  |
-| storage.storageSize                      | Body | Number  | O  | データストレージサイズ(GB)<br/>- 最小値:`20`<br/>- 最大値:`2048`                                                                                                                                                                    |
-| backup                                   | Body | Object  | O  | バックアップ情報オブジェクト                                                                                                                                                                                                            |
-| backup.backupPeriod                      | Body | Number  | O  | バックアップ保管期間(日)<br/>- 最小値:`0`<br/>- 最大値:`730`                                                                                                                                                                          |
-| backup.backupRetryCount                  | Body | Number  | X  | バックアップ再試行回数<br/>- デフォルト値:`0`<br/>- 最小値:`0`<br/>- 最大値:`10`                                                                                                                                                              |
-| backup.backupSchedules                   | Body | Array   | X  | バックアップスケジュールリスト                                                                                                                                                                                                           |
-| backup.backupSchedules.backupWndBgnTime  | Body | String  | O  | バックアップ開始時間<br/>- 例:`00:00:00`                                                                                                                                                                                        |
-| backup.backupSchedules.backupWndDuration | Body | Enum    | O  | バックアップWindows<br/>バックアップ開始時間から設定された期間内に自動バックアップが実行されます。<br/>- `HALF_AN_HOUR`:30分<br/>- `ONE_HOUR`:1時間<br/>- `ONE_HOUR_AND_HALF`:1時間30分<br/>- `TWO_HOURS`:2時間<br/>- `TWO_HOURS_AND_HALF`:2時間30分<br/>- `THREE_HOURS`:3時間 |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceName | Body | String | O | DBインスタンスを識別できる名前 |
+| dbInstanceCandidateName | Body | String | X | DBインスタンスを識別できる予備マスター名 |
+| description | Body | String | X | DBインスタンスの追加情報 |
+| dbFlavorId | Body | UUID | O | DBインスタンス仕様の識別子 |
+| dbVersion | Body | Enum | O | DBバージョン情報 |
+| dbPort | Body | Number | O | DBポート<br/>- 最小値: 5432、最大値: 45432 |
+| databaseName | Body | String | O | データベース名 |
+| dbUserName | Body | String | O | DBユーザーアカウント名 |
+| dbPassword | Body | String | O | DBユーザーアカウントのパスワード |
+| parameterGroupId | Body | UUID | O | パラメータグループの識別子 |
+| dbSecurityGroupIds | Body | Array | X | DBセキュリティグループの識別子リスト |
+| userGroupIds | Body | Array | X | ユーザーグループの識別子リスト |
+| useHighAvailability | Body | Boolean | X | 高可用性の使用有無<br/>- デフォルト値: `false` |
+| useDefaultNotification | Body | Boolean | X | 基本通知の使用有無<br/>- デフォルト値: `false` |
+| useDeletionProtection | Body | Boolean | X | 削除保護の有無<br/>- デフォルト値: `false` |
+| pingInterval | Body | Number | X | Ping間隔(秒)<br/>- 最小値: `1`<br/>- 最大値: `600` |
+| failoverReplWaitingTime | Body | Number | X | フェイルオーバー複製遅延待機時間(秒)<br/>- 最小値: `-1` |
+| network | Body | Object | O | ネットワーク情報オブジェクト |
+| network.subnetId | Body | UUID | O | サブネットの識別子 |
+| network.usePublicAccess | Body | Boolean | X | 外部接続可否<br/>- デフォルト値: `false` |
+| network.availabilityZone | Body | Enum | X | DBインスタンスを作成するアベイラビリティゾーン |
+| storage | Body | Object | O | ストレージ情報オブジェクト |
+| storage.storageType | Body | Enum | O | データストレージタイプ |
+| storage.storageSize | Body | Number | O | データストレージサイズ(GB)<br/>- 最小値: `20` |
+| backup | Body | Object | O | バックアップ情報オブジェクト |
+| backup.backupPeriod | Body | Number | O | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| backup.backupRetryCount | Body | Number | X | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| backup.backupSchedules | Body | Array | O | バックアップスケジュール情報 |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | O | バックアップ開始時間 |
+| backup.backupSchedules.backupWndDuration | Body | Enum | O | バックアップWindow<br/>バックアップ開始時間から設定された期間内に自動バックアップが実行されます。<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbVersion": "POSTGRESQL_V17_6",
-    "dbPort": 15432,
-    "databaseName": "database",
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
+    "dbInstanceName": "dbInstanceName-example",
+    "dbInstanceCandidateName": "dbInstanceCandidateName-example",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbVersion": "POSTGRESQL_V14_17",
+    "dbPort": 1,
+    "databaseName": "databaseName-example",
+    "dbUserName": "dbUserName-example",
+    "dbPassword": "dbPassword-example",
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
     "userGroupIds": [],
+    "useHighAvailability": false,
+    "useDefaultNotification": false,
+    "useDeletionProtection": false,
+    "pingInterval": 1,
+    "failoverReplWaitingTime": 1,
     "network": {
-        "subnetId": "e721a9dd-dad0-4cf0-a53b-dd654ebfc683",
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
         "availabilityZone": "kr-pub-a"
     },
     "storage": {
@@ -1016,26 +990,29 @@ POST /v1.0/db-instances
         "storageSize": 20
     },
     "backup": {
-        "backupPeriod": 1,
+        "backupPeriod": 0,
+        "backupRetryCount": 0,
         "backupSchedules": [
             {
                 "backupWndBgnTime": "00:00:00",
-                "backupWndDuration": "ONE_HOUR_AND_HALF",
-                "backupRetryExpireTime": "01:30:00"
+                "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
     }
 }
 ```
+
+</p>
 </details>
 
 #### レスポンス
 
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | リクエストした作業の識別子 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -1044,142 +1021,127 @@ POST /v1.0/db-instances
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-### DBインスタンスを修正する
+---
+### オブジェクトストレージにあるバックアップからDBインスタンスを復元する
 
 ```http
-PUT /v1.0/db-instances/{dbInstanceId}
+POST /v1.0/db-instances/restore-from-obs
 ```
 
 #### 必要権限
 
-| 権限名                               | 説明          |
-|------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Modify | DBインスタンスを修正する |
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.RestoreFromObs | オブジェクトストレージにあるバックアップからDBインスタンスを復元 |
 
 #### リクエスト
 
-| 名前                | 種類  | 形式     | 必須 | 説明                                                                       |
-|--------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId       | URL  | UUID    | O  | DBインスタンスの識別子                                                             |
-| dbInstanceName     | Body | String  | X  | DBインスタンスを識別できる名前                                                     |
-| description        | Body | String  | X  | DBインスタンスの追加情報                                                        |
-| dbPort             | Body | Number  | X  | DBポート<br/>- 最小値:`5432`<br/>- 最大値:`45432`                                |
-| dbFlavorId         | Body | UUID    | X  | DBインスタンス仕様の識別子                                                          |
-| parameterGroupId   | Body | UUID    | X  | パラメータグループの識別子                                                             |
-| dbSecurityGroupIds | Body | Array   | X  | DBセキュリティグループの識別子リスト                                                         |
-| executeBackup      | Body | Boolean | X  | 現時点バックアップを実行するかどうか<br/>- デフォルト値:`false`                                         |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceName | Body | String | X | DBインスタンスを識別できる名前<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| dbInstanceCandidateName | Body | String | X | DBインスタンスを識別できる予備マスターの名前 |
+| description | Body | String | X | DBインスタンスの追加情報<br/>- 最大長さ: `100` |
+| dbFlavorId | Body | UUID | O | DBインスタンス仕様の識別子 |
+| dbPort | Body | Number | X | DBポート<br/>- 最小値: 5432、最大値: 45432 |
+| dbVersion | Body | Enum | O | DBエンジンタイプ |
+| useHighAvailability | Body | Boolean | X | 高可用性の使用有無<br/>- デフォルト値: `false` |
+| imageId | Body | UUID | X | イメージの識別子 |
+| pingInterval | Body | Number | X | 高可用性使用時のPing間隔(秒)<br/>- 最小値: `1`<br/>- 最大値: `600` |
+| failoverReplWaitingTime | Body | Number | X | フェイルオーバー複製遅延待機時間(秒)<br/>- 最小値: `-1` |
+| storage | Body | Object | O | ストレージ情報オブジェクト |
+| storage.storageType | Body | Enum | O | ストレージタイプ |
+| storage.storageSize | Body | Number | O | データストレージサイズ(GB)<br/>- 最小値: `20` |
+| network | Body | Object | O | ネットワーク情報オブジェクト |
+| network.subnetId | Body | UUID | O | サブネットの識別子 |
+| network.usePublicAccess | Body | Boolean | X | 外部接続の可否<br/>- デフォルト値: `false` |
+| network.availabilityZone | Body | Enum | X | DBインスタンスを作成するアベイラビリティゾーン |
+| backup | Body | Object | O | バックアップ情報オブジェクト |
+| backup.backupPeriod | Body | Number | O | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| backup.backupRetryCount | Body | Number | X | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| backup.replicationRegion | Body | Enum | X | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)`<br/>- KR2: `韓国(ピョンチョン)` |
+| backup.backupSchedules | Body | Array | O | バックアップスケジュールリスト |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | O | バックアップ開始時刻 |
+| backup.backupSchedules.backupWndDuration | Body | Enum | O | バックアップ期間<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+| restore | Body | Object | O | 復元情報オブジェクト |
+| restore.tenantId | Body | String | O | バックアップが保存されているオブジェクトストレージのテナントID |
+| restore.username | Body | String | O | NHN CloudアカウントまたはIAMメンバーID |
+| restore.password | Body | String | O | バックアップが保存されているオブジェクトストレージのAPIパスワード |
+| restore.targetContainer | Body | String | O | バックアップが保存されているオブジェクトストレージのコンテナ |
+| restore.objectPath | Body | String | O | コンテナに保存されているバックアップのパス |
+| useDefaultNotification | Body | Boolean | X | デフォルト通知の使用有無<br/>- デフォルト値: `false` |
+| parameterGroupId | Body | UUID | O | パラメータグループの識別子 |
+| dbSecurityGroupIds | Body | Array | X | DBセキュリティグループの識別子リスト |
+| userGroupIds | Body | Array | X | ユーザーグループの識別子リスト |
+| useDeletionProtection | Body | Boolean | X | 削除保護の有無<br/>- デフォルト値: `false` |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
-    "dbInstanceName": "db-instance2",
-    "description": "description2",
-    "dbPort": 25432,
-    "dbSecurityGroupIds": [],
-    "executeBackup": true
-}
-```
-</details>
-
-#### レスポンス
-
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-
-### 高可用性情報の照会
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}/high-availability
-```
-
-#### 必要権限
-
-| 権限名                                  | 説明        |
-|---------------------------------------|------------|
-| RDSforPostgreSQL:HighAvailability.Get | 高可用性情報照会 |
-
-#### リクエスト
-
-| 名前                 | 種類  | 形式     | 必須 | 説明                                                  |
-|---------------------|------|---------|----|------------------------------------------------------|
-| dbInstanceId        | URL  | UUID    | O  | DBインスタンスの識別子                                        |
-
-#### レスポンス
-
-| 名前                     | 種類  | 形式     | 説明                                                                                                                                                                                                                                                                                                                            |
-|-------------------------|------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| haStatus                | Body | Boolean | 高可用性状態<br/>- `CREATED`:作成済み<br/>- `STABLE`:正常<br/>- `DISABLE_REPLICATION_DELAY`:複製遅延によるフェイルオーバー停止<br/>- `PAUSING`:一時停止中<br/>- `PAUSED`:一時停止<br/>- `PAUSED_DUE_TO_TASK`:作業による一時停止<br/>- `FAILOVER_STARTED`:フェイルオーバー開始<br/>- `FAILOVER_FAILED`:フェイルオーバー失敗<br/>- `FAILOVER_COMPLETED`:フェイルオーバー完了<br/>- `DELETED`:削除済み |
-| pingInterval            | Body | Number  | 高可用性使用時のPing間隔(秒)<br/>- 最小値:`1`<br/>- 最大値:`600`                                                                                                                                                                                                                                                                           |
-| failoverReplWaitingTime | Body | Number  | 高可用性使用時のフェイルオーバー待機時間<br/>- 最小値:`-1`<br/>- -1に設定時、複製遅延が解消されるまで待機し続けます。                                                                                                                                                                                                                                                   |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "useHighAvailability": true,
-    "haStatus": "STABLE",
+    "dbInstanceName": "dbInstanceName",
+    "dbInstanceCandidateName": "dbInstanceCandidateName-example",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "dbVersion": "POSTGRESQL_V14_17",
+    "useHighAvailability": false,
+    "imageId": "550e8400-e29b-41d4-a716-446655440000",
     "pingInterval": 3,
-    "failoverReplWaitingTime": 60
+    "failoverReplWaitingTime": 60,
+    "storage": {
+        "storageType": "General SSD",
+        "storageSize": 20
+    },
+    "network": {
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
+        "availabilityZone": "kr-pub-a"
+    },
+    "backup": {
+        "backupPeriod": 0,
+        "backupRetryCount": 0,
+        "replicationRegion": "KR1",
+        "backupSchedules": [
+            {
+                "backupWndBgnTime": "00:00:00",
+                "backupWndDuration": "HALF_AN_HOUR"
+            }
+        ]
+    },
+    "restore": {
+        "tenantId": "0123456789abcdef0123456789abcdef",
+        "username": "username-example",
+        "password": "password-example",
+        "targetContainer": "targetContainer-example",
+        "objectPath": "objectPath-example"
+    },
+    "useDefaultNotification": false,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useDeletionProtection": false
 }
 ```
+
+</p>
 </details>
-
-
-### 高可用性を修正する
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/high-availability
-```
-
-#### 必要権限
-
-| 権限名                                     | 説明       |
-|------------------------------------------|-----------|
-| RDSforPostgreSQL:HighAvailability.Modify | 高可用性を修正する |
-
-#### リクエスト
-
-| 名前                     | 種類  | 形式     | 必須 | 説明                                                                          |
-|-------------------------|------|---------|----|------------------------------------------------------------------------------|
-| dbInstanceId            | URL  | UUID    | O  | DBインスタンスの識別子                                                                |
-| useHighAvailability     | Body | Boolean | O  | 高可用性の使用有無                                                                   |
-| pingInterval            | Body | Number  | X  | 高可用性使用時のPing間隔(秒)<br/>- 最小値:`1`<br/>- 最大値:`600`                         |
-| failoverReplWaitingTime | Body | Number  | X  | 高可用性使用時フェイルオーバー待機時間<br/>- 最小値:`-1`<br/>- -1に設定時、複製遅延が解消されるまで待機し続けます。 |
 
 #### レスポンス
 
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | リクエストした作業の識別子 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -1188,840 +1150,14 @@ PUT /v1.0/db-instances/{dbInstanceId}/high-availability
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-### 高可用性の再起動
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/high-availability/resume
-```
-
-#### 必要権限
-
-| 権限名                                     | 説明          |
-|------------------------------------------|--------------|
-| RDSforPostgreSQL:HighAvailability.Resume | 高可用性の再起動 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前          | 種類 | 形式  | 必須 | 説明          |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-
-### 高可用性の一時停止
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/high-availability/pause
-```
-
-#### 必要権限
-
-| 権限名                                    | 説明          |
-|-----------------------------------------|--------------|
-| RDSforPostgreSQL:HighAvailability.Pause | 高可用性の一時停止 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前          | 種類 | 形式  | 必須 | 説明          |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-
-### 高可用性の復旧
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/high-availability/repair
-```
-
-#### 必要権限
-
-| 権限名                                     | 説明       |
-|------------------------------------------|-----------|
-| RDSforPostgreSQL:HighAvailability.Repair | 高可用性の復旧 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前          | 種類 | 形式  | 必須 | 説明          |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-
-### 高可用性の分離
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/high-availability/split
-```
-
-#### 必要権限
-
-| 権限名                                    | 説明       |
-|-----------------------------------------|-----------|
-| RDSforPostgreSQL:HighAvailability.Split | 高可用性の分離 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前          | 種類 | 形式  | 必須 | 説明          |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-
-### DBインスタンスストレージ情報の照会
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}/storage-info
-```
-
-#### 必要権限
-
-| 権限名                            | 説明           |
-|---------------------------------|---------------|
-| RDSforPostgreSQL:DbInstance.Get | DBインスタンス詳細を表示 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前          | 種類 | 形式  | 必須 | 説明          |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前              | 種類  | 形式     | 説明                                                                                  |
-|------------------|------|---------|--------------------------------------------------------------------------------------|
-| storageType      | Body | Enum    | データストレージタイプ                                                                         |
-| storageSize      | Body | Number  | データストレージサイズ(GB)                                                                      |
-| storageStatus    | Body | Enum    | データストレージの現在状態<br/>- `DETACHED`:デタッチ<br/>- `ATTACHED`:アタッチ<br/>- `DELETED`:削除済み |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "storageType": "General SSD",
-    "storageSize": 20,
-    "storageStatus": "ATTACHED"
-}
-```
-</details>
-
-
-### DBインスタンスストレージ情報の修正
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/storage-info
-```
-
-#### 必要権限
-
-| 権限名                               | 説明          |
-|------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Modify | DBインスタンスの修正 |
-
-#### リクエスト
-
-| 名前               | 種類  | 形式     | 必須 | 説明                                                                       |
-|-------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID    | O  | DBインスタンスの識別子                                                             |
-| storageSize       | Body | Number  | O  | データストレージサイズ(GB)<br/>- 最小値:現在値<br/>- 最大値:`2048`                          |
-
-#### レスポンス
-
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### DBインスタンスネットワーク情報の照会
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}/network-info
-```
-
-#### 必要権限
-
-| 権限名                            | 説明           |
-|---------------------------------|---------------|
-| RDSforPostgreSQL:DbInstance.Get | DBインスタンス詳細を表示 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前          | 種類 | 形式  | 必須 | 説明          |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前                     | 種類  | 形式     | 説明                                                                                                                                     |
-|-------------------------|------|---------|-----------------------------------------------------------------------------------------------------------------------------------------|
-| availabilityZone        | Body | Enum    | DBインスタンスを作成するアベイラビリティゾーン                                                                                                                    |
-| subnet                  | Body | Object  | サブネットオブジェクト                                                                                                                                 |
-| subnet.subnetId         | Body | UUID    | サブネットの識別子                                                                                                                               |
-| subnet.subnetName       | Body | UUID    | サブネットを識別できる名前                                                                                                                       |
-| subnet.subnetCidr       | Body | UUID    | サブネットのCIDR                                                                                                                               |
-| subnet.publicAccessible | Body | Boolean | 外部接続可否                                                                                                                            |
-| endPoints               | Body | Array   | 接続情報リスト                                                                                                                               |
-| endPoints.domain        | Body | String  | ドメイン                                                                                                                                    |
-| endPoints.ipAddress     | Body | String  | IPアドレス                                                                                                                                  |
-| endPoints.endPointType  | Body | Enum    | 接続情報タイプ<br>-`EXTERNAL`:外部接続ドメイン<br>-`INTERNAL`:内部接続ドメイン<br>-`PUBLIC`:(Deprecated)外部接続ドメイン<br>-`PRIVATE`:(Deprecated)内部接続ドメイン |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "availabilityZone": "kr-pub-a",
-    "subnet": {
-        "subnetId": "bd453789-34ae-416c-9f78-05b9e43a46be",
-        "subnetName": "Default Network",
-        "subnetCidr": "192.168.0.0/16",
-        "publicAccessible": true
-    },
-    "endPoints": [
-        {
-            "domain": "ea548a78-d85f-43b4-8ddf-c88d999b9905.internal.kr1.postgres.rds.nhncloudservice.com",
-            "ipAddress": "192.168.0.2",
-            "endPointType": "INTERNAL"
-        }
-    ]
-}
-```
-</details>
-
-### DBインスタンスネットワーク情報の修正
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/network-info
-```
-
-#### 必要権限
-
-| 権限名                               | 説明          |
-|------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Modify | DBインスタンスの修正 |
-
-#### リクエスト
-
-| 名前             | 種類  | 形式     | 必須 | 説明          |
-|-----------------|------|---------|----|--------------|
-| dbInstanceId    | URL  | UUID    | O  | DBインスタンスの識別子 |
-| usePublicAccess | Body | Boolean | O  | 外部接続可否 |
-
-#### レスポンス
-
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### DBインスタンスバックアップ情報の照会
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}/backup-info
-```
-
-#### 必要権限
-
-| 権限名                            | 説明           |
-|---------------------------------|---------------|
-| RDSforPostgreSQL:DbInstance.Get | DBインスタンス詳細を表示 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前          | 種類 | 形式  | 必須 | 説明          |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前                                   | 種類  | 形式    | 説明                                                                                                                                                                                                                  |
-|---------------------------------------|------|--------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| backupPeriod                          | Body | Number | バックアップの保管期間(日)                                                                                                                                                                                                          |
-| backupRetryCount                      | Body | Number | バックアップの再試行回数                                                                                                                                                                                                           |
-| backupSchedules                       | Body | Array  | バックアップスケジュールリスト                                                                                                                                                                                                           |
-| backupSchedules.backupWndBgnTime      | Body | String | バックアップ開始時間                                                                                                                                                                                                            |
-| backupSchedules.backupWndDuration     | Body | Enum   | バックアップWindows<br/>バックアップ開始時間から設定された期間内に自動バックアップが実行されます。<br/>- `HALF_AN_HOUR`:30分<br/>- `ONE_HOUR`:1時間<br/>- `ONE_HOUR_AND_HALF`:1時間30分<br/>- `TWO_HOURS`:2時間<br/>- `TWO_HOURS_AND_HALF`:2時間30分<br/>- `THREE_HOURS`:3時間 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "backupPeriod": 1,
-    "backupRetryCount": 0,
-    "backupSchedules": [
-        {
-            "backupWndBgnTime": "00:00:00",
-            "backupWndDuration": "ONE_HOUR_AND_HALF",
-            "backupRetryExpireTime": "01:30:00"
-        }
-    ]
-}
-```
-</details>
-
-### DBインスタンスバックアップ情報の修正
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/backup-info
-```
-
-#### 必要権限
-
-| 権限名                               | 説明          |
-|------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Modify | DBインスタンスの修正 |
-
-#### リクエスト
-
-| 名前                                   | 種類  | 形式    | 必須 | 説明                                                                                                                                                                                                                  |
-|---------------------------------------|------|--------|----|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                          | URL  | UUID   | O  | DBインスタンスの識別子                                                                                                                                                                                                        |
-| backupPeriod                          | Body | Number | X  | バックアップの保管期間(日)<br/>- 最小値:`0`<br/>- 最大値:`730`                                                                                                                                                                          |
-| backupRetryCount                      | Body | Number | X  | バックアップの再試行回数<br/>- 最小値:`0`<br/>- 最大値:`10`                                                                                                                                                                             |
-| backupSchedules                       | Body | Array  | X  | バックアップスケジュールリスト                                                                                                                                                                                                           |
-| backupSchedules.backupWndBgnTime      | Body | String | O  | バックアップ開始時間<br/>- 例:`00:00:00`                                                                                                                                                                                        |
-| backupSchedules.backupWndDuration     | Body | Enum   | O  | バックアップWindows<br/>バックアップ開始時間から設定された期間内に自動バックアップが実行されます。<br/>- `HALF_AN_HOUR`:30分<br/>- `ONE_HOUR`:1時間<br/>- `ONE_HOUR_AND_HALF`:1時間30分<br/>- `TWO_HOURS`:2時間<br/>- `TWO_HOURS_AND_HALF`:2時間30分<br/>- `THREE_HOURS`:3時間 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "backupPeriod": 5,
-    "backupSchedules": [
-        {
-            "backupWndBgnTime": "01:00:00",
-            "backupWndDuration": "TWO_HOURS",
-            "backupRetryExpireTime": "03:00:00"
-        }
-    ]
-}
-```
-</details>
-
-#### レスポンス
-
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### DBインスタンス復元情報の照会
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}/restoration-info
-```
-
-#### 必要権限
-
-| 権限名                            | 説明           |
-|---------------------------------|---------------|
-| RDSforPostgreSQL:DbInstance.Get | DBインスタンス詳細を表示 |
-
-#### リクエスト
-
-| 名前          | 種類 | 形式  | 必須 | 説明          |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前                                     | 種類  | 形式      | 説明                                                                                                                                                   |
-|-----------------------------------------|------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
-| oldestRestorableYmdt                    | Body | DateTime | 最も古い復元可能時間                                                                                                                                     |
-| latestRestorableYmdt                    | Body | DateTime | 最も最新の復元可能時間                                                                                                                                     |
-| restorableBackups                       | Body | Array    | 復元可能なバックアップリスト                                                                                                                                         |
-| restorableBackups.backup                | Body | Object   | バックアップの情報オブジェクト                                                                                                                                             |
-| restorableBackups.backup.backupId       | Body | UUID     | バックアップの識別子                                                                                                                                              |
-| restorableBackups.backup.backupName     | Body | String   | バックアップ名                                                                                                                                                |
-| restorableBackups.backup.backupSize     | Body | Number   | バックアップサイズ                                                                                                                                                |
-| restorableBackups.backup.backupType     | Body | Enum     | バックアップタイプ<br/>- `AUTO`:自動<br/>- `MANUAL`:手動                                                                                                            |
-| restorableBackups.backup.backupStatus   | Body | Enum     | バックアップ状態<br/>- `BACKING_UP`:バックアップ中の場合<br/>- `COMPLETED`:バックアップが完了した場合<br/>- `DELETING`:バックアップが削除中の場合<br/>- `DELETED`:バックアップが削除された場合<br/>- `ERROR`:エラーが発生した場合 |
-| restorableBackups.backup.dbInstanceId   | Body | UUID     | 原本DBインスタンスの識別子                                                                                                                                      |
-| restorableBackups.backup.dbInstanceName | Body | String   | 原本DBインスタンス名                                                                                                                                       |
-| restorableBackups.backup.dbVersion      | Body | String   | DBバージョン情報                                                                                                                                             |
-| restorableBackups.backup.failoverCount  | Body | Number   | フェイルオーバー回数                                                                                                                                             |
-| restorableBackups.backup.walFileName    | Body | String   | WALログファイル名                                                                                                                                         |
-| restorableBackups.backup.createdYmdt    | Body | DateTime | バックアップ作成日時                                                                                                                                             |
-| restorableBackups.backup.updatedYmdt    | Body | DateTime | バックアップ更新日時                                                                                                                                             |
-| restorableBackups.backup.startYmdt      | Body | DateTime | バックアップ開始日時                                                                                                                                             |
-| restorableBackups.backup.completedYmdt  | Body | DateTime | バックアップ完了日時                                                                                                                                             |
-
-<details><summary>例</summary>
-
-```json
-{
-	"header": {
-		"resultCode": 0,
-		"resultMessage": "SUCCESS",
-		"isSuccessful": true
-	},
-    "oldestRestorableYmdt": "2023-07-09T16:33:33+09:00",
-	"latestRestorableYmdt": "2023-07-10T15:44:44+09:00",
-	"restorableBackups": [
-		{
-			"backup": {
-				"backupId": "145d889a-fe08-474f-8f58-bde576ff96a9",
-				"backupName": "example-backup-name",
-				"backupStatus": "COMPLETED",
-				"dbInstanceId": "dba1be25-9429-4589-9716-7fb6daad7cb9",
-				"dbInstanceName": "original-db-instance-name",
-				"dbVersion": "POSTGRESQL_V17_6",
-				"backupType": "MANUAL",
-				"backupSize": 8299904,
-				"walFileName": "000000010000000000000005",
-				"createdYmdt": "2023-07-10T15:44:44+09:00",
-				"updatedYmdt": "2023-07-10T15:46:07+09:00"
-			}
-		}
-	]
-}
-```
-</details>
-
-### DBインスタンスの復元
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/restore
-```
-
-#### 必要権限
-
-| 権限名                                | 説明          |
-|-------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Restore | DBインスタンスの復元 |
-
-#### 共通リクエスト
-
-| 名前                                      | 種類  | 形式     | 必須 | 説明                                                                                                                                                                                                                                                 |
-|------------------------------------------|------|---------|----|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                             | URL  | UUID    | O  | DBインスタンスの識別子                                                                                                                                                                                                                                       |
-| restore                                  | Body | Object  | O  | 復元情報オブジェクト                                                                                                                                                                                                                                           |
-| restore.restoreType                      | Body | Enum    | O  | 復元タイプ種類<br/>- `TIMESTAMP`:復元可能時間内の時間を利用した時点復元タイプ<br/>- `BACKUP`:既存のバックアップを利用した復元タイプ                                                                                                                                                   |
-| dbInstanceName                           | Body | String  | O  | DBインスタンスを識別できる名前                                                                                                                                                                                                                               |
-| description                              | Body | String  | X  | DBインスタンスの追加情報                                                                                                                                                                                                                                  |
-| dbFlavorId                               | Body | UUID    | O  | DBインスタンス仕様の識別子                                                                                                                                                                                                                                    |
-| dbPort                                   | Body | Number  | O  | DBポート<br/>- 最小値:`3306`<br/>- 最大値:`43306`                                                                                                                                                                                                          |
-| parameterGroupId                         | Body | UUID    | O  | パラメータグループの識別子                                                                                                                                                                                                                                       |
-| dbSecurityGroupIds                       | Body | Array   | X  | DBセキュリティグループの識別子リスト                                                                                                                                                                                                                                   |
-| userGroupIds                             | Body | Array   | X  | ユーザーグループの識別子リスト                                                                                                                                                                                                                                     |
-| useDefaultNotification                   | Body | Boolean | X  | 基本通知の使用有無<br/>- デフォルト値:`false`                                                                                                                                                                                                                      |
-| useDeletionProtection                    | Body | Boolean | X  | 削除保護の有無<br>デフォルト値:`false`                                                                                                                                                                                                                            |                                                                                                                                                                                                                                                                                                                                                                                                                                        |
-| useHighAvailability                      | Body | Boolean | X  | 高可用性の使用有無<br/>- デフォルト値:`false`                                                                                                                                                                                                                       |
-| pingInterval                             | Body | Number  | X  | 高可用性使用時Ping間隔(秒)<br/>- デフォルト値: `3`最小値: `1`<br/>- 最大値: `600`                                                                                                                                                                                        |
-| failoverReplWaitingTime                  | Body | Number  | X  | 高可用性使用時のフェイルオーバー待機時間<br/>- 最小値:`-1`<br/>- -1に設定時、複製遅延が解消されるまで待機し続けます。                                                                                                                                                                        |                                                                                                                                                                                                                      | userGroupIds                             | Body | Array   | X  | 基本通知受信用のユーザーグループの識別子リスト                                                                                                                                                                                            |
-| network                                  | Body | Object  | O  | ネットワーク情報オブジェクト                                                                                                                                                                                                                                         |
-| network.subnetId                         | Body | UUID    | O  | サブネットの識別子                                                                                                                                                                                                                                           |
-| network.usePublicAccess                  | Body | Boolean | X  | 外部接続可否<br/>- デフォルト値:`false`</li></ul>                                                                                                                                                                                                            |
-| network.availabilityZone                 | Body | Enum    | X  | DBインスタンスを作成するアベイラビリティゾーン<br/>- 例:`kr-pub-a`<br/>- デフォルト値:`任意のアベイラビリティゾーン`                                                                                                                                                                                    |
-| storage                                  | Body | Object  | O  | ストレージ情報オブジェクト                                                                                                                                                                                                                                         |
-| storage.storageType                      | Body | Enum    | O  | データストレージタイプ<br/>- 例:`General SSD`                                                                                                                                                                                                                 |
-| storage.storageSize                      | Body | Number  | O  | データストレージサイズ(GB)<br/>- 最小値:`20`<br/>- 最大値:`2048`                                                                                                                                                                                                   |
-| backup                                   | Body | Object  | O  | バックアップの情報オブジェクト                                                                                                                                                                                                                                           |
-| backup.backupPeriod                      | Body | Number  | O  | バックアップの保管期間(日)<br/>- 最小値:`0`<br/>- 最大値:`730`                                                                                                                                                                                                         |
-| backup.backupRetryCount                  | Body | Number  | X  | バックアップの再試行回数<br/>- デフォルト値:`0`<br/>- 最小値:`0`<br/>- 最大値:`10`                                                                                                                                                                                             |
-| backup.backupSchedules                   | Body | Array   | O  | バックアップスケジュールリスト                                                                                                                                                                                                                                          |
-| backup.backupSchedules.backupWndBgnTime  | Body | String  | X  | バックアップ開始時刻<br/>- 例:`00:00:00`<br/>- デフォルト値:原本DBインスタンス値                                                                                                                                                                                              |
-| backup.backupSchedules.backupWndDuration | Body | Enum    | X  | バックアップDuration<br/>バックアップ開始時刻からDuration内に自動バックアップが実行されます。<br/>- `HALF_AN_HOUR`:30分<br/>- `ONE_HOUR`:1時間<br/>- `ONE_HOUR_AND_HALF`:1時間30分<br/>- `TWO_HOURS`:2時間<br/>- `TWO_HOURS_AND_HALF`:2時間30分<br/>- `THREE_HOURS`:3時間<br/>- デフォルト値:原本DBインスタンス値 |
-
-#### Timestampを利用した時点復元時のリクエスト(restoreTypeが`TIMESTAMP`の場合)
-
-| 名前                 | 種類  | 形式      | 必須 | 説明                                                                                             |
-|---------------------|------|----------|----|-------------------------------------------------------------------------------------------------|
-| restore.restoreYmdt | Body | DateTime | O  | DBインスタンス復元時間。(YYYY-MM-DDThh:mm:ss.SSSTZD)<br>復元情報照会で照会した最も最新の復元可能な時間以前のデータのみ復元が可能 |
-
-<details><summary>例</summary>
-
-```json
-{
-  "dbInstanceName": "db-instance",
-  "description": "description",
-  "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-  "dbPort": 10000,
-  "dbUserName": "db-user",
-  "dbPassword": "password",
-  "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-  "dbSecurityGroupIds": [
-    "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-  ],
-  "userGroupIds": [],
-  "network": {
-    "subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36"
-  },
-  "storage": {
-    "storageType": "General SSD",
-    "storageSize": 20
-  },
-  "restore": {
-    "restoreType": "TIMESTAMP",
-    "restoreYmdt": "2023-07-10T15:44:44+09:00"
-  },
-  "backup": {
-    "backupPeriod": 1,
-    "backupSchedules": [
-      {
-        "backupWndBgnTime": "00:00:00",
-        "backupWndDuration": "ONE_HOUR_AND_HALF"
-      }
-    ]
-  }
-}
-```
-</details>
-
-#### レスポンス
-
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-
-### DBインスタンス削除保護設定の変更
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/deletion-protection
-```
-
-#### 必要権限
-
-| 権限名                               | 説明          |
-|------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Modify | DBインスタンスの修正 |
-
-#### リクエスト
-
-| 名前                   | 種類  | 形式     | 必須 | 説明          |
-|-----------------------|------|---------|----|--------------|
-| dbInstanceId          | URL  | UUID    | O  | DBインスタンスの識別子 |
-| useDeletionProtection | Body | Boolean | O  | 削除保護の有無     |
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
-
-### DBインスタンス保守情報照会
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}/maintenance-info
-```
-
-#### 必要権限
-
-| 権限名                           | 説明          |
-|---------------------------------|---------------|
-| RDSforPostgreSQL:DbInstance.Get | DBインスタンス詳細表示 |
-
-#### リクエスト
-
-| 名前                  | 種類 | 形式    | 必須 | 説明         |
-|-----------------------|------|---------|----|--------------|
-| dbInstanceId          | URL  | UUID    | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前                  | 種類 | 形式    | 説明                                                                                                                 |
-|-----------------------|------|---------|----------------------------------------------------------------------------------------------------------------------|
-| allowAutoMaintenance  | Body | Boolean | 自動保守を許可するかどうか                                                                                                       |
-| useAutoStorageCleanup | Body | Boolean | 自動ストレージクリーンアップを使用するかどうか                                                                                                    |
-| maintWndBgnTime       | Body | String  | 自動保守開始時間 <br/>- 例: `00:00:00`                                                                                  |
-| maintWndDuration      | Body | ENUM    | 保守Windows <br/> 例: `HALF_AN_HOUR`, `ONE_HOUR`, `ONE_HOUR_AND_HALF`, `TWO_HOURS`, `TWO_HOURS_AND_HALF`, `THREE_HOURS` |
-| logRetentionPeriod    | Body | Number  | ログ保管期間(日)                                                                                                         |
-
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "allowAutoMaintenance": true,
-    "useAutoStorageCleanup": true,
-    "maintWndBgnTime": "00:00:00",
-    "maintWndDuration": "HALF_AN_HOUR",
-    "logRetentionPeriod": 7
-}
-```
-</details>
-
-
-### DBインスタンス保守情報修正
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/maintenance-info
-```
-
-#### 必要権限
-
-| 権限名                              | 説明         |
-|------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Modify | DBインスタンスを修正する |
-
-#### リクエスト
-
-| 名前                  | 種類 | 形式    | 必須 | 説明                                                                                                                 |
-|-----------------------|------|---------|----|----------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId          | URL  | UUID    | O  | DBインスタンスの識別子                                                                                                       |
-| allowAutoMaintenance  | Body | Boolean | X  | 自動保守を許可するかどうか                                                                                                       |
-| useAutoStorageCleanup | Body | Boolean | X  | 自動ストレージクリーンアップを使用するかどうか                                                                                                    |
-| maintWndBgnTime       | Body | String  | X  | 自動保守開始時間 <br/>- 例: `00:00:00`                                                                                  |
-| maintWndDuration      | Body | ENUM    | X  | 保守Windows <br/> 例: `HALF_AN_HOUR`, `ONE_HOUR`, `ONE_HOUR_AND_HALF`, `TWO_HOURS`, `TWO_HOURS_AND_HALF`, `THREE_HOURS` |
-| logRetentionPeriod    | Body | Number  | X  | ログ保管期間(日)                                                                                                         |
-
-<details><summary>例</summary>
-
-```json
-{
-  "allowAutoMaintenance": true,
-  "useAutoStorageCleanup": true,
-  "logRetentionPeriod": 7
-}
-```
-</details>
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-
-```json
-{
-  "header": {
-    "resultCode": 0,
-    "resultMessage": "SUCCESS",
-    "isSuccessful": true
-  },
-  "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-
-### 現在のDBインスタンスで選択可能なDBバージョンの照会
-
-```http
-GET /v1.0/db-instances/{dbInstanceId}/available-db-versions
-```
-
-#### 必要権限
-
-| 権限名                              | 説明         |
-|------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Get | DBインスタンス詳細表示 |
-
-#### リクエスト
-
-| 名前                  | 種類 | 形式    | 必須 | 説明         |
-|-----------------------|------|---------|----|--------------|
-| dbInstanceId          | URL  | UUID    | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前                         | 種類 | 形式    | 説明                  |
-|------------------------------|------|---------|-----------------------|
-| dbVersions                   | Body | Array   | DBバージョンリスト            |
-| dbVersions.dbVersion         | Body | String  | DBバージョン               |
-| dbVersions.dbVersionName     | Body | String  | DBバージョン名              |
-| dbVersions.restorableFromObs | Body | Boolean | オブジェクトストレージから復元の可否 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbVersions": [
-        {
-            "dbVersion": "POSTGRESQL_V17_6",
-            "dbVersionName": "PostgreSQL V17.6",
-            "restorableFromObs": true
-        }
-    ]
-}
-```
-</details>
+---
 
 ### DBインスタンスの削除
 
@@ -2031,25 +1167,26 @@ DELETE /v1.0/db-instances/{dbInstanceId}
 
 #### 必要権限
 
-| 権限名                               | 説明          |
-|------------------------------------|--------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:DbInstance.Delete | DBインスタンスの削除 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前          | 種類 | 形式  | 必須 | 説明          |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
 
 #### レスポンス
 
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | リクエストした作業の識別子 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -2058,123 +1195,61 @@ DELETE /v1.0/db-instances/{dbInstanceId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-### DBインスタンスの再起動
+---
+
+### DBインスタンス詳細を表示
 
 ```http
-POST /v1.0/db-instances/{dbInstanceId}/restart
+GET /v1.0/db-instances/{dbInstanceId}
 ```
 
 #### 必要権限
 
-| 権限名                                | 説明           |
-|-------------------------------------|---------------|
-| RDSforPostgreSQL:DbInstance.Restart | DBインスタンスの再起動 |
-
-#### リクエスト
-
-| 名前               | 種類  | 形式     | 必須 | 説明                                                                       |
-|-------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID    | O  | DBインスタンスの識別子                                                             |
-| useOnlineFailover | Body | Boolean | X  | フェイルオーバーを利用した再起動の有無<br/>高可用性を使用中のDBインスタンスでのみ使用可能です。<br/>- デフォルト値:`false` |
-| executeBackup     | Body | Boolean | X  | 現時点バックアップを実行するかどうか<br/>- デフォルト値: `false`                                         |
-
-<details><summary>例</summary>
-
-```json
-{
-    "executeBackup": true
-}
-```
-</details>
-
-#### レスポンス
-
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### DBインスタンスの強制再起動
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/force-restart
-```
-
-#### 必要権限
-
-| 権限名                                     | 説明              |
-|------------------------------------------|------------------|
-| RDSforPostgreSQL:DbInstance.ForceRestart | DBインスタンスの強制再起動 |
-
-#### リクエスト
-
-| 名前          | 種類 | 形式  | 必須 | 説明          |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
-
-
-### DBインスタンス開始
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/start
-```
-
-#### 必要権限
-
-| 権限名                              | 説明          |
-|-----------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Start | DBインスタンス開始 |
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Get | DBインスタンス詳細を表示 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前          | 種類 | 形式  | 必須 | 説明          |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
 
 #### レスポンス
 
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceId | Body | UUID | DBインスタンスの識別子 |
+| dbInstanceGroupId | Body | UUID | DBインスタンスグループの識別子 |
+| dbInstanceName | Body | String | DBインスタンスを識別できる名前 |
+| description | Body | String | DBインスタンスの追加情報 |
+| dbVersion | Body | Enum | DBエンジンタイプ |
+| dbPort | Body | Number | DBポート |
+| dbInstanceType | Body | Enum | DBインスタンスのロールタイプ<br/>- MASTER: `マスター`<br/>- FAILED_MASTER: `フェイルオーバーされたマスター`<br/>- CANDIDATE_MASTER: `予備マスター`<br/>- READ_ONLY_SLAVE: `リードレプリカ` |
+| dbInstanceStatus | Body | Enum | DBインスタンスの現在状態<br/>- BEFORE_CREATE: `作成以前(グレー)`<br/>- AVAILABLE: `使用可能(緑)`<br/>- STORAGE_FULL: `容量不足(赤)`<br/>- FAIL_TO_CREATE: `作成失敗(赤)`<br/>- FAIL_TO_CONNECT: `接続失敗(赤)`<br/>- REPLICATION_STOP: `複製中断(赤)`<br/>- REPLICATION_DELAY: `複製遅延(黄色)`<br/>- FAILOVER: `フェイルオーバー完了(赤)`<br/>- SHUTDOWN: `停止済み(グレー)`<br/>- DELETED: `削除済み(グレー)` |
+| progressStatus | Body | String | DBインスタンスの現在の作業進行状態 |
+| dbFlavorId | Body | UUID | DBインスタンス仕様の識別子 |
+| parameterGroupId | Body | UUID | DBインスタンスに適用されたパラメータグループの識別子 |
+| dbSecurityGroupIds | Body | Array | DBインスタンスに適用されたDBセキュリティグループの識別子リスト |
+| notificationGroupIds | Body | Array | DBインスタンスに適用された通知グループの識別子リスト |
+| useDeletionProtection | Body | Boolean | DBインスタンスの削除保護の有無 |
+| needToApplyParameterGroup | Body | Boolean | 最新パラメータグループの適用可否 |
+| needMigration | Body | Boolean | マイグレーションの要否 |
+| osVersion | Body | String | OSバージョン |
+| createdYmdt | Body | DateTime | 作成日時 |
+| updatedYmdt | Body | DateTime | 修正日時 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -2183,38 +1258,98 @@ POST /v1.0/db-instances/{dbInstanceId}/start
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbInstanceName": "dbInstanceName-example",
+    "description": "description-example",
+    "dbVersion": "POSTGRESQL_V14_17",
+    "dbPort": 1,
+    "dbInstanceType": "MASTER",
+    "dbInstanceStatus": "BEFORE_CREATE",
+    "progressStatus": "progressStatus-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [
+        "550e8400-e29b-41d4-a716-446655440000"
+    ],
+    "notificationGroupIds": [
+        "550e8400-e29b-41d4-a716-446655440000"
+    ],
+    "useDeletionProtection": false,
+    "needToApplyParameterGroup": false,
+    "needMigration": false,
+    "osVersion": "osVersion-example",
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
+
+</p>
 </details>
 
-### DBインスタンス停止
+---
+
+### DBインスタンスを修正する
 
 ```http
-POST /v1.0/db-instances/{dbInstanceId}/stop
+PUT /v1.0/db-instances/{dbInstanceId}
 ```
 
 #### 必要権限
 
-| 権限名                            | 説明         |
-|----------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Stop | DBインスタンスを停止する |
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Modify | DBインスタンスを修正する |
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceName | Body | String | X | DBインスタンスを識別できる名前 |
+| dbInstanceCandidateName | Body | String | X | DBインスタンスを識別できる予備マスターの名前 |
+| description | Body | String | X | DBインスタンスの追加情報<br/>- 最大長さ: `100` |
+| dbPort | Body | Number | X | DBポート<br/>- 最小値: 5432、最大値: 45432 |
+| dbFlavorId | Body | UUID | X | DBインスタンス仕様の識別子 |
+| parameterGroupId | Body | UUID | X | パラメータグループの識別子 |
+| dbVersion | Body | Enum | X | DBエンジンバージョンコード |
+| dbSecurityGroupIds | Body | Array | X | DBセキュリティグループの識別子リスト |
+| executeBackup | Body | Boolean | X | 現時点バックアップを実行するかどうか<br/>- デフォルト値: `false` |
+| useOnlineFailover | Body | Boolean | X | フェイルオーバーを利用した再起動の有無<br/>- デフォルト値: `false` |
+| waitReplicationDelay | Body | Boolean | X | 複製遅延の解消を待機するかどうか<br/>- デフォルト値: `false` |
+| useReadOnly | Body | Boolean | X | 書き込み負荷のブロック<br/>- デフォルト値: `false` |
 
-| 名前          | 種類 | 形式  | 必須 | 説明          |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName-example",
+    "dbInstanceCandidateName": "dbInstanceCandidateName-example",
+    "description": "description-example",
+    "dbPort": 1,
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbVersion": "POSTGRESQL_V14_17",
+    "dbSecurityGroupIds": [],
+    "executeBackup": false,
+    "useOnlineFailover": false,
+    "waitReplicationDelay": false,
+    "useReadOnly": false
+}
+```
+
+</p>
+</details>
 
 #### レスポンス
 
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | リクエストした作業の識別子 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -2223,114 +1358,14 @@ POST /v1.0/db-instances/{dbInstanceId}/stop
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-### DBインスタンスのバックアップ
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/backup
-```
-
-#### 必要権限
-
-| 権限名                               | 説明          |
-|------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Backup | DBインスタンスのバックアップ |
-
-#### リクエスト
-
-| 名前          | 種類  | 形式    | 必須 | 説明             |
-|--------------|------|--------|----|-----------------|
-| dbInstanceId | URL  | UUID   | O  | DBインスタンスの識別子   |
-| backupName   | Body | String | O  | バックアップを識別できる名前 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "backupName": "backup"
-}
-```
-</details>
-
-#### レスポンス
-
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### DBインスタンスバックアップ後にエクスポート
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/backup-to-object-storage
-```
-
-#### 必要権限
-
-| 権限名                                              | 説明                        |
-|---------------------------------------------------|----------------------------|
-| RDSforPostgreSQL:DbInstance.BackupToObjectStorage | バックアップ後にバックアップファイルをオブジェクトストレージにエクスポート |
-
-#### リクエスト
-
-| 名前             | 種類  | 形式    | 必須 | 説明                         |
-|-----------------|------|--------|----|-----------------------------|
-| dbInstanceId    | URL  | UUID   | O  | DBインスタンスの識別子               |
-| tenantId        | Body | String | O  | バックアップが保存されるオブジェクトストレージのテナントID   |
-| username        | Body | String | O  | NHN CloudアカウントまたはIAMアカウントID   |
-| password        | Body | String | O  | バックアップが保存されるオブジェクトストレージのAPIパスワード |
-| targetContainer | Body | String | O  | バックアップが保存されるオブジェクトストレージのコンテナ    |
-| objectPath      | Body | String | O  | コンテナに保存されるバックアップのパス           |
-
-<details><summary>例</summary>
-
-```json
-{
-    "tenantId": "399631c404744dbbb18ce4fa2dc71a5a",
-    "username": "gildong.hong@nhn.com",
-    "password": "password",
-    "targetContainer": "/container",
-    "objectPath": "/backups/backup_file"
-}
-```
-</details>
-
-#### レスポンス
-
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
+---
 
 ### DBインスタンスの最新パラメータグループを適用する
 
@@ -2340,143 +1375,26 @@ POST /v1.0/db-instances/{dbInstanceId}/apply-recent-parameter-group
 
 #### 必要権限
 
-| 権限名                               | 説明          |
-|------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Modify | DBインスタンスの修正 |
-
-#### リクエスト
-
-| 名前               | 種類  | 形式     | 必須 | 説明                                                                       |
-|-------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID    | O  | DBインスタンスの識別子                                                             |
-| executeBackup     | Body | Boolean | X  | 現時点バックアップを実行するかどうか<br/>- デフォルト値:`false`                                         |
-
-<details><summary>例</summary>
-
-```json
-{
-  "executeBackup": true
-}
-```
-</details>
-
-#### レスポンス
-
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### DBインスタンスの複製
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/replicate
-```
-
-#### 必要権限
-
-| 権限名                                  | 説明          |
-|---------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Replicate | DBインスタンスの複製 |
-
-#### リクエスト
-
-| 名前                                          | 種類  | 形式     | 必須 | 説明                                                                                                                                                                                                                                                 |
-|----------------------------------------------|------|---------|----|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                                 | URL  | UUID    | O  | DBインスタンスの識別子                                                                                                                                                                                                                                       |
-| dbInstanceName                               | Body | String  | O  | DBインスタンスを識別できる名前                                                                                                                                                                                                                               |
-| description                                  | Body | String  | X  | DBインスタンスの追加情報                                                                                                                                                                                                                                  |
-| dbFlavorId                                   | Body | UUID    | X  | DBインスタンス仕様の識別子<br/>- デフォルト値:原本DBインスタンス値                                                                                                                                                                                                            |
-| dbPort                                       | Body | Number  | X  | DBポート<br/>- デフォルト値:原本DBインスタンス値<br/>- 最小値:`5432`<br/>- 最大値:`45432`                                                                                                                                                                                  |
-| parameterGroupId                             | Body | UUID    | X  | パラメータグループの識別子<br/>- デフォルト値:原本DBインスタンス値                                                                                                                                                                                                               |
-| dbSecurityGroupIds                           | Body | Array   | X  | DBセキュリティグループの識別子リスト<br/>- デフォルト値:原本DBインスタンス値                                                                                                                                                                                                           |
-| userGroupIds                                 | Body | Array   | X  | ユーザーグループの識別子リスト                                                                                                                                                                                                                                     |
-| useDefaultNotification                       | Body | Boolean | X  | 基本通知の使用有無<br/>- デフォルト値:`false`                                                                                                                                                                                                                      |
-| useDeletionProtection                        | Body | Boolean | X  | 削除保護の有無<br/>- デフォルト値: `false`                                                                                                                                                                                                                         |
-| network                                      | Body | Object  | X  | ネットワーク情報オブジェクト                                                                                                                                                                                                                                         |
-| network.usePublicAccess                      | Body | Boolean | X  | 外部接続可否<br/>- デフォルト値:`false`                                                                                                                                                                                                                      |
-| network.availabilityZone                     | Body | Enum    | X  | DBインスタンスを作成するアベイラビリティゾーン<br/>- 例:`kr-pub-a`<br/>- デフォルト値:`任意のアベイラビリティゾーン`                                                                                                                                                                                    |  
-| storage                                      | Body | Object  | X  | ストレージ情報オブジェクト                                                                                                                                                                                                                                         |    
-| storage.storageType                          | Body | Enum    | X  | データストレージタイプ<br>- 例:`General SSD`                                                                                                                                                                                                                  |
-| storage.storageSize                          | Body | Number  | X  | データストレージサイズ(GB)<br/>- デフォルト値:原本DBインスタンス値<br/>- 最小値:`20`<br/>- 最大値:`2048`                                                                                                                                                                           |
-| backup                                       | Body | Object  | X  | バックアップ情報オブジェクト                                                                                                                                                                                                                                           |
-| backup.backupPeriod                          | Body | Number  | X  | バックアップの保管期間(日)<br/>- デフォルト値:原本DBインスタンス値<br/>- 最小値:`0`<br/>- 最大値:`730`                                                                                                                                                                                 |
-| backup.backupRetryCount                      | Body | Number  | X  | バックアップの再試行回数<br/>- デフォルト値:原本DBインスタンス値<br/>- 最小値:`0`<br/>- 最大値:`10`                                                                                                                                                                                    |
-
-<details><summary>例</summary>
-
-```json
-{
-    "dbInstanceName": "db-instance-replicate",
-    "description": "description",
-    "dbPort": 15432,
-    "storage": {
-        "storageSize": 100
-    }
-}
-```
-</details>
-
-#### レスポンス
-
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### DBインスタンスの昇格
-
-```http
-POST /v1.0/db-instances/{dbInstanceId}/promote
-```
-
-#### 必要権限
-
-| 権限名                                | 説明          |
-|-------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Promote | DBインスタンスの昇格 |
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Modify | DBインスタンスの最新パラメータグループを適用する |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前          | 種類 | 形式  | 必須 | 説明          |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
 
 #### レスポンス
 
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | リクエストした作業の識別子 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -2485,14 +1403,320 @@ POST /v1.0/db-instances/{dbInstanceId}/promote
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
+---
+### 現在のDBインスタンスで選択可能なDBバージョンの照会
 
-## DBインスタンス > データベース
+```http
+GET /v1.0/db-instances/{dbInstanceId}/available-db-versions
+```
 
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Get | 現在のDBインスタンスで選択可能なDBバージョンの照会 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| availableDbVersions | Body | Array | DBバージョン情報 |
+| availableDbVersions.dbVersionCode | Body | Enum | DBバージョンコード<br/>- MYSQL_V5633<br/>- MYSQL_V5715<br/>- MYSQL_V5719<br/>- MYSQL_V5726<br/>- MYSQL_V5731<br/>- MYSQL_V5733<br/>- MYSQL_V5737<br/>- MYSQL_V8018<br/>- MYSQL_V8023<br/>- MYSQL_V8028<br/>- MYSQL_V8032<br/>- MYSQL_V8033<br/>- MYSQL_V8034<br/>- MYSQL_V8035<br/>- MYSQL_V8036<br/>- MYSQL_V8040<br/>- MYSQL_V8041<br/>- MYSQL_V8042<br/>- MYSQL_V8043<br/>- MYSQL_V8044<br/>- MYSQL_V8045<br/>- MYSQL_V8405<br/>- MYSQL_V8406<br/>- MYSQL_V8407<br/>- MYSQL_V8408<br/>- MYSQL_V8409<br/>- MARIADB_V10330<br/>- MARIADB_V10611<br/>- MARIADB_V10612<br/>- MARIADB_V10616<br/>- MARIADB_V10622<br/>- MARIADB_V10625<br/>- MARIADB_V101107<br/>- MARIADB_V101108<br/>- MARIADB_V101113<br/>- MARIADB_V101116<br/>- MARIADB_V11407<br/>- MARIADB_V11410<br/>- MARIADB_V11806<br/>- POSTGRESQL_V14_6<br/>- POSTGRESQL_V14_15<br/>- POSTGRESQL_V14_17<br/>- POSTGRESQL_V14_19<br/>- POSTGRESQL_V17_2<br/>- POSTGRESQL_V17_4<br/>- POSTGRESQL_V17_6 |
+| availableDbVersions.dbMajorVersionCode | Body | Enum | DBメジャーバージョンコード<br/>- MYSQL_V56<br/>- MYSQL_V57<br/>- MYSQL_V80<br/>- MYSQL_V84<br/>- MARIADB_V103<br/>- MARIADB_V106<br/>- MARIADB_V1011<br/>- MARIADB_V114<br/>- MARIADB_V118<br/>- POSTGRES_V14<br/>- POSTGRES_V17 |
+| availableDbVersions.name | Body | String | DBバージョン名 |
+| availableDbVersions.canCreate | Body | Boolean | 新規作成可能かどうか |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "availableDbVersions": [
+        {
+            "dbVersionCode": "MYSQL_V5633",
+            "dbMajorVersionCode": "MYSQL_V56",
+            "name": "PostgreSQL V14.6",
+            "canCreate": false
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBインスタンスのバックアップ
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/backup
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Backup | DBインスタンスのバックアップ |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| backupName | Body | String | O | バックアップを識別できる名前 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "backupName": "backupName-example"
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBインスタンスバックアップ情報の照会
+
+```http
+GET /v1.0/db-instances/{dbInstanceId}/backup-info
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Get | DBインスタンスバックアップ情報の照会 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| allowAutoBackup | Body | Boolean | 自動バックアップを許可するかどうか |
+| usePeriodicAutoBackup | Body | Boolean | 予定された自動バックアップを使用するかどうか |
+| backupPeriod | Body | Number | バックアップの保管期間(日) |
+| backupRetryCount | Body | Number | バックアップの再試行回数 |
+| backupSchedules | Body | Array | バックアップスケジュールリスト |
+| backupSchedules.backupWndBgnTime | Body | Time | バックアップ開始時間 |
+| backupSchedules.backupWndDuration | Body | Enum | バックアップWindows<br/>バックアップ開始時間から設定された期間内に自動バックアップが実行されます。<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "allowAutoBackup": false,
+    "usePeriodicAutoBackup": false,
+    "backupPeriod": 1,
+    "backupRetryCount": 1,
+    "backupSchedules": [
+        {
+            "backupWndBgnTime": "00:00:00",
+            "backupWndDuration": "HALF_AN_HOUR"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBインスタンスバックアップ情報の修正
+
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/backup-info
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Modify | DBインスタンスバックアップ情報の修正 |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| allowAutoBackup | Body | Boolean | X | 自動バックアップを許可するかどうか |
+| usePeriodicAutoBackup | Body | Boolean | X | 予定された自動バックアップを使用するかどうか |
+| backupPeriod | Body | Number | X | バックアップの保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| backupRetryCount | Body | Number | X | バックアップの再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| backupSchedules | Body | Array | X | バックアップスケジュールリスト |
+| backupSchedules.backupWndBgnTime | Body | Time | O | バックアップ開始時間 |
+| backupSchedules.backupWndDuration | Body | Enum | O | バックアップWindows<br/>バックアップ開始時間から設定された期間内に自動バックアップが実行されます。<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "allowAutoBackup": false,
+    "usePeriodicAutoBackup": false,
+    "backupPeriod": 0,
+    "backupRetryCount": 0,
+    "backupSchedules": [
+        {
+            "backupWndBgnTime": "00:00:00",
+            "backupWndDuration": "HALF_AN_HOUR"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBインスタンスバックアップ後にオブジェクトストレージへエクスポート
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/backup-to-object-storage
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.BackupToObjectStorage | DBインスタンスバックアップ後にオブジェクトストレージへエクスポート |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| tenantId | Body | String | O | バックアップが保存されるオブジェクトストレージのテナントID<br/>- 最小長さ: `32`<br/>- 最大長さ: `32` |
+| username | Body | String | O | NHN CloudアカウントまたはIAMメンバーID |
+| password | Body | String | O | バックアップが保存されるオブジェクトストレージのAPIパスワード |
+| targetContainer | Body | String | O | バックアップが保存されるオブジェクトストレージのコンテナ |
+| objectPath | Body | String | O | コンテナに保存されるバックアップのパス |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "tenantId": "0123456789abcdef0123456789abcdef",
+    "username": "username-example",
+    "password": "password-example",
+    "targetContainer": "targetContainer-example",
+    "objectPath": "objectPath-example"
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
 ### データベースリスト表示
 
 ```http
@@ -2501,32 +1725,34 @@ GET /v1.0/db-instances/{dbInstanceId}/databases
 
 #### 必要権限
 
-| 権限名                                     | 説明                    |
-|------------------------------------------|------------------------|
-| RDSforPostgreSQL:DbInstanceDatabase.List | DBインスタンス内のデータベースリスト表示 |
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceDatabase.List | データベースリスト表示 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前          | 種類 | 形式  | 必須 | 説明          |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
 
 #### レスポンス
 
-| 名前                          | 種類  | 形式      | 説明                                                                                                                                                 |
-|------------------------------|------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| databases                    | Body | Array    | データベースリスト                                                                                                                                          |
-| databases.databaseId         | Body | UUID     | データベースの識別子                                                                                                                                        |
-| databases.databaseName       | Body | String   | データベース名                                                                                                                                          |
-| databases.databaseStatus     | Body | Enum     | データベースの現在状態<br/>- `STABLE`:作成済み<br/>- `CREATING`:作成中<br/>- `MODIFYING`:修正中<br/>- `SYNCING`:同期中<br/>- `DELETING`:削除中<br/>- `DELETED`:削除済み |
-| databases.createdYmdt        | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                   |
-| databases.updatedYmdt        | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                   |
-| databases.schemas            | Body | Array    | データベース内のスキーマリスト                                                                                                                                    |
-| databases.schemas.schemaName | Body | String   | スキーマ名                                                                                                                                             |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| databases | Body | Array | データベース情報 |
+| databases.databaseId | Body | UUID | データベースの識別子 |
+| databases.databaseName | Body | String | データベース名 |
+| databases.databaseStatus | Body | Enum | データベースの現在状態<br/>- STABLE: `使用可能`<br/>- CREATING: `作成中`<br/>- MODIFYING: `修正中`<br/>- DELETING: `削除中`<br/>- DELETED: `削除済み`<br/>- SYNCING: `同期中`<br/>- DELETE_ERROR: `削除失敗` |
+| databases.createdYmdt | Body | DateTime | 作成日時 |
+| databases.updatedYmdt | Body | DateTime | 修正日時 |
+| databases.schemas | Body | Array | スキーマ情報 |
+| databases.schemas.schemaName | Body | String | スキーマ名 |
+| databases.errorReason | Body | String | 削除失敗の原因 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -2537,21 +1763,26 @@ GET /v1.0/db-instances/{dbInstanceId}/databases
     },
     "databases": [
         {
-            "databaseId": "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4",
-            "databaseName": "database",
+            "databaseId": "550e8400-e29b-41d4-a716-446655440000",
+            "databaseName": "databaseName-example",
             "databaseStatus": "STABLE",
-            "createdYmdt": "2023-03-20T13:37:45+09:00",
-            "updatedYmdt": "2023-03-20T13:37:45+09:00",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00",
             "schemas": [
                 {
-                    "schemaName": "rds"
+                    "schemaName": "schemaName-example"
                 }
-            ]
+            ],
+            "errorReason": "errorReason-example"
         }
     ]
 }
 ```
+
+</p>
 </details>
+
+---
 
 ### データベース作成
 
@@ -2561,33 +1792,37 @@ POST /v1.0/db-instances/{dbInstanceId}/databases
 
 #### 必要権限
 
-| 権限名                                       | 説明                   |
-|--------------------------------------------|-----------------------|
-| RDSforPostgreSQL:DbInstanceDatabase.Create | DBインスタンス内のデータベース作成 |
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceDatabase.Create | データベース作成 |
 
 #### リクエスト
 
-| 名前          | 種類  | 形式    | 必須 | 説明          |
-|--------------|------|--------|----|--------------|
-| dbInstanceId | URL  | UUID   | O  | DBインスタンスの識別子 |
-| databaseName | Body | String | O  | データベース名   |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| databaseName | Body | String | O | データベース名 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
-    "databaseName": "database"
+    "databaseName": "databaseName-example"
 }
 ```
+
+</p>
 </details>
 
 #### レスポンス
 
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | リクエストした作業の識別子 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -2596,60 +1831,14 @@ POST /v1.0/db-instances/{dbInstanceId}/databases
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-### データベースの修正
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/databases/{databaseId}
-```
-
-#### 必要権限
-
-| 権限名                                       | 説明                   |
-|--------------------------------------------|-----------------------|
-| RDSforPostgreSQL:DbInstanceDatabase.Modify | DBインスタンス内のデータベース修正 |
-
-#### リクエスト
-
-| 名前                      | 種類  | 形式     | 必須 | 説明                                                                                         |
-|--------------------------|------|---------|----|---------------------------------------------------------------------------------------------|
-| dbInstanceId             | URL  | UUID    | O  | DBインスタンスの識別子                                                                               |
-| databaseId               | URL  | UUID    | O  | データベースの識別子                                                                                |
-| databaseName             | Body | String  | O  | データベース名                                                                                  |
-| applyHbaRulesImmediately | Body | Boolean | X  | 関連するアクセス制御ルールを即時適用するかどうか<br/>- データベース名変更時、以前のデータベース名で設定されたアクセス制御ルールが存在する場合、変更された名前で反映します。 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "databaseName": "database-1"
-}
-```
-</details>
-
-#### レスポンス
-
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
+---
 
 ### データベース削除
 
@@ -2659,26 +1848,27 @@ DELETE /v1.0/db-instances/{dbInstanceId}/databases/{databaseId}
 
 #### 必要権限
 
-| 権限名                                       | 説明                   |
-|--------------------------------------------|-----------------------|
-| RDSforPostgreSQL:DbInstanceDatabase.Delete | DBインスタンス内のデータベースを削除 |
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceDatabase.Delete | データベース削除 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前          | 種類 | 形式  | 必須 | 説明          |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-| databaseId   | URL | UUID | O  | データベースの識別子 |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| databaseId | URL | UUID | O | データベースの識別子 |
 
 #### レスポンス
 
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | リクエストした作業の識別子 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -2687,13 +1877,73 @@ DELETE /v1.0/db-instances/{dbInstanceId}/databases/{databaseId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-## DBインスタンス > ユーザー
+---
 
+### データベースの修正
+
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/databases/{databaseId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceDatabase.Modify | データベースの修正 |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| databaseId | URL | UUID | O | データベースの識別子 |
+| applyHbaRulesImmediately | Body | Boolean | X | 関連するアクセス制御ルールを即時適用するかどうか<br/>- デフォルト値: `false` |
+| databaseName | Body | String | O | データベース名 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "applyHbaRulesImmediately": false,
+    "databaseName": "databaseName-example"
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
 ### ユーザーリスト表示
 
 ```http
@@ -2702,31 +1952,32 @@ GET /v1.0/db-instances/{dbInstanceId}/db-users
 
 #### 必要権限
 
-| 権限名                                 | 説明                 |
-|--------------------------------------|---------------------|
-| RDSforPostgreSQL:DbInstanceUser.List | DBインスタンス内のユーザーリストを表示 |
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceUser.List | ユーザーリスト表示 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前          | 種類 | 形式  | 必須 | 説明          |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
 
 #### レスポンス
 
-| 名前                   | 種類  | 形式      | 説明                                                                                                                                                 |
-|-----------------------|------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbUsers               | Body | Array    | DBユーザーリスト                                                                                                                                          |
-| dbUsers.dbUserId      | Body | UUID     | DBユーザーの識別子                                                                                                                                        |
-| dbUsers.dbUserName    | Body | String   | DBユーザーアカウント名                                                                                                                                       |
-| dbUsers.authorityType | Body | Enum     | DBユーザー権限タイプ<br/>- `CRUD`:DMLクエリ実行可能な権限<br/>- `DDL`:DDLクエリ実行可能な権限                                                                          |
-| dbUsers.dbUserStatus  | Body | Enum     | DBユーザーの現在状態<br/>- `STABLE`:作成済み<br/>- `CREATING`:作成中<br/>- `MODIFYING`:修正中<br/>- `SYNCING`:同期中<br/>- `DELETING`:削除中<br/>- `DELETED`:削除済み |
-| dbUsers.createdYmdt   | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                   |
-| dbUsers.updatedYmdt   | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                   |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| dbUsers | Body | Array | DBユーザーリスト |
+| dbUsers.dbUserId | Body | UUID | DBユーザーの識別子 |
+| dbUsers.dbUserName | Body | String | DBユーザーアカウント名 |
+| dbUsers.authorityType | Body | Enum | DBユーザー権限タイプ<br/>- CUSTOM: `カスタム権限`<br/>- READ: `READ権限(読み取り専用権限)`<br/>- CRUD: `CRUD権限(読み取り権限を含む)`<br/>- DDL: `DDL権限(CRUD権限を含む)` |
+| dbUsers.dbUserStatus | Body | Enum | DBユーザーの現在状態<br/>- STABLE: `使用可能`<br/>- CREATING: `作成中`<br/>- MODIFYING: `修正中`<br/>- DELETING: `削除中`<br/>- DELETED: `削除済み`<br/>- SYNCING: `同期中`<br/>- DELETE_ERROR: `削除失敗` |
+| dbUsers.createdYmdt | Body | DateTime | 作成日時 |
+| dbUsers.updatedYmdt | Body | DateTime | 修正日時 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -2735,17 +1986,23 @@ GET /v1.0/db-instances/{dbInstanceId}/db-users
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "databases": [
+    "dbUsers": [
         {
-            "databaseId": "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4",
-            "databaseName": "database",
-            "databaseStatus": "STABLE",
-            "createdYmdt": "2023-03-20T13:37:45+09:00"
+            "dbUserId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbUserName": "dbUserName-example",
+            "authorityType": "CUSTOM",
+            "dbUserStatus": "STABLE",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
+
+</p>
 </details>
+
+---
 
 ### ユーザー作成
 
@@ -2755,39 +2012,45 @@ POST /v1.0/db-instances/{dbInstanceId}/db-users
 
 #### 必要権限
 
-| 権限名                                   | 説明                |
-|----------------------------------------|--------------------|
-| RDSforPostgreSQL:DbInstanceUser.Create | DBインスタンス内のユーザー作成 |
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceUser.Create | ユーザー作成 |
 
 #### リクエスト
 
-| 名前                   | 種類  | 形式     | 必須 | 説明                                                                       |
-|-----------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId          | URL  | UUID    | O  | DBインスタンスの識別子                                                             |
-| dbUserName            | Body | String  | O  | DBユーザーアカウント名<br/>- 最小文字数:`1`<br/>- 最大文字数:`20`                           |
-| dbPassword            | Body | String  | O  | DBユーザーアカウントパスワード<br/>- 最小文字数:`1`<br/>- 最大文字数:`100`                          |
-| authorityType         | Body | Enum    | O  | DBユーザー権限タイプ<br/>- `CRUD`:DMLクエリ実行可能な権限<br/>- `DDL`:DDLクエリ実行可能な権限 |
-| createDefaultHbaRules | Body | Boolean | X  | 基本アクセス制御ルールの作成可否                                                          |
-| address               | Body | String  | X  | 基本アクセス制御ルール作成時に使用する接続アドレス                                               |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbUserName | Body | String | O | DBユーザーアカウント名 |
+| dbPassword | Body | String | O | DBユーザーアカウントパスワード |
+| authorityType | Body | Enum | O | DBユーザー権限タイプ<br/>- CUSTOM: `カスタム権限`<br/>- READ: `読み取り権限`<br/>- CRUD: `CRUD権限`<br/>- DDL: `DDL権限` |
+| createDefaultHbaRules | Body | Boolean | X | 基本アクセス制御ルールの作成可否<br/>- デフォルト値: `false` |
+| address | Body | String | X | 接続アドレス |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "authorityType": "CRUD"
+    "dbUserName": "dbUserName-example",
+    "dbPassword": "dbPassword-example",
+    "authorityType": "CUSTOM",
+    "createDefaultHbaRules": false,
+    "address": "address-example"
 }
 ```
+
+</p>
 </details>
 
 #### レスポンス
 
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | リクエストした作業の識別子 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -2796,63 +2059,14 @@ POST /v1.0/db-instances/{dbInstanceId}/db-users
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-### ユーザー修正
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
-```
-
-#### 必要権限
-
-| 権限名                                   | 説明                |
-|----------------------------------------|--------------------|
-| RDSforPostgreSQL:DbInstanceUser.Modify | DBインスタンス内のユーザー修正 |
-
-#### リクエスト
-
-| 名前                      | 種類  | 形式     | 必須 | 説明                                                                                         |
-|--------------------------|------|---------|----|---------------------------------------------------------------------------------------------|
-| dbInstanceId             | URL  | UUID    | O  | DBインスタンスの識別子                                                                               |
-| dbUserId                 | URL  | UUID    | O  | DBユーザーの識別子                                                                                |
-| dbUserName               | Body | String  | X  | DBユーザーアカウント名<br/>- 最小文字数:`1`<br/>- 最大文字数:`20`                                             |
-| dbPassword               | Body | String  | X  | DBユーザーアカウントパスワード<br/>- 最小文字数:`1`<br/>- 最大文字数:`100`                                            |
-| authorityType            | Body | Enum    | X  | DBユーザー権限タイプ<br/>- `CRUD`:DMLクエリ実行可能な権限<br/>- `DDL`:DDLクエリ実行可能な権限                  |
-| applyHbaRulesImmediately | Body | Boolean | X  | 関連するアクセス制御ルールを即時適用するかどうか<br/>- ユーザーアカウント名変更時に以前のユーザーアカウント名で設定されたアクセス制御ルールが存在する場合、変更された名前で反映します。 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "dbUserName": "db-user-1",
-    "dbPassword": "new-password"
-}
-```
-</details>
-
-#### レスポンス
-
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
+---
 
 ### ユーザー削除
 
@@ -2862,26 +2076,27 @@ DELETE /v1.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
 
 #### 必要権限
 
-| 権限名                                   | 説明                |
-|----------------------------------------|--------------------|
-| RDSforPostgreSQL:DbInstanceUser.Delete | DBインスタンス内のユーザー削除 |
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceUser.Delete | ユーザー削除 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前          | 種類 | 形式  | 必須 | 説明          |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-| dbUserId     | URL | UUID | O  | DBユーザーの識別子 |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbUserId | URL | UUID | O | ユーザーの識別子 |
 
 #### レスポンス
 
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | リクエストした作業の識別子 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -2890,13 +2105,140 @@ DELETE /v1.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-## DBインスタンス > アクセス制御
+---
 
+### ユーザー修正
+
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceUser.Modify | ユーザー修正 |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbUserId | URL | UUID | O | ユーザーの識別子 |
+| dbUserName | Body | String | X | DBユーザーアカウント名 |
+| dbPassword | Body | String | X | DBユーザーアカウントパスワード |
+| authorityType | Body | Enum | X | DBユーザー権限<br/>- CUSTOM: `カスタム権限`<br/>- READ: `読み取り権限`<br/>- CRUD: `CRUD権限`<br/>- DDL: `DDL権限` |
+| applyHbaRulesImmediately | Body | Boolean | X | アクセス制御変更事項の即時適用可否<br/>- デフォルト値: `false` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "dbUserName": "dbUserName-example",
+    "dbPassword": "dbPassword-example",
+    "authorityType": "CUSTOM",
+    "applyHbaRulesImmediately": false
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBインスタンス削除保護設定の変更
+
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/deletion-protection
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Modify | DBインスタンス削除保護設定の変更 |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| useDeletionProtection | Body | Boolean | O | 削除保護の有無 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "useDeletionProtection": false
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
+
+### DBインスタンスの強制再起動
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/force-restart
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.ForceRestart | DBインスタンスの強制再起動 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
 ### アクセス制御ルールリストを表示
 
 ```http
@@ -2905,41 +2247,42 @@ GET /v1.0/db-instances/{dbInstanceId}/hba-rules
 
 #### 必要権限
 
-| 権限名                                | 説明                      |
-|-------------------------------------|--------------------------|
-| RDSforPostgreSQL:DbInstanceHba.List | DBインスタンス内のアクセス制御ルールリストを表示 |
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceHba.List | アクセス制御ルールリストを表示 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前          | 種類 | 形式  | 必須 | 説明          |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
 
 #### レスポンス
 
-| 名前                             | 種類  | 形式     | 説明                                                                                                                                                  |
-|---------------------------------|------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------|
-| hbaRules                        | Body | Array   | アクセス制御ルールリスト                                                                                                                                         |
-| hbaRules.hbaRuleId              | Body | UUID    | アクセス制御ルールの識別子                                                                                                                                       |
-| hbaRules.hbaRuleStatus          | Body | Enum    | アクセス制御ルールの現在状態<br/>- `CREATED`:作成済み<br/>- `APPLIED`:適用済み<br/>- `CREATING`:作成中<br/>- `MODIFYING`:修正中<br/>- `DELETING`:削除中<br/>- `DELETED`:削除済み |
-| hbaRules.databaseApplyType      | Body | String  | データベースルールの適用方式<br/>- `ENTIRE`:全体<br/>- `USER_CUSTOM`:ユーザー指定                                                                                      |
-| hbaRules.dbUserApplyType        | Body | Enum    | DBユーザールールの適用方式<br/>- `ENTIRE`:全体<br/>- `USER_CUSTOM`:ユーザー指定                                                                                      |
-| hbaRules.databases              | Body | Array   | ユーザー指定のデータベースリスト                                                                                                                                    |
-| hbaRules.databases.databaseId   | Body | UUID    | ユーザー指定のデータベースの識別子                                                                                                                                  |
-| hbaRules.databases.databaseName | Body | String  | ユーザー指定のデータベース名                                                                                                                                    |
-| hbaRules.dbUsers                | Body | Array   | ユーザー指定のDBユーザーリスト                                                                                                                                    |
-| hbaRules.dbUsers.dbUserId       | Body | UUID    | ユーザー指定のDBユーザーの識別子                                                                                                                                  |
-| hbaRules.dbUsers.dbUserName     | Body | String  | ユーザー指定のDBユーザーアカウント名                                                                                                                                 |
-| hbaRules.address                | Body | String  | 接続アドレス                                                                                                                                               |
-| hbaRules.authMethod             | Body | Enum    | 認証方式<br/>- `TRUST`:トラスト(パスワード不要)<br/>- `REJECT`:接続ブロック<br/>- `SCRAM_SHA_256`:パスワード(SCRAM-SHA-256)                                                 |
-| hbaRules.reservedAction         | Body | Enum    | 予約作業<br/>- `NONE`:なし<br/>- `CREATE`:作成予約(適用必要)<br/>- `MODIFY`:修正予約(適用必要)<br/>- `DELETE`:削除予約(適用必要)                                        |
-| hbaRules.order                  | Body | Number  | 適用順序                                                                                                                                               |
-| hbaRules.applicable             | Body | Boolean | 適用可否<br/>- 適用不可状態のルールは無視される                                                                                                                     |
-| needToApply                     | Body | Boolean | 変更内容の適用が必要かどうか                                                                                                                                       |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| hbaRules | Body | Array | アクセス制御ルールリスト |
+| hbaRules.hbaRuleId | Body | UUID | アクセス制御ルールの識別子 |
+| hbaRules.hbaRuleStatus | Body | Enum | アクセス制御ルールの現在状態<br/>- CREATED: `作成済み`<br/>- APPLIED: `適用済み`<br/>- CREATING: `作成中`<br/>- MODIFYING: `修正中`<br/>- DELETING: `削除中`<br/>- DELETED: `削除済み` |
+| hbaRules.databaseApplyType | Body | Enum | データベース適用タイプ<br/>- ENTIRE: `全体`<br/>- USER_CUSTOM: `ユーザー指定` |
+| hbaRules.dbUserApplyTypeCode | Body | Enum | DBユーザー適用タイプ<br/>- ENTIRE: `全体`<br/>- USER_CUSTOM: `ユーザー指定` |
+| hbaRules.databases | Body | Array | ユーザー指定のデータベースリスト |
+| hbaRules.databases.databaseId | Body | UUID | データベースID |
+| hbaRules.databases.databaseName | Body | String | データベース名 |
+| hbaRules.dbUsers | Body | Array | ユーザー指定のDBユーザーリスト |
+| hbaRules.dbUsers.dbUserId | Body | UUID | DBユーザーID |
+| hbaRules.dbUsers.dbUserName | Body | String | DBユーザー名 |
+| hbaRules.address | Body | String | 接続アドレス |
+| hbaRules.authMethod | Body | Enum | 認証方式<br/>- TRUST: `トラスト(パスワード不要)`<br/>- REJECT: `接続ブロック`<br/>- SCRAM_SHA_256: `パスワード(SCRAM-SHA-256)` |
+| hbaRules.reservedAction | Body | Enum | 予約作業<br/>- NONE: `なし`<br/>- CREATE: `作成予約(適用必要)`<br/>- MODIFY: `修正予約(適用必要)`<br/>- DELETE: `削除予約(適用必要)` |
+| hbaRules.order | Body | Number | 適用順序 |
+| hbaRules.applicable | Body | Boolean | 適用可否 |
+| needToApply | Body | Boolean | 変更の適用要否 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -2950,27 +2293,37 @@ GET /v1.0/db-instances/{dbInstanceId}/hba-rules
     },
     "hbaRules": [
         {
-            "hbaRuleId": "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4",
-            "hbaRuleStatus": "APPLIED",
-            "databaseApplyType": "USER_CUSTOM",
-            "dbUserApplyType": "ENTIRE",
+            "hbaRuleId": "550e8400-e29b-41d4-a716-446655440000",
+            "hbaRuleStatus": "CREATED",
+            "databaseApplyType": "ENTIRE",
+            "dbUserApplyTypeCode": "ENTIRE",
             "databases": [
                 {
-                    "databaseId": "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4",
-                    "databaseName": "database"
+                    "databaseId": "550e8400-e29b-41d4-a716-446655440000",
+                    "databaseName": "databaseName-example"
                 }
             ],
-            "dbUsers": [],
-            "address": "0.0.0.0/0",
+            "dbUsers": [
+                {
+                    "dbUserId": "550e8400-e29b-41d4-a716-446655440000",
+                    "dbUserName": "dbUserName-example"
+                }
+            ],
+            "address": "address-example",
             "authMethod": "TRUST",
             "reservedAction": "NONE",
-            "order": 0,
-            "applicable": true
+            "order": 1,
+            "applicable": false
         }
-    ]
+    ],
+    "needToApply": false
 }
 ```
+
+</p>
 </details>
+
+---
 
 ### アクセス制御ルールの追加
 
@@ -2980,45 +2333,49 @@ POST /v1.0/db-instances/{dbInstanceId}/hba-rules
 
 #### 必要権限
 
-| 権限名                                  | 説明                     |
-|---------------------------------------|-------------------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:DbInstanceHba.Create | DBインスタンス内のアクセス制御ルール追加 |
 
 #### リクエスト
 
-| 名前               | 種類  | 形式    | 必須 | 説明                                                                                                  |
-|-------------------|------|--------|----|------------------------------------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID   | O  | DBインスタンスの識別子                                                                                        |
-| databaseApplyType | Body | String | O  | データベースルール適用方式<br/>- `ENTIRE`:全体<br/>- `USER_CUSTOM`:ユーザー指定                                      |
-| dbUserApplyType   | Body | Enum   | O  | DBユーザールール適用方式<br/>- `ENTIRE`:全体<br/>- `USER_CUSTOM`:ユーザー指定                                      |
-| databaseIds       | Body | Array  | X  | ユーザー指定のデータベースの識別子リスト                                                                               |
-| dbUserIds         | Body | Array  | X  | ユーザー指定のDBユーザーの識別子リスト                                                                               |
-| address           | Body | String | O  | 接続アドレス<br/>- CIDR形式、ホスト名またはドメイン形式で入力                                                            |
-| authMethod        | Body | Enum   | O  | 認証方式<br/>- `TRUST`:トラスト(パスワード不要)<br/>- `REJECT`:接続ブロック<br/>- `SCRAM_SHA_256`:パスワード(SCRAM-SHA-256) |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| connectionTypeCode | Body | Enum | X | アクセス制御レコードタイプ<br/>- HOST: `TCP/IP接続時に有効`<br/>- HOST_NO_SSL: `SSL暗号化を使用しない接続時のみ有効` |
+| databaseApplyType | Body | Enum | O | データベース適用タイプ<br/>- ENTIRE: `全体`<br/>- USER_CUSTOM: `ユーザー指定` |
+| dbUserApplyType | Body | Enum | O | DBユーザー適用タイプ<br/>- ENTIRE: `全体`<br/>- USER_CUSTOM: `ユーザー指定` |
+| databaseIds | Body | Array | X | データベースの識別子リスト |
+| dbUserIds | Body | Array | X | DBユーザーの識別子リスト |
+| address | Body | String | O | 接続アドレス |
+| authMethod | Body | Enum | O | 認証方式<br/>- TRUST: `トラスト(パスワード不要)`<br/>- REJECT: `接続ブロック`<br/>- SCRAM_SHA_256: `パスワード(SCRAM-SHA-256)` |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
+    "connectionTypeCode": "HOST",
     "databaseApplyType": "ENTIRE",
-    "dbUserApplyType": "USER_CUSTOM",
-    "databaseIds": [], 
-    "dbUserIds": [
-        "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4"
-    ],
-    "address": "0.0.0.0/0",
+    "dbUserApplyType": "ENTIRE",
+    "databaseIds": [],
+    "dbUserIds": [],
+    "address": "address-example",
     "authMethod": "TRUST"
 }
 ```
+
+</p>
 </details>
 
 #### レスポンス
 
-| 名前       | 種類  | 形式  | 説明           |
-|-----------|------|------|---------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | hbaRuleId | Body | UUID | アクセス制御ルールの識別子 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -3027,151 +2384,14 @@ POST /v1.0/db-instances/{dbInstanceId}/hba-rules
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "hbaRuleId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "hbaRuleId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-### アクセス制御ルールの修正
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/hba-rules/{hbaRuleId}
-```
-
-#### 必要権限
-
-| 権限名                                  | 説明                     |
-|---------------------------------------|-------------------------|
-| RDSforPostgreSQL:DbInstanceHba.Modify | DBインスタンス内のアクセス制御ルール修正 |
-
-#### リクエスト
-
-| 名前               | 種類  | 形式    | 必須 | 説明                                                                                                  |
-|-------------------|------|--------|----|------------------------------------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID   | O  | DBインスタンスの識別子                                                                                        |
-| hbaRuleId         | URL  | UUID   | O  | アクセス制御ルールの識別子                                                                                       |
-| databaseApplyType | Body | String | O  | データベースルールの適用方式<br/>- `ENTIRE`:全体<br/>- `USER_CUSTOM`:ユーザー指定                                      |
-| dbUserApplyType   | Body | Enum   | O  | DBユーザールールの適用方式<br/>- `ENTIRE`:全体<br/>- `USER_CUSTOM`:ユーザー指定                                      |
-| databaseIds       | Body | Array  | X  | ユーザー指定のデータベースの識別子リスト                                                                               |
-| dbUserIds         | Body | Array  | X  | ユーザー指定のDBユーザーの識別子リスト                                                                               |
-| address           | Body | String | O  | 接続アドレス<br/>- CIDR形式、ホスト名またはドメイン形式で入力                                                            |
-| authMethod        | Body | Enum   | O  | 認証方式<br/>- `TRUST`:トラスト(パスワード不要)<br/>- `REJECT`:接続ブロック<br/>- `SCRAM_SHA_256`:パスワード(SCRAM-SHA-256) |
-
-<details><summary>例</summary>
-
-```json
-{
-    "databaseApplyType": "ENTIRE",
-    "dbUserApplyType": "ENTIRE",
-    "databaseIds": [], 
-    "dbUserIds": [],
-    "address": "0.0.0.0/0",
-    "authMethod": "REJECT"
-}
-```
-</details>
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
-
-### アクセス制御ルールの削除
-
-```http
-DELETE /v1.0/db-instances/{dbInstanceId}/hba-rules/{hbaRuleId}
-```
-
-#### 必要権限
-
-| 権限名                                  | 説明                     |
-|---------------------------------------|-------------------------|
-| RDSforPostgreSQL:DbInstanceHba.Delete | DBインスタンス内のアクセス制御ルール削除 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前          | 種類 | 形式  | 必須 | 説明           |
-|--------------|-----|------|----|---------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-| hbaRuleId    | URL | UUID | O  | アクセス制御ルールの識別子 |
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
-
-### アクセス制御ルールの順序調整
-
-```http
-PUT /v1.0/db-instances/{dbInstanceId}/hba-rules/orders
-```
-
-#### 必要権限
-
-| 権限名                                  | 説明                     |
-|---------------------------------------|-------------------------|
-| RDSforPostgreSQL:DbInstanceHba.Modify | DBインスタンス内のアクセス制御ルール修正 |
-
-#### リクエスト
-
-| 名前          | 種類 | 形式  | 必須 | 説明                                 |
-|--------------|-----|------|----|-------------------------------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子                       |
-| hbaRuleIds   | URL | Body | O  | アクセス制御ルールの識別子リスト<br/>- リクエストした順序どおりに調整 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "hbaRuleIds": [
-        "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4"
-    ]
-}
-```
-</details>
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
+---
 
 ### アクセス制御ルールを適用
 
@@ -3181,25 +2401,26 @@ POST /v1.0/db-instances/{dbInstanceId}/hba-rules/apply
 
 #### 必要権限
 
-| 権限名                                  | 説明          |
-|---------------------------------------|--------------|
-| RDSforPostgreSQL:DbInstance.Modify    | DBインスタンスの修正 |
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Modify | DBインスタンスの修正 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前          | 種類 | 形式  | 必須 | 説明          |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
 
 #### レスポンス
 
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | リクエストした作業の識別子 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -3208,12 +2429,1239 @@ POST /v1.0/db-instances/{dbInstanceId}/hba-rules/apply
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
+---
+
+### アクセス制御ルールの順序調整
+
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/hba-rules/orders
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceHba.Modify | DBインスタンス内のアクセス制御ルール修正 |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| hbaRuleIds | Body | Array | O | 整列されたアクセス制御ルールIDリスト(リクエストした順序どおりに保存) |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "hbaRuleIds": []
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
+
+### アクセス制御ルールの削除
+
+```http
+DELETE /v1.0/db-instances/{dbInstanceId}/hba-rules/{hbaRuleId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceHba.Delete | DBインスタンス内のアクセス制御ルール削除 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| hbaRuleId | URL | UUID | O | アクセス制御ルールの識別子 |
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
+
+### アクセス制御ルールの修正
+
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/hba-rules/{hbaRuleId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstanceHba.Modify | DBインスタンス内のアクセス制御ルール修正 |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| hbaRuleId | URL | UUID | O | アクセス制御ルールの識別子 |
+| connectionTypeCode | Body | Enum | X | アクセス制御レコードタイプ<br/>- HOST: `TCP/IP接続時に有効`<br/>- HOST_NO_SSL: `SSL暗号化を使用しない接続時のみ有効` |
+| databaseApplyType | Body | Enum | O | データベース適用タイプ<br/>- ENTIRE: `全体`<br/>- USER_CUSTOM: `ユーザー指定` |
+| dbUserApplyType | Body | Enum | O | DBユーザー適用タイプ<br/>- ENTIRE: `全体`<br/>- USER_CUSTOM: `ユーザー指定` |
+| databaseIds | Body | Array | X | データベースの識別子リスト |
+| dbUserIds | Body | Array | X | DBユーザーの識別子リスト |
+| address | Body | String | O | 接続アドレス |
+| authMethod | Body | Enum | O | 認証方式<br/>- TRUST: `トラスト(パスワード不要)`<br/>- REJECT: `接続ブロック`<br/>- SCRAM_SHA_256: `パスワード(SCRAM-SHA-256)` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "connectionTypeCode": "HOST",
+    "databaseApplyType": "ENTIRE",
+    "dbUserApplyType": "ENTIRE",
+    "databaseIds": [],
+    "dbUserIds": [],
+    "address": "address-example",
+    "authMethod": "TRUST"
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
+### 高可用性情報の照会
+
+```http
+GET /v1.0/db-instances/{dbInstanceId}/high-availability
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:HighAvailability.Get | 高可用性情報照会 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| haStatus | Body | Enum | 高可用性状態<br/>- CREATED: `作成済み`<br/>- STABLE: `正常`<br/>- PAUSING: `一時停止中`<br/>- DISABLE: `停止`<br/>- DISABLE_MASTER_IN_REPLICATION: `マスター異常複製検知による高可用性停止`<br/>- DISABLE_MHA_PROCESS: `高可用性プロセス停止`<br/>- DISABLE_REPLICATION_STOP: `複製停止による高可用性停止`<br/>- DISABLE_REPLICATION_DELAY: `複製遅延による高可用性停止`<br/>- FAILOVER_STARTED: `フェイルオーバー開始`<br/>- FAILOVER_FAILED: `フェイルオーバー失敗`<br/>- FAILOVER_COMPLETED: `フェイルオーバー完了`<br/>- DELETED: `削除済み`<br/>- PAUSED: `一時停止`<br/>- PAUSED_DUE_TO_TASK: `作業による一時停止`<br/>- MASTER_FAILURE_DETECTION: `マスター障害検知` |
+| pingInterval | Body | Number | Ping間隔(秒) |
+| failoverReplWaitingTime | Body | Number | フェイルオーバー複製遅延待機時間(秒) |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "haStatus": "CREATED",
+    "pingInterval": 1,
+    "failoverReplWaitingTime": 1
+}
+```
+
+</p>
+</details>
+
+---
+
+### 高可用性を修正する
+
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/high-availability
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:HighAvailability.Modify | 高可用性を修正する |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| useHighAvailability | Body | Boolean | O | 高可用性の使用有無 |
+| pingInterval | Body | Number | X | Ping間隔(秒)<br/>- 最小値: `1`<br/>- 最大値: `600` |
+| failoverReplWaitingTime | Body | Number | X | フェイルオーバー複製遅延待機時間(秒)<br/>- 最小値: `-1` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "useHighAvailability": false,
+    "pingInterval": 1,
+    "failoverReplWaitingTime": 1
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 高可用性の一時停止
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/high-availability/pause
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:HighAvailability.Pause | 高可用性の一時停止 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 高可用性の復旧
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/high-availability/repair
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:HighAvailability.Repair | 高可用性の復旧 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 高可用性の再起動
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/high-availability/resume
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:HighAvailability.Resume | 高可用性の再起動 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 高可用性の分離
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/high-availability/split
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:HighAvailability.Split | 高可用性の分離 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+### DBインスタンスメンテナンス情報照会
+
+```http
+GET /v1.0/db-instances/{dbInstanceId}/maintenance-info
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Get | DBインスタンスメンテナンス情報照会 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| allowAutoMaintenance | Body | Boolean | 自動メンテナンスを許可するかどうか |
+| useAutoStorageCleanup | Body | Boolean | 自動ストレージクリーンアップを使用するかどうか |
+| maintWndBgnTime | Body | Time | 自動メンテナンス開始時間 |
+| maintWndDuration | Body | Enum | メンテナンス期間<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+| logRetentionPeriod | Body | Number | ログ保管期間(日) |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "allowAutoMaintenance": false,
+    "useAutoStorageCleanup": false,
+    "maintWndBgnTime": "00:00:00",
+    "maintWndDuration": "HALF_AN_HOUR",
+    "logRetentionPeriod": 1
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBインスタンスメンテナンス情報修正
+
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/maintenance-info
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Modify | DBインスタンスメンテナンス情報修正 |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| allowAutoMaintenance | Body | Boolean | X | 自動メンテナンスを許可するかどうか |
+| useAutoStorageCleanup | Body | Boolean | X | 自動ストレージクリーンアップを使用するかどうか |
+| maintWndBgnTime | Body | Time | X | 自動メンテナンス開始時間 |
+| maintWndDuration | Body | Enum | X | メンテナンス期間<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+| logRetentionPeriod | Body | Number | X | ログ保管期間(日)<br/>- 最小値: `1`<br/>- 最大値: `30` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "allowAutoMaintenance": false,
+    "useAutoStorageCleanup": false,
+    "maintWndBgnTime": "00:00:00",
+    "maintWndDuration": "HALF_AN_HOUR",
+    "logRetentionPeriod": 1
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+### DBインスタンスネットワーク情報の照会
+
+```http
+GET /v1.0/db-instances/{dbInstanceId}/network-info
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Get | DBインスタンスネットワーク情報の照会 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| availabilityZone | Body | Enum | DBインスタンスを作成するアベイラビリティゾーン |
+| subnet | Body | Object | サブネットオブジェクト |
+| subnet.subnetId | Body | UUID | サブネットの識別子 |
+| subnet.subnetName | Body | String | サブネットを識別できる名前 |
+| subnet.subnetCidr | Body | String | サブネットのCIDR |
+| subnet.publicAccessible | Body | Boolean | 外部接続可否 |
+| endPoints | Body | Array | 接続情報リスト |
+| endPoints.domain | Body | String | ドメイン |
+| endPoints.ipAddress | Body | String | IPアドレス |
+| endPoints.endPointType | Body | String | 接続情報タイプ |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "availabilityZone": "kr-pub-a",
+    "subnet": {
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "subnetName": "subnetName-example",
+        "subnetCidr": "192.168.0.0/24",
+        "publicAccessible": false
+    },
+    "endPoints": [
+        {
+            "domain": "domain-example",
+            "ipAddress": "192.168.0.1",
+            "endPointType": "https://example.com"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBインスタンスネットワーク情報の修正
+
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/network-info
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Modify | DBインスタンスネットワーク情報の修正 |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| usePublicAccess | Body | Boolean | O | 外部接続可否 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "usePublicAccess": false
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBインスタンスの昇格
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/promote
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Promote | DBインスタンスの昇格 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+### リードレプリカの作成
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/replicate
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Replicate | リードレプリカの作成 |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceName | Body | String | O | DBインスタンスを識別できる名前 |
+| description | Body | String | X | DBインスタンスの追加情報 |
+| dbFlavorId | Body | UUID | X | DBインスタンス仕様の識別子 |
+| dbPort | Body | Number | X | DBポート<br/>- 最小値: 5432、最大値: 45432 |
+| parameterGroupId | Body | UUID | X | パラメータグループの識別子 |
+| dbSecurityGroupIds | Body | Array | X | DBセキュリティグループの識別子リスト |
+| userGroupIds | Body | Array | X | ユーザーグループの識別子リスト |
+| useDefaultNotification | Body | Boolean | X | 基本通知の使用有無<br/>- デフォルト値: `false` |
+| useDeletionProtection | Body | Boolean | X | 削除保護の有無<br/>- デフォルト値: `false` |
+| network | Body | Object | X | ネットワーク情報オブジェクト |
+| network.usePublicAccess | Body | Boolean | X | 外部接続可否<br/>- デフォルト値: `false` |
+| network.availabilityZone | Body | Enum | X | DBインスタンスを作成するアベイラビリティゾーン |
+| storage | Body | Object | X | ストレージ情報オブジェクト |
+| storage.storageType | Body | Enum | X | データストレージタイプ |
+| storage.storageSize | Body | Number | X | データストレージサイズ(GB)<br/>- 最小値: `20`<br/>- 最大値: `2048` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName-example",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useDefaultNotification": false,
+    "useDeletionProtection": false,
+    "network": {
+        "usePublicAccess": false,
+        "availabilityZone": "kr-pub-a"
+    },
+    "storage": {
+        "storageType": "General SSD",
+        "storageSize": 20
+    }
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBインスタンスの再起動
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/restart
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Restart | DBインスタンスの再起動 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBインスタンス復元情報の照会
+
+```http
+GET /v1.0/db-instances/{dbInstanceId}/restoration-info
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Get | DBインスタンス復元情報の照会 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| oldestRestorableYmdt | Body | DateTime | 最も古い復元可能時間 |
+| latestRestorableYmdt | Body | DateTime | 最も最新の復元可能時間 |
+| restorableBackups | Body | Array | 復元可能なバックアップリスト |
+| restorableBackups.backupId | Body | UUID | バックアップの識別子 |
+| restorableBackups.backupName | Body | String | バックアップ名 |
+| restorableBackups.backupStatus | Body | Enum | バックアップ状態<br/>- BACKING_UP: `バックアップ中(スピナー)`<br/>- VERIFYING: `検証中(スピナー)`<br/>- COMPLETED: `使用可能(緑色アイコン)`<br/>- DELETING: `削除中(スピナー)`<br/>- DELETED: `削除済み(グレーアイコン)`<br/>- ERROR: `エラー(赤色アイコン)` |
+| restorableBackups.dbInstanceId | Body | UUID | 原本DBインスタンスの識別子 |
+| restorableBackups.dbInstanceName | Body | String | 原本DBインスタンス名 |
+| restorableBackups.dbVersion | Body | Enum | DBエンジンタイプ |
+| restorableBackups.backupType | Body | Enum | バックアップタイプ<br/>- AUTO<br/>- MANUAL |
+| restorableBackups.backupSize | Body | Number | バックアップサイズ |
+| restorableBackups.failoverCount | Body | Number | フェイルオーバー回数 |
+| restorableBackups.walFileName | Body | String | WALファイル名 |
+| restorableBackups.createdYmdt | Body | DateTime | バックアップ作成日時 |
+| restorableBackups.updatedYmdt | Body | DateTime | バックアップ更新日時 |
+| restorableBackups.startYmdt | Body | DateTime | バックアップ開始日時 |
+| restorableBackups.completedYmdt | Body | DateTime | バックアップ完了日時 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "oldestRestorableYmdt": "2023-12-31T15:00:00+09:00",
+    "latestRestorableYmdt": "2023-12-31T15:00:00+09:00",
+    "restorableBackups": [
+        {
+            "backupId": "550e8400-e29b-41d4-a716-446655440000",
+            "backupName": "backupName-example",
+            "backupStatus": "BACKING_UP",
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbInstanceName": "dbInstanceName-example",
+            "dbVersion": "POSTGRESQL_V14_17",
+            "backupType": "AUTO",
+            "backupSize": 1,
+            "failoverCount": 1,
+            "walFileName": "walFileName-example",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00",
+            "startYmdt": "2023-12-31T15:00:00+09:00",
+            "completedYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBインスタンスの復元
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/restore
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Restore | DBインスタンスの復元 |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceName | Body | String | X | DBインスタンスを識別できる名前 |
+| dbInstanceCandidateName | Body | String | X | DBインスタンスを識別できる予備マスター名 |
+| description | Body | String | X | DBインスタンスの追加情報<br/>- 最大長: `100` |
+| dbFlavorId | Body | UUID | O | DBインスタンス仕様の識別子 |
+| dbPort | Body | Number | X | DBポート<br/>- 最小値: 5432、最大値: 45432 |
+| useHighAvailability | Body | Boolean | X | 高可用性の使用有無<br/>- デフォルト値: `false` |
+| imageId | Body | UUID | X | イメージの識別子 |
+| pingInterval | Body | Number | X | 高可用性使用時のPing間隔(秒)<br/>- 最小値: `1`<br/>- 最大値: `600` |
+| failoverReplWaitingTime | Body | Number | X | フェイルオーバー複製遅延待機時間(秒)<br/>- 最小値: `-1` |
+| storage | Body | Object | O | ストレージ情報オブジェクト |
+| storage.storageType | Body | Enum | O | ストレージタイプ |
+| storage.storageSize | Body | Number | O | データストレージサイズ(GB)<br/>- 最小値: `20` |
+| network | Body | Object | O | ネットワーク情報オブジェクト |
+| network.subnetId | Body | UUID | O | サブネットの識別子 |
+| network.usePublicAccess | Body | Boolean | X | 外部接続可否<br/>- デフォルト値: `false` |
+| network.availabilityZone | Body | Enum | X | DBインスタンスを作成するアベイラビリティゾーン |
+| backup | Body | Object | O | バックアップ情報オブジェクト |
+| backup.backupPeriod | Body | Number | O | バックアップの保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| backup.backupRetryCount | Body | Number | X | バックアップの再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| backup.replicationRegion | Body | Enum | X | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)`<br/>- KR2: `韓国(ピョンチョン)` |
+| backup.backupSchedules | Body | Array | O | バックアップスケジュールリスト |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | O | バックアップ開始時刻 |
+| backup.backupSchedules.backupWndDuration | Body | Enum | O | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+| restore | Body | Object | O | 復元情報オブジェクト |
+| restore.restoreType | Body | Enum | O | 復元タイプ<br/>- BACKUP: `既存のバックアップを利用した復元`<br/>- TIMESTAMP: `復元可能時間内の時間を利用した時点復元` |
+| restore.restoreYmdt | Body | DateTime | X | DBインスタンス復元日時 |
+| restore.backupId | Body | UUID | X | 復元に使用するバックアップの識別子 |
+| useDefaultNotification | Body | Boolean | X | 基本通知の使用有無<br/>- デフォルト値: `false` |
+| parameterGroupId | Body | UUID | O | パラメータグループの識別子 |
+| dbSecurityGroupIds | Body | Array | X | DBセキュリティグループの識別子リスト |
+| userGroupIds | Body | Array | X | ユーザーグループの識別子リスト |
+| useDeletionProtection | Body | Boolean | X | 削除保護の有無<br/>- デフォルト値: `false` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName-example",
+    "dbInstanceCandidateName": "dbInstanceCandidateName-example",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "useHighAvailability": false,
+    "imageId": "550e8400-e29b-41d4-a716-446655440000",
+    "pingInterval": 3,
+    "failoverReplWaitingTime": 60,
+    "storage": {
+        "storageType": "General SSD",
+        "storageSize": 20
+    },
+    "network": {
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
+        "availabilityZone": "kr-pub-a"
+    },
+    "backup": {
+        "backupPeriod": 0,
+        "backupRetryCount": 0,
+        "replicationRegion": "KR1",
+        "backupSchedules": [
+            {
+                "backupWndBgnTime": "00:00:00",
+                "backupWndDuration": "HALF_AN_HOUR"
+            }
+        ]
+    },
+    "restore": {
+        "restoreType": "BACKUP",
+        "restoreYmdt": "2023-12-31T15:00:00+09:00",
+        "backupId": "550e8400-e29b-41d4-a716-446655440000"
+    },
+    "useDefaultNotification": false,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useDeletionProtection": false
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+### DBインスタンス開始
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/start
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Start | DBインスタンス開始 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBインスタンス停止
+
+```http
+POST /v1.0/db-instances/{dbInstanceId}/stop
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Stop | DBインスタンスを停止する |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBインスタンスストレージ情報の照会
+
+```http
+GET /v1.0/db-instances/{dbInstanceId}/storage-info
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Get | DBインスタンスストレージ情報の照会 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| storageType | Body | Enum | データストレージタイプ |
+| storageSize | Body | Number | データストレージサイズ(GB) |
+| storageStatus | Body | Enum | データストレージの現在状態<br/>- DELETED: `削除済み`<br/>- PENDING_DELETION: `削除猶予中`<br/>- DELETION_RESERVED: `削除予約済み（スナップショット整理待ち）`<br/>- DETACHED: `デタッチ`<br/>- ATTACHED: `アタッチ` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "storageType": "General SSD",
+    "storageSize": 1,
+    "storageStatus": "DELETED"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBインスタンスストレージ情報の修正
+
+```http
+PUT /v1.0/db-instances/{dbInstanceId}/storage-info
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:DbInstance.Modify | DBインスタンスストレージ情報の修正 |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| storageSize | Body | Number | O | データストレージサイズ(GB)<br/>- 最大値:`2048` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "storageSize": 1
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
 ## バックアップ
+
+### バックアップ状態
+
+| 状態           | 説明                   |
+|--------------|----------------------|
+| `BACKING_UP` | バックアップ中の場合            |
+| `COMPLETED`  | バックアップが完了した場合         |
+| `DELETING`   | バックアップが削除中の場合         |
+| `DELETED`    | バックアップが削除された場合        |
+| `ERROR`      | エラーが発生した場合            |
 
 ### バックアップリスト照会
 
@@ -3223,40 +3671,34 @@ GET /v1.0/backups
 
 #### 必要権限
 
-| 権限名                         | 説明      |
-|------------------------------|----------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:Backup.List | バックアップリスト照会 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前          | 種類   | 形式    | 必須 | 説明                                                        |
-|--------------|-------|--------|----|------------------------------------------------------------|
-| page         | Query | Number | O  | 照会するリストのページ<br/>- 最小値:`1`                                 |
-| size         | Query | Number | O  | 照会するリストのページサイズ<br/>- 最小値:`1`<br/>- 最大値:`100`             |
-| backupType   | Query | Enum   | X  | バックアップタイプ<br/>- `AUTO`:自動<br/>- `MANUAL`: 手動<br/>- デフォルト値:`全体` |
-| dbInstanceId | Query | UUID   | X  | 原本DBインスタンスの識別子                                           |
-| dbVersion    | Query | Enum   | X  | DBバージョン情報                                                  |
-
 #### レスポンス
 
-| 名前                  | 種類  | 形式      | 説明                                                                                                                                                       |
-|----------------------|------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| totalCounts          | Body | Number   | 全体バックアップリスト数                                                                                                                                                |
-| backups              | Body | Array    | バックアップリスト                                                                                                                                                    |
-| backups.backupId     | Body | UUID     | バックアップの識別子                                                                                                                                                  |
-| backups.backupName   | Body | String   | バックアップを識別できる名前                                                                                                                                          |
-| backups.backupStatus | Body | Enum     | バックアップの現在状態<br/>- `BACKING_UP`:バックアップ中の場合<br/>- `COMPLETED`:バックアップが完了した場合<br/>- `DELETING`:バックアップが削除中の場合<br/>- `DELETED`:バックアップが削除された場合<br/>- `ERROR`:エラーが発生した場合 |
-| backups.dbInstanceId | Body | UUID     | 原本DBインスタンスの識別子                                                                                                                                          |
-| backups.dbVersion    | Body | Enum     | DBバージョン情報                                                                                                                                                 |
-| backups.backupType   | Body | Enum     | バックアップタイプ<br/>- `AUTO`:自動<br/>- `MANUAL`: 手動                                                                                                               |
-| backups.backupSize   | Body | Number   | バックアップのサイズ<br/>- 単位:`バイト`                                                                                                                                    |
-| createdYmdt          | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                         |
-| updatedYmdt          | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                         |
-| completedYmdt        | Body | DateTime | 完了日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                         |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | 全体バックアップリスト数 |
+| backups | Body | Array | バックアップリスト |
+| backups.backupId | Body | UUID | バックアップの識別子 |
+| backups.backupName | Body | String | バックアップを識別できる名前 |
+| backups.backupStatus | Body | Enum | バックアップの現在状態<br/>- BACKING_UP: `バックアップ中(スピナー)`<br/>- VERIFYING: `検証中(スピナー)`<br/>- COMPLETED: `使用可能(緑アイコン)`<br/>- DELETING: `削除中(スピナー)`<br/>- DELETED: `削除済み(グレーアイコン)`<br/>- ERROR: `エラー(赤アイコン)` |
+| backups.dbInstanceId | Body | UUID | 原本DBインスタンスの識別子 |
+| backups.dbVersion | Body | Enum | DBエンジンバージョン |
+| backups.backupType | Body | Enum | バックアップタイプ<br/>- AUTO<br/>- MANUAL |
+| backups.backupSize | Body | Number | バックアップのサイズ(バイト) |
+| backups.startYmdt | Body | DateTime | 開始日時 |
+| backups.createdYmdt | Body | DateTime | 作成日時 |
+| backups.updatedYmdt | Body | DateTime | 修正日時 |
+| backups.completedYmdt | Body | DateTime | 完了日時 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -3268,170 +3710,26 @@ GET /v1.0/backups
     "totalCounts": 1,
     "backups": [
         {
-            "backupId": "0017f136-3e01-4530-94aa-20661afe6632",
-            "backupName": "backup",
-            "backupStatus": "COMPLETED",
-            "dbInstanceId": "142e6ccc-3bfb-4e1e-84f7-38861284fafd",
-            "dbVersion": "POSTGRESQL_V17_6",
+            "backupId": "550e8400-e29b-41d4-a716-446655440000",
+            "backupName": "backupName-example",
+            "backupStatus": "BACKING_UP",
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbVersion": "POSTGRESQL_V14_17",
             "backupType": "AUTO",
-            "backupSize": 4996786,
-            "createdYmdt": "2023-02-21T00:35:00+09:00",
-            "updatedYmdt": "2023-02-22T00:35:32+09:00",
-            "completedYmdt": "2023-02-22T00:35:32+09:00"
+            "backupSize": 1,
+            "startYmdt": "2023-12-31T15:00:00+09:00",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00",
+            "completedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
+
+</p>
 </details>
 
-### オブジェクトストレージにバックアップをエクスポート
-
-```http
-POST /v1.0/backups/{backupId}/export
-```
-
-#### 必要権限
-
-| 権限名                           | 説明                |
-|--------------------------------|--------------------|
-| RDSforPostgreSQL:Backup.Export | オブジェクトストレージにバックアップをエクスポート |
-
-#### リクエスト
-
-| 名前             | 種類  | 形式    | 必須 | 説明                         |
-|-----------------|------|--------|----|-----------------------------|
-| backupId        | URL  | UUID   | O  | バックアップの識別子                    |
-| tenantId        | Body | String | O  | バックアップが保存されるオブジェクトストレージのテナントID   |
-| username        | Body | String | O  | NHN CloudアカウントまたはIAMアカウントID   |
-| password        | Body | String | O  | バックアップが保存されるオブジェクトストレージのAPIパスワード |
-| targetContainer | Body | String | O  | バックアップが保存されるオブジェクトストレージのコンテナ    |
-| objectPath      | Body | String | O  | コンテナに保存されるバックアップのパス           |
-
-<details><summary>例</summary>
-
-```json
-{
-    "tenantId": "399631c404744dbbb18ce4fa2dc71a5a",
-    "username": "gildong.hong@nhn.com",
-    "password": "password",
-    "targetContainer": "/container",
-    "objectPath": "/backups/backup_file"
-}
-```
-</details>
-
-#### レスポンス
-
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### バックアップの復元
-
-```http
-POST /v1.0/backups/{backupId}/restore
-```
-
-#### 必要権限
-
-| 権限名                            | 説明     |
-|---------------------------------|---------|
-| RDSforPostgreSQL:Backup.Restore | バックアップの復元 |
-
-#### リクエスト
-
-| 名前                                      | 種類  | 形式     | 必須 | 説明                                                                                                                                                                                                                       |
-|------------------------------------------|------|---------|----|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| backupId                                 | URL  | UUID    | O  | バックアップの識別子                                                                                                                                                                                                                  |
-| dbInstanceName                           | Body | String  | O  | DBインスタンスを識別できる名前                                                                                                                                                                                                     |
-| description                              | Body | String  | X  | DBインスタンスの追加情報                                                                                                                                                                                                        |
-| dbFlavorId                               | Body | UUID    | O  | DBインスタンス仕様の識別子                                                                                                                                                                                                          |
-| dbPort                                   | Body | Number  | O  | DBポート<br/>- 最小値:`5432`<br/>- 最大値:`45432`                                                                                                                                                                                |
-| parameterGroupId                         | Body | UUID    | O  | パラメータグループの識別子                                                                                                                                                                                                             |
-| dbSecurityGroupIds                       | Body | Array   | X  | DBセキュリティグループの識別子リスト                                                                                                                                                                                                         ||network|Body|Object|O|ネットワーク情報オブジェクト|
-| userGroupIds                             | Body | Array   | X  | ユーザーグループの識別子リスト                                                                                                                                                                                                           |
-| useDefaultNotification                   | Body | Boolean | X  | 基本通知の使用有無<br/>- デフォルト値:`false`                                                                                                                                                                                            |
-| useDeletionProtection                    | Body | Boolean | X  | 削除保護の有無<br/>- デフォルト値:`false`                                                                                                                                                                                               | 
-| useHighAvailability                      | Body | Boolean | X  | 高可用性の使用有無                                                                                                                                                                                                                |
-| pingInterval                             | Body | Number  | X  | 高可用性使用時のPing間隔(秒)<br/>- 最小値:`1`<br/>- 最大値:`600`                                                                                                                                                                      |
-| failoverReplWaitingTime                  | Body | Number  | X  | 高可用性使用時のフェイルオーバー待機時間<br/>- 最小値:`-1`<br/>- -1に設定時、複製遅延が解消されるまで待機し続けます。                                                                                                                                              |                                                                                                                                                                                                                      | userGroupIds                             | Body | Array   | X  | 基本通知受信用のユーザーグループの識別子リスト                                                                                                                                                                                            |
-| network                                  | Body | Object  | O  | ネットワーク情報オブジェクト                                                                                                                                                                                                               |
-| network.subnetId                         | Body | UUID    | O  | サブネットの識別子                                                                                                                                                                                                                 |
-| network.usePublicAccess                  | Body | Boolean | X  | 外部接続可否<br/>- デフォルト値:`false`                                                                                                                                                                                            |
-| network.availabilityZone                 | Body | Enum    | X  | DBインスタンスを作成するアベイラビリティゾーン<br/>- 例:`kr-pub-a`<br/>- デフォルト値:`任意のアベイラビリティゾーン`                                                                                                                                                          |
-| storage                                  | Body | Object  | O  | ストレージ情報オブジェクト                                                                                                                                                                                                               |    
-| storage.storageType                      | Body | Enum    | O  | データストレージタイプ<br/>- 例:`General SSD`                                                                                                                                                                                       |
-| storage.storageSize                      | Body | Number  | O  | データストレージサイズ<br/>- 単位: `ギガバイト`<br/>- 最小値:`20`<br/>- 最大値:`2048`                                                                                                                                                           |
-| backup                                   | Body | Object  | O  | バックアップ情報オブジェクト                                                                                                                                                                                                                 |
-| backup.backupPeriod                      | Body | Number  | O  | バックアップの保管期間(日)<br/>- 最小値:`0`<br/>- 最大値:`730`                                                                                                                                                                               |
-| backup.backupRetryCount                  | Body | Number  | X  | バックアップの再試行回数<br/>- デフォルト値:`0`<br/>- 最小値:`0`<br/>- 最大値:`10`                                                                                                                                                                   |
-| backup.backupSchedules                   | Body | Array   | X  | バックアップスケジュールリスト                                                                                                                                                                                                                |
-| backup.backupSchedules.backupWndBgnTime  | Body | String  | O  | バックアップ開始時間<br/>- 例:`00:00:00`                                                                                                                                                                                             |
-| backup.backupSchedules.backupWndDuration | Body | Enum    | O  | バックアップDuration<br/>バックアップ開始時間から設定された期間内に自動バックアップが実行されます。<br/>- `HALF_AN_HOUR`:30分<br/>- `ONE_HOUR`:1時間<br/>- `ONE_HOUR_AND_HALF`:1時間30分<br/>- `TWO_HOURS`:2時間<br/>- `TWO_HOURS_AND_HALF`:2時間30分<br/>- `THREE_HOURS`:3時間 |
-
-<details><summary>例</summary>
-
-```json
-
-{
-  "dbInstanceName": "db-instance-restore",
-  "dbFlavorId": "50be6d9c-02d6-4594-a2d4-12010eb65ec0",
-  "dbPort": 15432,
-  "parameterGroupId": "132d383c-38e3-468a-a826-5e9a8fff15d0",
-  "network": {
-    "subnetId": "e721a9dd-dad0-4cf0-a53b-dd654ebfc683"
-  },
-  "storage": {
-    "storageType": "General SSD",
-    "storageSize": 20
-  },
-  "backup": {
-    "backupPeriod": 1,
-    "backupSchedules": [
-      {
-        "backupWndBgnTime": "00:00:00",
-        "backupWndDuration": "HALF_AN_HOUR",
-        "backupRetryExpireTime": "00:30:00"
-      }
-    ]
-  }
-}
-```
-</details>
-
-#### レスポンス
-
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
+---
 
 ### バックアップ削除
 
@@ -3441,25 +3739,26 @@ DELETE /v1.0/backups/{backupId}
 
 #### 必要権限
 
-| 権限名                           | 説明     |
-|--------------------------------|---------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:Backup.Delete | バックアップ削除 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前      | 種類 | 形式  | 必須 | 説明     |
-|----------|-----|------|----|---------|
-| backupId | URL | UUID | O  | バックアップの識別子 |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | O | バックアップの識別子 |
 
 #### レスポンス
 
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | リクエストした作業の識別子 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -3468,12 +3767,200 @@ DELETE /v1.0/backups/{backupId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
+---
+
+### バックアップをエクスポート
+
+```http
+POST /v1.0/backups/{backupId}/export
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:Backup.Export | バックアップをエクスポート |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | O | バックアップの識別子 |
+| tenantId | Body | String | O | バックアップが保存されるオブジェクトストレージのテナントID<br/>- 最小長: `32`<br/>- 最大長: `32` |
+| username | Body | String | O | NHN CloudアカウントまたはIAMメンバーID |
+| password | Body | String | O | バックアップが保存されるオブジェクトストレージのAPIパスワード |
+| targetContainer | Body | String | O | バックアップが保存されるオブジェクトストレージのコンテナ |
+| objectPath | Body | String | O | コンテナに保存されるバックアップのパス |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "tenantId": "0123456789abcdef0123456789abcdef",
+    "username": "username-example",
+    "password": "password-example",
+    "targetContainer": "targetContainer-example",
+    "objectPath": "objectPath-example"
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### バックアップの復元
+
+```http
+POST /v1.0/backups/{backupId}/restore
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:Backup.Restore | バックアップの復元 |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | O | バックアップの識別子 |
+| dbInstanceName | Body | String | O | DBインスタンスを識別できる名前 |
+| dbInstanceCandidateName | Body | String | X | DBインスタンスを識別できる予備マスター名 |
+| description | Body | String | X | DBインスタンスの追加情報 |
+| dbFlavorId | Body | UUID | O | DBインスタンス仕様の識別子 |
+| dbPort | Body | Number | O | DBポート<br/>- 最小値: 5432、最大値: 45432 |
+| parameterGroupId | Body | UUID | O | パラメータグループの識別子 |
+| dbSecurityGroupIds | Body | Array | X | DBセキュリティグループの識別子リスト |
+| userGroupIds | Body | Array | X | ユーザーグループの識別子リスト |
+| useHighAvailability | Body | Boolean | X | 高可用性の使用有無<br/>- デフォルト値: `false` |
+| useDefaultNotification | Body | Boolean | X | 基本通知の使用有無<br/>- デフォルト値: `false` |
+| useDeletionProtection | Body | Boolean | X | 削除保護の有無<br/>- デフォルト値: `false` |
+| pingInterval | Body | Number | X | Ping間隔(秒)<br/>- 最小値: `1`<br/>- 最大値: `600` |
+| failoverReplWaitingTime | Body | Number | X | フェイルオーバー複製遅延待機時間(秒)<br/>- 最小値: `-1` |
+| network | Body | Object | O | ネットワーク情報オブジェクト |
+| network.subnetId | Body | UUID | O | サブネットの識別子 |
+| network.usePublicAccess | Body | Boolean | X | 外部接続可否<br/>- デフォルト値: `false` |
+| network.availabilityZone | Body | Enum | X | DBインスタンスを作成するアベイラビリティゾーン |
+| storage | Body | Object | O | ストレージ情報オブジェクト |
+| storage.storageType | Body | Enum | O | ストレージタイプ |
+| storage.storageSize | Body | Number | O | データストレージサイズ(GB)<br/>- 最小値: `20` |
+| backup | Body | Object | O | バックアップ情報オブジェクト |
+| backup.backupPeriod | Body | Number | O | バックアップの保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| backup.backupRetryCount | Body | Number | X | バックアップの再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| backup.backupSchedules | Body | Array | O | バックアップスケジュールリスト |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | O | バックアップ開始時間 |
+| backup.backupSchedules.backupWndDuration | Body | Enum | O | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName-example",
+    "dbInstanceCandidateName": "dbInstanceCandidateName-example",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useHighAvailability": false,
+    "useDefaultNotification": false,
+    "useDeletionProtection": false,
+    "pingInterval": 1,
+    "failoverReplWaitingTime": 1,
+    "network": {
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
+        "availabilityZone": "kr-pub-a"
+    },
+    "storage": {
+        "storageType": "General SSD",
+        "storageSize": 20
+    },
+    "backup": {
+        "backupPeriod": 0,
+        "backupRetryCount": 0,
+        "backupSchedules": [
+            {
+                "backupWndBgnTime": "00:00:00",
+                "backupWndDuration": "HALF_AN_HOUR"
+            }
+        ]
+    }
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
 ## DBセキュリティグループ
+
+### DBセキュリティグループの進行状態
+
+| 状態              | 説明                     |
+|-----------------|--------------------------|
+| `NONE`          | 進行中の作業なし           |
+| `CREATING_RULE` | ルールポリシー作成中       |
+| `UPDATING_RULE` | ルールポリシー修正中       |
+| `DELETING_RULE` | ルールポリシー削除中       |
 
 ### DBセキュリティグループリストを表示
 
@@ -3483,8 +3970,8 @@ GET /v1.0/db-security-groups
 
 #### 必要権限
 
-| 権限名                                  | 説明            |
-|---------------------------------------|----------------|
+| 権限名                                  | 説明                       |
+|---------------------------------------|--------------------------|
 | RDSforPostgreSQL:DbSecurityGroup.List | DBセキュリティグループリストを表示 |
 
 #### リクエスト
@@ -3493,18 +3980,19 @@ GET /v1.0/db-security-groups
 
 #### レスポンス
 
-| 名前                                    | 種類  | 形式      | 説明                                                                                                                                                                                            |
-|----------------------------------------|------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroups                       | Body | Array    | DBセキュリティグループリスト                                                                                                                                                                                   |
-| dbSecurityGroups.dbSecurityGroupId     | Body | UUID     | DBセキュリティグループの識別子                                                                                                                                                                                 |
-| dbSecurityGroups.dbSecurityGroupName   | Body | String   | DBセキュリティグループを識別できる名前                                                                                                                                                                         |
-| dbSecurityGroups.dbSecurityGroupStatus | Body | Enum     | DBセキュリティグループの現在状態<br/>- `CREATED`:作成済み<br/>- `DELETED`:削除済み                                                                                                                                     |
-| dbSecurityGroups.description           | Body | String   | DBセキュリティグループの追加情報                                                                                                                                                                            |
-| dbSecurityGroups.progressStatus        | Body | Enum     | DBセキュリティグループの現在の進行状態<br/>- `NONE`:進行中の作業なし<br/>- `CREATING_RULE`:ルールポリシー作成中<br/>- `UPDATING_RULE`:ルールポリシー修正中<br/>- `DELETING_RULE`:ルールポリシー削除中<br/>- `APPLYING_DEFAULT_RULE`:基本ルール適用中 |
-| dbSecurityGroups.createdYmdt           | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                              |
-| dbSecurityGroups.updatedYmdt           | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                              |
+| 名前                                    | 種類  | 形式      | 説明                                                                                                                                                                                                                                                              |
+|----------------------------------------|------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| dbSecurityGroups                       | Body | Array    | DBセキュリティグループリスト                                                                                                                                                                                                                                              |
+| dbSecurityGroups.dbSecurityGroupId     | Body | UUID     | DBセキュリティグループの識別子                                                                                                                                                                                                                                            |
+| dbSecurityGroups.dbSecurityGroupName   | Body | String   | DBセキュリティグループを識別できる名前                                                                                                                                                                                                                                    |
+| dbSecurityGroups.dbSecurityGroupStatus | Body | Enum     | DBセキュリティグループの現在状態<br/>- CREATED: `作成済み`<br/>- DELETED: `削除済み`                                                                                                                                                                                       |
+| dbSecurityGroups.description           | Body | String   | DBセキュリティグループの追加情報                                                                                                                                                                                                                                         |
+| dbSecurityGroups.progressStatus        | Body | Enum     | DBセキュリティグループの現在の進行状態<br/>- NONE: `進行中の作業なし`<br/>- CREATING_RULE: `ルールポリシー作成中`<br/>- UPDATING_RULE: `ルールポリシー修正中`<br/>- DELETING_RULE: `ルールポリシー削除中`<br/>- APPLYING_DEFAULT_RULE: `基本ルール適用中` |
+| dbSecurityGroups.createdYmdt           | Body | DateTime | 作成日時                                                                                                                                                                                                                                                          |
+| dbSecurityGroups.updatedYmdt           | Body | DateTime | 修正日時                                                                                                                                                                                                                                                          |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -3515,100 +4003,22 @@ GET /v1.0/db-security-groups
     },
     "dbSecurityGroups": [
         {
-            "dbSecurityGroupId": "fe4f2aee-afbb-4c19-a5e9-eb2eab394708",
-            "dbSecurityGroupName": "dbSecurityGroup",
+            "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbSecurityGroupName": "dbSecurityGroupName-example",
             "dbSecurityGroupStatus": "CREATED",
-            "description": "description",
+            "description": "description-example",
             "progressStatus": "NONE",
-            "createdYmdt": "2023-02-19T19:18:13+09:00",
-            "updatedYmdt": "2022-02-19T19:18:13+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
+
+</p>
 </details>
 
-### DBセキュリティグループ詳細を表示
-
-```http
-GET /v1.0/db-security-groups/{dbSecurityGroupId}
-```
-
-#### 必要権限
-
-| 権限名                                 | 説明            |
-|--------------------------------------|----------------|
-| RDSforPostgreSQL:DbSecurityGroup.Get | DBセキュリティグループ詳細を表示 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前               | 種類 | 形式  | 必須 | 説明           |
-|-------------------|-----|------|----|---------------|
-| dbSecurityGroupId | URL | UUID | O  | DBセキュリティグループの識別子 |
-
-#### レスポンス
-
-| 名前                   | 種類  | 形式      | 説明                                                                                                                                                                                           |
-|-----------------------|------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId     | Body | UUID     | DBセキュリティグループの識別子                                                                                                                                                                                |
-| dbSecurityGroupName   | Body | String   | DBセキュリティグループを識別できる名前                                                                                                                                                                        |
-| dbSecurityGroupStatus | Body | Enum     | DBセキュリティグループの現在状態<br/>- `CREATED`:作成済み<br/>- `DELETED`:削除済み                                                                                                                                    |
-| description           | Body | String   | DBセキュリティグループの追加情報                                                                                                                                                                           |
-| progressStatus        | Body | Enum     | DBセキュリティグループの現在の進行状態<br/>- `NONE`:進行中の作業なし<br/>- `CREATING_RULE`:ルールポリシー作成中<br/>- `UPDATING_RULE`:ルールポリシー修正中<br/>- `DELETING_RULE`:ルールポリシー削除中<br/>- `APPLYING_DEFAULT_RULE`:基本ルール適用中 |
-| rules                 | Body | Array    | DBセキュリティグループルールリスト                                                                                                                                                                               |
-| rules.ruleId          | Body | UUID     | DBセキュリティグループルールの識別子                                                                                                                                                                             |
-| rules.description     | Body | String   | DBセキュリティグループルールの追加情報                                                                                                                                                                        |
-| rules.direction       | Body | Enum     | 通信方向<br/>- `INGRESS`:受信<br/>- `EGRESS`:送信                                                                                                                                                 |
-| rules.etherType       | Body | Enum     | Etherタイプ<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                                |
-| rules.port            | Body | Object   | ポートオブジェクト                                                                                                                                                                                        |
-| rules.port.portType   | Body | Enum     | ポートタイプ<br/>- `DB_PORT`:各DBインスタンスポート値で設定されます。<br/>- `PORT`:指定されたポート値で設定されます。<br/>- `PORT_RANGE`:指定されたポート範囲で設定されます。                                                                            |
-| rules.port.minPort    | Body | Number   | 最小ポート範囲                                                                                                                                                                                     |
-| rules.port.maxPort    | Body | Number   | 最大ポート範囲                                                                                                                                                                                     |
-| rules.cidr            | Body | String   | 許可するトラフィックの遠隔ソース                                                                                                                                                                               |
-| rules.createdYmdt     | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                             |
-| rules.updatedYmdt     | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                             |
-| createdYmdt           | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                             |
-| updatedYmdt           | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                             |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbSecurityGroup": {
-        "dbSecurityGroupId": "fe4f2aee-afbb-4c19-a5e9-eb2eab394708",
-        "dbSecurityGroupName": "dbSecurityGroup",
-        "dbSecurityGroupStatus": "CREATED",
-        "description": "description",
-        "progressStatus": "NONE",
-        "rules": [
-            {
-                "ruleId": "17c88ef6-95f1-4678-84f9-fee1b22e250d",
-                "description": "description",
-                "direction": "INGRESS",
-                "etherType": "IPV4",
-                "port": {
-                    "portType": "PORT_RANGE",
-                    "minPort": 10000,
-                    "maxPort": 10005
-                },
-                "cidr": "0.0.0.0/0",
-                "createdYmdt": "2023-02-19T19:18:13+09:00",
-                "updatedYmdt": "2023-02-19T19:18:13+09:00"
-            }
-        ],
-        "createdYmdt": "2023-02-19T19:18:13+09:00",
-        "updatedYmdt": "2023-02-19T19:18:13+09:00"
-    }
-}
-```
-</details>
+---
 
 ### DBセキュリティグループの作成
 
@@ -3618,55 +4028,60 @@ POST /v1.0/db-security-groups
 
 #### 必要権限
 
-| 権限名                                    | 説明           |
-|-----------------------------------------|---------------|
+| 権限名                                    | 説明                    |
+|-----------------------------------------|------------------------|
 | RDSforPostgreSQL:DbSecurityGroup.Create | DBセキュリティグループ作成 |
 
 #### リクエスト
 
-| 名前                 | 種類  | 形式    | 必須 | 説明                                                                                                                                                                                      |
-|---------------------|------|--------|----|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupName | Body | String | O  | DBセキュリティグループを識別できる名前                                                                                                                                                                   |
-| description         | Body | String | X  | DBセキュリティグループの追加情報                                                                                                                                                                      |
-| rules               | Body | Array  | O  | DBセキュリティグループルールリスト                                                                                                                                                                          |
-| rules.description   | Body | String | X  | DBセキュリティグループルールの追加情報                                                                                                                                                                   |
-| rules.direction     | Body | Enum   | O  | 通信方向<br/>- `INGRESS`:受信<br/>- `EGRESS`:送信                                                                                                                                            |
-| rules.etherType     | Body | Enum   | O  | Etherタイプ<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                           |
-| rules.cidr          | Body | String | O  | 許可するトラフィックの遠隔ソース<br/>- 例:`1.1.1.1/32`                                                                                                                                                    |
-| rules.port          | Body | Object | O  | ポートオブジェクト                                                                                                                                                                                   |
-| rules.port.portType | Body | Enum   | O  | ポートタイプ<br/>- `DB_PORT`:各DBインスタンスポート値で設定されます。`minPort`値と`maxPort`値を必要としません。<br/>- `PORT`:指定されたポート値で設定されます。`minPort`値と`maxPort`値が同じである必要があります。<br/>- `PORT_RANGE`:指定されたポート範囲で設定されます。 |
-| rules.port.minPort  | Body | Number | X  | 最小ポート範囲<br/>- 受信最小値:5432<br/>- 送信最小値:1                                                                                                                                              |
-| rules.port.maxPort  | Body | Number | X  | 最大ポート範囲<br/>- 受信最大値:45432<br/>- 送信最大値:65535                                                                                                                                         |
+| 名前                 | 種類  | 形式    | 必須 | 説明                                                                                                                                                                                                                                                              |
+|---------------------|------|--------|-----|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| dbSecurityGroupName | Body | String | O   | DBセキュリティグループを識別できる名前                                                                                                                                                                                                                                |
+| description         | Body | String | X   | DBセキュリティグループの追加情報                                                                                                                                                                                                                                     |
+| rules               | Body | Array  | O   | DBセキュリティグループルール情報                                                                                                                                                                                                                                     |
+| rules.direction     | Body | Enum   | O   | 通信方向<br/>- INGRESS: `受信`<br/>- EGRESS: `送信`                                                                                                                                                                                                               |
+| rules.etherType     | Body | Enum   | O   | Etherタイプ<br/>- IPV4: `IPv4形式`<br/>- IPV6: `IPv6形式`                                                                                                                                                                                                        |
+| rules.port          | Body | Object | O   | ポートオブジェクト                                                                                                                                                                                                                                                  |
+| rules.port.portType | Body | Enum   | O   | ポートタイプ<br/>- ALL: `ポート範囲全体(ユーザーコンソールでは使用しない)`<br/>- PORT: `特定ポート`<br/>- DB_PORT: `DB受信ポート`<br/>- PORT_RANGE: `ポート範囲`                                                                                                           |
+| rules.port.minPort  | Body | Number | X   | 最小ポート範囲<br/>- 最小値: `1`                                                                                                                                                                                                                                    |
+| rules.port.maxPort  | Body | Number | X   | 最大ポート範囲<br/>- 最大値: `65535`                                                                                                                                                                                                                               |
+| rules.cidr          | Body | String | O   | CIDR                                                                                                                                                                                                                                                             |
+| rules.description   | Body | String | X   | DBセキュリティグループルールの追加情報                                                                                                                                                                                                                               |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
-    "dbSecurityGroupName": "dbSecurityGroup",
-    "description": "description",
+    "dbSecurityGroupName": "dbSecurityGroupName-example",
+    "description": "description-example",
     "rules": [
         {
             "direction": "INGRESS",
             "etherType": "IPV4",
             "port": {
-                "portType": "PORT_RANGE",
-                "minPort": 10000,
-                "maxPort": 10005
+                "portType": "ALL",
+                "minPort": 1,
+                "maxPort": 1
             },
-            "cidr": "0.0.0.0/0"
+            "cidr": "192.168.0.0/24",
+            "description": "description-example"
         }
     ]
 }
 ```
+
+</p>
 </details>
 
 #### レスポンス
 
-| 名前               | 種類  | 形式  | 説明           |
-|-------------------|------|------|---------------|
+| 名前               | 種類  | 形式  | 説明                      |
+|-------------------|------|------|--------------------------|
 | dbSecurityGroupId | Body | UUID | DBセキュリティグループの識別子 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -3675,57 +4090,14 @@ POST /v1.0/db-security-groups
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "dbSecurityGroupId": "fe4f2aee-afbb-4c19-a5e9-eb2eab394708"
+    "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-### DBセキュリティグループの修正
-
-```http
-PUT /v1.0/db-security-groups/{dbSecurityGroupId}
-```
-
-#### 必要権限
-
-| 権限名                                    | 説明           |
-|-----------------------------------------|---------------|
-| RDSforPostgreSQL:DbSecurityGroup.Modify | DBセキュリティグループの修正 |
-
-#### リクエスト
-
-| 名前                 | 種類  | 形式    | 必須 | 説明                   |
-|---------------------|------|--------|----|-----------------------|
-| dbSecurityGroupId   | URL  | UUID   | O  | DBセキュリティグループの識別子        |
-| dbSecurityGroupName | Body | String | X  | DBセキュリティグループを識別できる名前 |
-| description         | Body | String | X  | DBセキュリティグループの追加情報   |
-
-<details><summary>例</summary>
-
-```json
-{
-    "dbSecurityGroupName": "dbSecurityGroup",
-    "description": "description"
-}
-```
-</details>
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
+---
 
 ### DBセキュリティグループの削除
 
@@ -3735,23 +4107,71 @@ DELETE /v1.0/db-security-groups/{dbSecurityGroupId}
 
 #### 必要権限
 
-| 権限名                                    | 説明           |
-|-----------------------------------------|---------------|
+| 権限名                                    | 説明                    |
+|-----------------------------------------|------------------------|
 | RDSforPostgreSQL:DbSecurityGroup.Delete | DBセキュリティグループの削除 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前               | 種類 | 形式  | 必須 | 説明           |
-|-------------------|-----|------|----|---------------|
-| dbSecurityGroupId | URL | UUID | O  | DBセキュリティグループの識別子 |
+| 名前               | 種類 | 形式  | 必須 | 説明 |
+|-------------------|-----|------|----|-----|
+| dbSecurityGroupId | URL | UUID | O  |     |
 
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
 
+---
+
+### DBセキュリティグループ詳細を表示
+
+```http
+GET /v1.0/db-security-groups/{dbSecurityGroupId}
+```
+
+#### 必要権限
+
+| 権限名                                 | 説明                         |
+|--------------------------------------|------------------------------|
+| RDSforPostgreSQL:DbSecurityGroup.Get | DBセキュリティグループ詳細を表示 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前               | 種類 | 形式  | 必須 | 説明                      |
+|-------------------|-----|------|----|--------------------------|
+| dbSecurityGroupId | URL | UUID | O  |                          |
+
+#### レスポンス
+
+| 名前                                    | 種類  | 形式      | 説明                                                                                                                                                                                                                                                                 |
+|-----------------------------------------|------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| dbSecurityGroup                         | Body | Object   | DBセキュリティグループ                                                                                                                                                                                                                                                  |
+| dbSecurityGroup.dbSecurityGroupId       | Body | UUID     | DBセキュリティグループの識別子                                                                                                                                                                                                                                           |
+| dbSecurityGroup.dbSecurityGroupName     | Body | String   | DBセキュリティグループを識別できる名前                                                                                                                                                                                                                                   |
+| dbSecurityGroup.dbSecurityGroupStatus   | Body | Enum     | DBセキュリティグループの現在状態<br/>- CREATED: `作成済み`<br/>- DELETED: `削除済み`                                                                                                                                                                                      |
+| dbSecurityGroup.description             | Body | String   | DBセキュリティグループの追加情報                                                                                                                                                                                                                                        |
+| dbSecurityGroup.progressStatus          | Body | Enum     | DBセキュリティグループの現在の進行状態<br/>- NONE: `進行中の作業なし`<br/>- CREATING_RULE: `ルールポリシー作成中`<br/>- UPDATING_RULE: `ルールポリシー修正中`<br/>- DELETING_RULE: `ルールポリシー削除中`<br/>- APPLYING_DEFAULT_RULE: `基本ルール適用中` |
+| dbSecurityGroup.rules                   | Body | Array    | DBセキュリティグループルールリスト                                                                                                                                                                                                                                      |
+| dbSecurityGroup.rules.ruleId            | Body | UUID     | DBセキュリティグループルールの識別子                                                                                                                                                                                                                                    |
+| dbSecurityGroup.rules.description       | Body | String   | DBセキュリティグループルールの追加情報                                                                                                                                                                                                                                  |
+| dbSecurityGroup.rules.direction         | Body | Enum     | 通信方向<br/>- INGRESS: `受信`<br/>- EGRESS: `送信`                                                                                                                                                                                                                  |
+| dbSecurityGroup.rules.etherType         | Body | Enum     | Etherタイプ<br/>- IPV4: `IPv4形式`<br/>- IPV6: `IPv6形式`                                                                                                                                                                                                           |
+| dbSecurityGroup.rules.port              | Body | Object   | ポートオブジェクト                                                                                                                                                                                                                                                      |
+| dbSecurityGroup.rules.port.portType     | Body | Enum     | ポートタイプ<br/>- ALL: `ポート範囲全体(ユーザーコンソールでは使用しない)`<br/>- PORT: `特定ポート`<br/>- DB_PORT: `DB受信ポート`<br/>- PORT_RANGE: `ポート範囲`                                                                                                            |
+| dbSecurityGroup.rules.port.minPort      | Body | Number   | 最小ポート範囲                                                                                                                                                                                                                                                        |
+| dbSecurityGroup.rules.port.maxPort      | Body | Number   | 最大ポート範囲                                                                                                                                                                                                                                                        |
+| dbSecurityGroup.rules.cidr              | Body | String   | CIDR                                                                                                                                                                                                                                                                |
+| dbSecurityGroup.rules.createdYmdt       | Body | DateTime | 作成日時                                                                                                                                                                                                                                                            |
+| dbSecurityGroup.rules.updatedYmdt       | Body | DateTime | 修正日時                                                                                                                                                                                                                                                            |
+| dbSecurityGroup.createdYmdt             | Body | DateTime | 作成日時                                                                                                                                                                                                                                                            |
+| dbSecurityGroup.updatedYmdt             | Body | DateTime | 修正日時                                                                                                                                                                                                                                                            |
+
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -3759,133 +4179,78 @@ DELETE /v1.0/db-security-groups/{dbSecurityGroupId}
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
+    },
+    "dbSecurityGroup": {
+        "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
+        "dbSecurityGroupName": "dbSecurityGroupName-example",
+        "dbSecurityGroupStatus": "CREATED",
+        "description": "description-example",
+        "progressStatus": "NONE",
+        "rules": [
+            {
+                "ruleId": "550e8400-e29b-41d4-a716-446655440000",
+                "description": "description-example",
+                "direction": "INGRESS",
+                "etherType": "IPV4",
+                "port": {
+                    "portType": "ALL",
+                    "minPort": 1,
+                    "maxPort": 1
+                },
+                "cidr": "192.168.0.0/24",
+                "createdYmdt": "2023-12-31T15:00:00+09:00",
+                "updatedYmdt": "2023-12-31T15:00:00+09:00"
+            }
+        ],
+        "createdYmdt": "2023-12-31T15:00:00+09:00",
+        "updatedYmdt": "2023-12-31T15:00:00+09:00"
     }
 }
 ```
+
+</p>
 </details>
 
-### DBセキュリティグループルールの作成
+---
+
+### DBセキュリティグループの修正
 
 ```http
-POST /v1.0/db-security-groups/{dbSecurityGroupId}/rules
+PUT /v1.0/db-security-groups/{dbSecurityGroupId}
 ```
 
 #### 必要権限
 
-| 権限名                                        | 説明              |
-|---------------------------------------------|------------------|
-| RDSforPostgreSQL:DbSecurityGroupRule.Create | DBセキュリティグループルールの作成 |
+| 権限名                                    | 説明                    |
+|-----------------------------------------|------------------------|
+| RDSforPostgreSQL:DbSecurityGroup.Modify | DBセキュリティグループの修正 |
 
 #### リクエスト
 
-| 名前               | 種類  | 形式    | 必須 | 説明                                                                                                                                                                                      |
-|-------------------|------|--------|----|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId | URL  | UUID   | O  | DBセキュリティグループの識別子                                                                                                                                                                           |
-| description       | Body | String | X  | DBセキュリティグループルールの追加情報                                                                                                                                                                   |
-| direction         | Body | Enum   | O  | 通信方向<br/>- `INGRESS`:受信<br/>- `EGRESS`:送信                                                                                                                                            |
-| etherType         | Body | Enum   | O  | Etherタイプ<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                           |
-| port              | Body | Object | O  | ポートオブジェクト                                                                                                                                                                                   |
-| port.portType     | Body | Enum   | O  | ポートタイプ<br/>- `DB_PORT`:各DBインスタンスポート値で設定されます。`minPort`値と`maxPort`値を必要としません。<br/>- `PORT`:指定されたポート値で設定されます。`minPort`値と`maxPort`値が同じである必要があります。<br/>- `PORT_RANGE`:指定されたポート範囲で設定されます。 |
-| port.minPort      | Body | Number | X  | 最小ポート範囲<br/>- 受信最小値:5432<br/>- 送信最小値:1                                                                                                                                              |
-| port.maxPort      | Body | Number | X  | 最大ポート範囲<br/>- 受信最大値:45432<br/>- 送信最大値:65535                                                                                                                                         |
-| cidr              | Body | String | O  | 許可するトラフィックの遠隔ソース<br/>- 例:`1.1.1.1/32`                                                                                                                                                    |
+| 名前                 | 種類  | 形式    | 必須 | 説明                                    |
+|---------------------|------|--------|-----|----------------------------------------|
+| dbSecurityGroupId   | URL  | UUID   | O   |                                        |
+| dbSecurityGroupName | Body | String | O   | DBセキュリティグループを識別できる名前       |
+| description         | Body | String | X   | DBセキュリティグループの追加情報            |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
-    "direction": "INGRESS",
-    "etherType": "IPV4",
-    "port": {
-        "portType": "PORT",
-        "minPort": 10000,
-        "maxPort": 10000
-    },
-    "cidr": "0.0.0.0/0"
+    "dbSecurityGroupName": "dbSecurityGroupName-example",
+    "description": "description-example"
 }
 ```
+
+</p>
 </details>
 
 #### レスポンス
 
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
+このAPIはレスポンス本文を返しません。
 
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
-
-### DBセキュリティグループルールの修正
-
-```http
-PUT /v1.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
-```
-
-#### 必要権限
-
-| 権限名                                        | 説明              |
-|---------------------------------------------|------------------|
-| RDSforPostgreSQL:DbSecurityGroupRule.Modify | DBセキュリティグループルールの修正 |
-
-#### リクエスト
-
-| 名前               | 種類  | 形式    | 必須 | 説明                                                                                                                                                                                      |
-|-------------------|------|--------|----|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId | URL  | UUID   | O  | DBセキュリティグループの識別子                                                                                                                                                                           |
-| ruleId            | URL  | UUID   | O  | DBセキュリティグループルールの識別子                                                                                                                                                                        |
-| description       | Body | String | X  | DBセキュリティグループルールの追加情報                                                                                                                                                                   |
-| direction         | Body | Enum   | O  | 通信方向<br/>- `INGRESS`:受信<br/>- `EGRESS`:送信                                                                                                                                            |
-| etherType         | Body | Enum   | O  | Etherタイプ<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                           |
-| port              | Body | Object | O  | ポートオブジェクト                                                                                                                                                                                   |
-| port.portType     | Body | Enum   | O  | ポートタイプ<br/>- `DB_PORT`:各DBインスタンスポート値で設定されます。`minPort`値と`maxPort`値を必要としません。<br/>- `PORT`:指定されたポート値で設定されます。`minPort`値と`maxPort`値が同じである必要があります。<br/>- `PORT_RANGE`:指定されたポート範囲で設定されます。 |
-| port.minPort      | Body | Number | X  | 最小ポート範囲<br/>- 受信最小値:5432<br/>- 送信最小値:1                                                                                                                                              |
-| port.maxPort      | Body | Number | X  | 最大ポート範囲<br/>- 受信最大値:45432<br/>- 送信最大値:65535                                                                                                                                         |
-| cidr              | Body | String | O  | 許可するトラフィックの遠隔ソース<br/>- 例:`1.1.1.1/32`                                                                                                                                                    |
-
-<details><summary>例</summary>
-
-```json
-{
-    "direction": "INGRESS",
-    "etherType": "IPV4",
-    "port": {
-        "portType": "DB_PORT"
-    },
-    "cidr": "0.0.0.0/0"
-}
-```
-</details>
-
-#### レスポンス
-
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
-}
-```
-</details>
+---
 
 ### DBセキュリティグループルールの削除
 
@@ -3895,26 +4260,27 @@ DELETE /v1.0/db-security-groups/{dbSecurityGroupId}/rules
 
 #### 必要権限
 
-| 権限名                                        | 説明              |
-|---------------------------------------------|------------------|
-| RDSforPostgreSQL:DbSecurityGroupRule.Create | DBセキュリティグループルールの削除 |
+| 権限名                                        | 説明                         |
+|---------------------------------------------|------------------------------|
+| RDSforPostgreSQL:DbSecurityGroupRule.Delete | DBセキュリティグループルールの削除 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前               | 種類   | 形式   | 必須 | 説明                 |
-|-------------------|-------|-------|----|---------------------|
-| dbSecurityGroupId | URL   | UUID  | O  | DBセキュリティグループの識別子      |
-| ruleIds           | Query | Array | O  | DBセキュリティグループルールの識別子リスト |
+| 名前               | 種類   | 形式    | 必須 | 説明                             |
+|-------------------|-------|--------|-----|----------------------------------|
+| dbSecurityGroupId | URL   | UUID   | O   |                                  |
+| ruleIds           | Query | String | O   | DBセキュリティグループルールIDリスト |
 
 #### レスポンス
 
-| 名前   | 種類  | 形式  | 説明         |
-|-------|------|------|-------------|
+| 名前   | 種類  | 形式  | 説明                    |
+|-------|------|------|------------------------|
 | jobId | Body | UUID | リクエストした作業の識別子 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -3923,11 +4289,157 @@ DELETE /v1.0/db-security-groups/{dbSecurityGroupId}/rules
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
+---
+
+### DBセキュリティグループルールの作成
+
+```http
+POST /v1.0/db-security-groups/{dbSecurityGroupId}/rules
+```
+
+#### 必要権限
+
+| 権限名                                        | 説明                         |
+|---------------------------------------------|------------------------------|
+| RDSforPostgreSQL:DbSecurityGroupRule.Create | DBセキュリティグループルールの作成 |
+
+#### リクエスト
+
+| 名前               | 種類  | 形式    | 必須 | 説明                                                                                                                                                                                                               |
+|-------------------|------|--------|-----|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| dbSecurityGroupId | URL  | UUID   | O   |                                                                                                                                                                                                                    |
+| direction         | Body | Enum   | O   | 通信方向<br/>- INGRESS: `受信`<br/>- EGRESS: `送信`                                                                                                                                                               |
+| etherType         | Body | Enum   | O   | Etherタイプ<br/>- IPV4: `IPv4形式`<br/>- IPV6: `IPv6形式`                                                                                                                                                        |
+| port              | Body | Object | O   | ポート情報                                                                                                                                                                                                         |
+| port.portType     | Body | Enum   | O   | ポートタイプ<br/>- ALL: `ポート範囲全体(ユーザーコンソールでは使用しない)`<br/>- PORT: `特定ポート`<br/>- DB_PORT: `DB受信ポート`<br/>- PORT_RANGE: `ポート範囲`                                                       |
+| port.minPort      | Body | Number | X   | 最小ポート範囲<br/>- 最小値: `1`                                                                                                                                                                                   |
+| port.maxPort      | Body | Number | X   | 最大ポート範囲<br/>- 最大値: `65535`                                                                                                                                                                              |
+| cidr              | Body | String | O   | CIDR                                                                                                                                                                                                              |
+| description       | Body | String | X   | DBセキュリティグループルールの追加情報                                                                                                                                                                               |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "direction": "INGRESS",
+    "etherType": "IPV4",
+    "port": {
+        "portType": "ALL",
+        "minPort": 1,
+        "maxPort": 1
+    },
+    "cidr": "192.168.0.0/24",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前   | 種類  | 形式  | 説明                    |
+|-------|------|------|------------------------|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBセキュリティグループルールの修正
+
+```http
+PUT /v1.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
+```
+
+#### 必要権限
+
+| 権限名                                        | 説明                         |
+|---------------------------------------------|------------------------------|
+| RDSforPostgreSQL:DbSecurityGroupRule.Modify | DBセキュリティグループルールの修正 |
+
+#### リクエスト
+
+| 名前               | 種類  | 形式    | 必須 | 説明                                                                                                                                                                                                               |
+|-------------------|------|--------|-----|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| dbSecurityGroupId | URL  | UUID   | O   |                                                                                                                                                                                                                    |
+| ruleId            | URL  | UUID   | O   |                                                                                                                                                                                                                    |
+| direction         | Body | Enum   | O   | 通信方向<br/>- INGRESS: `受信`<br/>- EGRESS: `送信`                                                                                                                                                               |
+| etherType         | Body | Enum   | O   | Etherタイプ<br/>- IPV4: `IPv4形式`<br/>- IPV6: `IPv6形式`                                                                                                                                                        |
+| port              | Body | Object | O   | ポート情報                                                                                                                                                                                                         |
+| port.portType     | Body | Enum   | O   | ポートタイプ<br/>- ALL: `ポート範囲全体(ユーザーコンソールでは使用しない)`<br/>- PORT: `特定ポート`<br/>- DB_PORT: `DB受信ポート`<br/>- PORT_RANGE: `ポート範囲`                                                       |
+| port.minPort      | Body | Number | X   | 最小ポート範囲<br/>- 最小値: `1`                                                                                                                                                                                   |
+| port.maxPort      | Body | Number | X   | 最大ポート範囲<br/>- 最大値: `65535`                                                                                                                                                                              |
+| cidr              | Body | String | O   | CIDR                                                                                                                                                                                                              |
+| description       | Body | String | X   | DBセキュリティグループルールの追加情報                                                                                                                                                                               |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "direction": "INGRESS",
+    "etherType": "IPV4",
+    "port": {
+        "portType": "ALL",
+        "minPort": 1,
+        "maxPort": 1
+    },
+    "cidr": "192.168.0.0/24",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前   | 種類  | 形式  | 説明                    |
+|-------|------|------|------------------------|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
 ## パラメータグループ
 
 ### パラメータグループリストを表示
@@ -3938,32 +4450,29 @@ GET /v1.0/parameter-groups
 
 #### 必要権限
 
-| 権限名                                 | 説明           |
-|--------------------------------------|---------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:ParameterGroup.List | パラメータグループリストを表示 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前       | 種類   | 形式  | 必須 | 説明      |
-|-----------|-------|------|----|----------|
-| dbVersion | Query | Enum | X  | DBバージョン情報 |
-
 #### レスポンス
 
-| 名前                                  | 種類  | 形式      | 説明                                                               |
-|--------------------------------------|------|----------|-------------------------------------------------------------------|
-| parameterGroups                      | Body | Array    | パラメータグループリスト                                                       |
-| parameterGroups.parameterGroupId     | Body | UUID     | パラメータグループの識別子                                                     |
-| parameterGroups.parameterGroupName   | Body | String   | パラメータグループを識別できる名前                                             |
-| parameterGroups.parameterGroupStatus | Body | Enum     | パラメータグループの現在状態<br/>- `STABLE`:適用完了<br/>- `NEED_TO_APPLY`:適用必要 |
-| parameterGroups.description          | Body | String   | パラメータグループの追加情報                                                |
-| parameterGroups.dbVersion            | Body | Enum     | DBバージョン情報                                                         |
-| parameterGroups.createdYmdt          | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                 |
-| parameterGroups.updatedYmdt          | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                 |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| parameterGroups | Body | Array | パラメータグループリスト |
+| parameterGroups.parameterGroupId | Body | UUID | パラメータグループの識別子 |
+| parameterGroups.parameterGroupName | Body | String | パラメータグループを識別できる名前 |
+| parameterGroups.description | Body | String | パラメータグループの追加情報 |
+| parameterGroups.dbVersion | Body | Enum | DBバージョン情報 |
+| parameterGroups.parameterGroupStatus | Body | Enum | パラメータグループの現在状態<br/>- STABLE: `適用完了`<br/>- NEED_TO_APPLY: `適用必要`<br/>- DELETED: `削除済み` |
+| parameterGroups.createdYmdt | Body | DateTime | 作成日時 |
+| parameterGroups.updatedYmdt | Body | DateTime | 修正日時 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -3974,96 +4483,22 @@ GET /v1.0/parameter-groups
     },
     "parameterGroups": [
         {
-            "parameterGroupId": "404e8a89-ca4d-4fca-96c2-1518754d50b7",
-            "parameterGroupName": "parameter-group",
+            "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "parameterGroupName": "parameterGroupName-example",
+            "description": "description-example",
+            "dbVersion": "POSTGRESQL_V14_17",
             "parameterGroupStatus": "STABLE",
-            "description": null,
-            "dbVersion": "POSTGRESQL_V17_6",
-            "createdYmdt": "2023-02-31T15:28:17+09:00",
-            "updatedYmdt": "2023-02-31T15:28:17+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
+
+</p>
 </details>
 
-
-### パラメータグループ詳細を表示
-
-```http
-GET /v1.0/parameter-groups/{parameterGroupId}
-```
-
-#### 必要権限
-
-| 権限名                                | 説明           |
-|-------------------------------------|---------------|
-| RDSforPostgreSQL:ParameterGroup.Get | パラメータグループ詳細を表示 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前              | 種類 | 形式  | 必須 | 説明          |
-|------------------|-----|------|----|--------------|
-| parameterGroupId | URL | UUID | O  | パラメータグループの識別子 |
-
-#### レスポンス
-
-| 名前                          | 種類  | 形式      | 説明                                                                                                                                                                                                                                                                                                                                                |
-|------------------------------|------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| parameterGroupId             | Body | UUID     | パラメータグループの識別子                                                                                                                                                                                                                                                                                                                                      |
-| parameterGroupName           | Body | String   | パラメータグループを識別できる名前                                                                                                                                                                                                                                                                                                                              |
-| description                  | Body | String   | パラメータグループの追加情報                                                                                                                                                                                                                                                                                                                                 |
-| dbVersion                    | Body | Enum     | DBバージョン情報                                                                                                                                                                                                                                                                                                                                          |
-| parameterGroupStatus         | Body | Enum     | パラメータグループの現在状態<br/>- `STABLE`:適用完了<br/>- `NEED_TO_APPLY`:適用必要<br/>- `DELETED`:削除済み                                                                                                                                                                                                                                                            |
-| parameters                   | Body | Array    | パラメータリスト                                                                                                                                                                                                                                                                                                                                           |
-| parameters.parameterCategory | Body | String   | パラメータカテゴリー                                                                                                                                                                                                                                                                                                                                         |
-| parameters.parameterName     | Body | String   | パラメータ名                                                                                                                                                                                                                                                                                                                                           |
-| parameters.value             | Body | String   | 現在設定されている値                                                                                                                                                                                                                                                                                                                                          |
-| parameters.valueUnit         | Body | Enum     | 現在設定されている値の単位<br/>- `B`:バイト<br/>- `kB`:キロバイト<br/>- `MB`:メガバイト<br/>- `GB`:ギガバイト<br/>- `TB`:テラバイト<br/>- `us`:マイクロ秒<br/>- `ms`:ミリ秒<br/>- `s`:秒<br/>- `min`:分<br/>- `h`:時間<br/>- `d`:日                                                                                                                                                        |
-| parameters.defaultValue      | Body | String   | デフォルト値                                                                                                                                                                                                                                                                                                                                               |
-| parameters.allowedValue      | Body | String   | 許可された値                                                                                                                                                                                                                                                                                                                                             |
-| parameters.valueType         | Body | Enum     | 値タイプ<br/>- `BOOLEAN`:ブーリアンタイプ<br/>- `STRING`:文字列タイプ<br/>- `NUMERIC`:整数および浮動小数点タイプ<br/>- `NUMERIC_WITH_BYTE_UNIT`:バイト単位の数字タイプ(例：120KB、100MB)<br/>- `NUMERIC_WITH_TIME_UNIT`:時間単位の数字タイプ(例：120ms、100s、1d)<br/>- `ENUMERATED`:許可された値に宣言された値の中から1つを入力<br/>- `MULTI_ENUMERATED`:許可された値に宣言された値の中から複数個を入力(コンマ(,)で区分される)<br/>- `TIMEZONE`:タイムゾーンタイプ |
-| parameters.updateType        | Body | Enum     | 修正タイプ<br/>- `VARIABLE`:常に修正可能<br/>- `CONSTANT`:修正 不可能                                                                                                                                                                                                                                                                                        |
-| parameters.applyType         | Body | Enum     | 適用タイプ<br/>- `SESSION`:セッション適用<br/>- `FILE`:設定ファイル適用(再起動必要)<br/>- `BOTH`:全体                                                                                                                                                                                                                                                                      | 
-| createdYmdt                  | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                                                                                                                                                                                  |
-| updatedYmdt                  | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                                                                                                                                                                                  |
-| expressionAvailable          | Body | Boolean  | 数式の使用可否                                                                                                                                                                                                                                                                                                                                           |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroupId": "404e8a89-ca4d-4fca-96c2-1518754d50b7",
-    "parameterGroupName": "parameter-group",
-    "description": null,
-    "dbVersion": "POSTGRESQL_V17_6",
-    "parameterGroupStatus": "STABLE",
-    "parameters": [
-        {
-            "parameterCategory": "Write-Ahead Log / Checkpoints",
-            "parameterName": "checkpoint_timeout",
-            "value": "300s",
-            "defaultValue": "300s",
-            "allowedValue": "30~86400s",
-            "valueType": "NUMERIC_WITH_TIME_UNIT",
-            "updateType": "VARIABLE",
-            "applyType": "BOTH",
-            "expressionAvailable": true
-        }
-    ],
-    "createdYmdt": "2023-03-13T11:02:28+09:00",
-    "updatedYmdt": "2023-03-13T11:02:28+09:00"
-}
-```
-</details>
-
+---
 
 ### パラメータグループの作成
 
@@ -4073,36 +4508,40 @@ POST /v1.0/parameter-groups
 
 #### 必要権限
 
-| 権限名                                   | 説明          |
-|----------------------------------------|--------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:ParameterGroup.Create | パラメータグループの作成 |
 
 #### リクエスト
 
-| 名前                | 種類  | 形式    | 必須 | 説明                  |
-|--------------------|------|--------|----|----------------------|
-| parameterGroupName | Body | String | O  | パラメータグループを識別できる名前 |
-| description        | Body | String | X  | パラメータグループの追加情報   |
-| dbVersion          | Body | Enum   | O  | DBバージョン情報            |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupName | Body | String | O | パラメータグループを識別できる名前 |
+| description | Body | String | X | パラメータグループの追加情報 |
+| dbVersion | Body | Enum | O | DBバージョン情報 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
-    "parameterGroupName": "parameter-group",
-    "description": "description",
-    "dbVersion": "POSTGRESQL_V17_6"
+    "parameterGroupName": "parameterGroupName-example",
+    "description": "description-example",
+    "dbVersion": "POSTGRESQL_V14_17"
 }
 ```
+
+</p>
 </details>
 
 #### レスポンス
 
-| 名前              | 種類  | 形式  | 説明          |
-|------------------|------|------|--------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | parameterGroupId | Body | UUID | パラメータグループの識別子 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -4111,194 +4550,14 @@ POST /v1.0/parameter-groups
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "parameterGroupId": "404e8a89-ca4d-4fca-96c2-1518754d50b7"
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
 
-### パラメータグループのコピー
-
-```http
-POST /v1.0/parameter-groups/{parameterGroupId}/copy
-```
-
-#### 必要権限
-
-| 権限名                                 | 説明          |
-|--------------------------------------|--------------|
-| RDSforPostgreSQL:ParameterGroup.Copy | パラメータグループのコピー |
-
-#### リクエスト
-
-| 名前                | 種類  | 形式    | 必須 | 説明                  |
-|--------------------|------|--------|----|----------------------|
-| parameterGroupId   | URL  | UUID   | O  | パラメータグループの識別子        |
-| parameterGroupName | Body | String | O  | パラメータグループを識別できる名前 |
-| description        | Body | String | X  | パラメータグループの追加情報   |
-
-<details><summary>例</summary>
-
-```json
-{
-    "parameterGroupName": "parameter-group-copy",
-    "description": "copy"
-}
-```
-</details>
-
-#### レスポンス
-
-| 名前              | 種類  | 形式  | 説明          |
-|------------------|------|------|--------------|
-| parameterGroupId | Body | UUID | パラメータグループの識別子 |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroupId": "404e8a89-ca4d-4fca-96c2-1518754d50b7"
-}
-```
-</details>
-
-### パラメータグループの修正
-
-```http
-PUT /v1.0/parameter-groups/{parameterGroupId}
-```
-
-#### 必要権限
-
-| 権限名                                   | 説明          |
-|----------------------------------------|--------------|
-| RDSforPostgreSQL:ParameterGroup.Modify | パラメータグループの修正 |
-
-#### リクエスト
-
-| 名前                | 種類  | 形式    | 必須 | 説明                  |
-|--------------------|------|--------|----|----------------------|
-| parameterGroupId   | URL  | UUID   | O  | パラメータグループの識別子        |
-| parameterGroupName | Body | String | X  | パラメータグループを識別できる名前 |
-| description        | Body | String | X  | パラメータグループの追加情報   |
-
-<details><summary>例</summary>
-
-```json
-{
-    "parameterGroupName": "parameter-group",
-    "description": "description"
-}
-```
-</details>
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
-
-### パラメータ修正
-
-```http
-PUT /v1.0/parameter-groups/{parameterGroupId}/parameters
-```
-
-#### 必要権限
-
-| 権限名                                   | 説明          |
-|----------------------------------------|--------------|
-| RDSforPostgreSQL:ParameterGroup.Modify | パラメータグループの修正 |
-
-#### リクエスト
-
-| 名前                              | 種類  | 形式    | 必須 | 説明          |
-|----------------------------------|------|--------|----|--------------|
-| parameterGroupId                 | URL  | UUID   | O  | パラメータグループの識別子 |
-| modifiedParameters               | Body | Array  | O  | 変更するパラメータリスト |
-| modifiedParameters.parameterName | Body | UUID   | O  | パラメータ名     |
-| modifiedParameters.value         | Body | String | O  | 変更するパラメータ値  |
-
-<details><summary>例</summary>
-
-```json
-{
-   "modifiedParameters": [
-       {
-           "parameterName": "checkpoint_timeout",
-           "value": "100s"
-       }
-   ]
-}
-```
-</details>
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
-
-### パラメータグループの再設定
-
-```http
-PUT /v1.0/parameter-groups/{parameterGroupId}/reset
-```
-
-#### 必要権限
-
-| 権限名                                  | 説明           |
-|---------------------------------------|---------------|
-| RDSforPostgreSQL:ParameterGroup.Reset | パラメータグループの再設定 |
-
-#### リクエスト
-
-| 名前              | 種類 | 形式  | 必須 | 説明          |
-|------------------|-----|------|----|--------------|
-| parameterGroupId | URL | UUID | O  | パラメータグループの識別子 |
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
+---
 
 ### パラメータグループの削除
 
@@ -4308,23 +4567,69 @@ DELETE /v1.0/parameter-groups/{parameterGroupId}
 
 #### 必要権限
 
-| 権限名                                   | 説明          |
-|----------------------------------------|--------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:ParameterGroup.Delete | パラメータグループの削除 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前              | 種類 | 形式  | 必須 | 説明          |
-|------------------|-----|------|----|--------------|
-| parameterGroupId | URL | UUID | O  | パラメータグループの識別子 |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O | パラメータグループの識別子 |
 
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
 
+---
+
+### パラメータグループ詳細を表示
+
+```http
+GET /v1.0/parameter-groups/{parameterGroupId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:ParameterGroup.Get | パラメータグループ詳細を表示 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O | パラメータグループの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| parameterGroupId | Body | UUID | パラメータグループの識別子 |
+| parameterGroupName | Body | String | パラメータグループを識別できる名前 |
+| description | Body | String | パラメータグループの追加情報 |
+| dbVersion | Body | Enum | DBバージョン情報 |
+| parameterGroupStatus | Body | Enum | パラメータグループの現在状態<br/>- STABLE: `適用完了`<br/>- NEED_TO_APPLY: `適用必要`<br/>- DELETED: `削除済み` |
+| parameters | Body | Array | パラメータリスト |
+| parameters.parameterCategory | Body | String | パラメータカテゴリー |
+| parameters.parameterName | Body | String | パラメータ名 |
+| parameters.value | Body | String | 現在設定されている値 |
+| parameters.valueUnit | Body | String | 値の単位(バイト: B,kB,MB,GB,TB、時間: us,ms,s,min,h,d) |
+| parameters.defaultValue | Body | String | デフォルト値 |
+| parameters.allowedValue | Body | String | 許可された値 |
+| parameters.valueType | Body | Enum | 値タイプ<br/>- BOOLEAN: `ブーリアンタイプ`<br/> `* ex) on, off, true, false, yes, no, 1, 0`<br/>- STRING: `文字列タイプ`<br/>- NUMERIC: `整数および浮動小数点タイプ`<br/>- NUMERIC_WITH_BYTE_UNIT: `バイト単位の数字タイプ`<br/> `* ex) 120kB, 100MB`<br/> `* 許可されたバイト単位: B (bytes), kB (kilobytes), MB (megabytes), GB (gigabytes), and TB (terabytes)`<br/>- NUMERIC_WITH_TIME_UNIT: `時間単位の数字タイプ`<br/> `* ex) 120ms, 100s, 1d`<br/> `* 許可された時間単位: us (microseconds), ms (milliseconds), s (seconds), min (minutes), h (hours), and d (days)`<br/>- ENUMERATED: `許可された値に宣言された値の中から1つを選択(コンマ(,)で区分される)`<br/>- MULTI_ENUMERATED: `許可された値に宣言された値の中から複数個を選択(コンマ(,)で区分される)` |
+| parameters.updateType | Body | Enum | 修正タイプ<br/>- VARIABLE: `常に修正可能`<br/>- CONSTANT: `修正不可能` |
+| parameters.applyType | Body | Enum | 適用タイプ<br/>- BOTH: `セッション、設定ファイルの両方に適用`<br/>- SESSION: `セッションにのみ適用`<br/>- FILE: `設定ファイルにのみ適用` |
+| parameters.expressionAvailable | Body | Boolean | 数式の使用可否 |
+| createdYmdt | Body | DateTime | 作成日時 |
+| updatedYmdt | Body | DateTime | 修正日時 |
+
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -4332,11 +4637,202 @@ DELETE /v1.0/parameter-groups/{parameterGroupId}
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "parameterGroupName": "parameterGroupName-example",
+    "description": "description-example",
+    "dbVersion": "POSTGRESQL_V14_17",
+    "parameterGroupStatus": "STABLE",
+    "parameters": [
+        {
+            "parameterCategory": "parameterCategory-example",
+            "parameterName": "parameterName-example",
+            "value": "value-example",
+            "valueUnit": "valueUnit-example",
+            "defaultValue": "defaultValue-example",
+            "allowedValue": "allowedValue-example",
+            "valueType": "BOOLEAN",
+            "updateType": "VARIABLE",
+            "applyType": "BOTH",
+            "expressionAvailable": false
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
+
+</p>
 </details>
 
+---
+
+### パラメータグループの修正
+
+```http
+PUT /v1.0/parameter-groups/{parameterGroupId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:ParameterGroup.Modify | パラメータグループの修正 |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O | パラメータグループの識別子 |
+| parameterGroupName | Body | String | X | パラメータグループを識別できる名前 |
+| description | Body | String | X | パラメータグループの追加情報 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "parameterGroupName": "parameterGroupName-example",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
+
+### パラメータグループのコピー
+
+```http
+POST /v1.0/parameter-groups/{parameterGroupId}/copy
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:ParameterGroup.Copy | パラメータグループのコピー |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O | パラメータグループの識別子 |
+| parameterGroupName | Body | String | O | パラメータグループを識別できる名前 |
+| description | Body | String | X | パラメータグループの追加情報 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "parameterGroupName": "parameterGroupName-example",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| parameterGroupId | Body | UUID | パラメータグループの識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### パラメータ修正
+
+```http
+PUT /v1.0/parameter-groups/{parameterGroupId}/parameters
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:ParameterGroup.Modify | パラメータグループの修正 |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O | パラメータグループの識別子 |
+| modifiedParameters | Body | Array | O | 変更するパラメータリスト |
+| modifiedParameters.parameterName | Body | String | O | パラメータ名 |
+| modifiedParameters.value | Body | String | O | 変更するパラメータ値 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "modifiedParameters": [
+        {
+            "parameterName": "parameterName-example",
+            "value": "value-example"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
+
+### パラメータグループの再設定
+
+```http
+PUT /v1.0/parameter-groups/{parameterGroupId}/reset
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:ParameterGroup.Reset | パラメータグループの再設定 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O | パラメータグループの識別子 |
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
 ## ユーザーグループ
 
 ### ユーザーグループリストを表示
@@ -4347,8 +4843,8 @@ GET /v1.0/user-groups
 
 #### 必要権限
 
-| 権限名                            | 説明          |
-|---------------------------------|--------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:UserGroup.List | ユーザーグループリストを表示 |
 
 #### リクエスト
@@ -4357,16 +4853,17 @@ GET /v1.0/user-groups
 
 #### レスポンス
 
-| 名前                      | 種類  | 形式      | 説明                                                     |
-|--------------------------|------|----------|---------------------------------------------------------|
-| userGroups               | Body | Array    | ユーザーグループリスト                                              |
-| userGroups.userGroupId   | Body | UUID     | ユーザーグループの識別子                                            |
-| userGroups.userGroupName | Body | String   | ユーザーグループを識別できる名前                                    |
-| userGroupStatus          | Body | Enum     | ユーザーグループの現在状態<br/>- `CREATED`:作成済み<br/>- `DELETED`:削除済み |
-| userGroups.createdYmdt   | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                       |
-| userGroups.updatedYmdt   | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                       |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| userGroups | Body | Array | ユーザーグループリスト |
+| userGroups.userGroupId | Body | UUID | ユーザーグループの識別子 |
+| userGroups.userGroupName | Body | String | ユーザーグループを識別できる名前 |
+| userGroupStatus | Body | Enum | ユーザーグループの現在状態<br/>- CREATED<br/>- DELETED |
+| userGroups.createdYmdt | Body | DateTime | 作成日時 |
+| userGroups.updatedYmdt | Body | DateTime | 修正日時 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -4377,75 +4874,20 @@ GET /v1.0/user-groups
     },
     "userGroups": [
         {
-            "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-            "userGroupName": "dev-team",
+            "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "userGroupName": "userGroupName-example",
             "userGroupStatus": "CREATED",
-            "createdYmdt": "2023-02-23T10:07:54+09:00",
-            "updatedYmdt": "2023-02-26T01:15:50+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
+
+</p>
 </details>
 
-
-### ユーザーグループ詳細を表示
-
-```http
-GET /v1.0/user-groups/{userGroupId}
-```
-
-#### 必要権限
-
-| 権限名                           | 説明          |
-|--------------------------------|--------------|
-| RDSforPostgreSQL:UserGroup.Get | ユーザーグループ詳細を表示 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前         | 種類 | 形式  | 必須 | 説明         |
-|-------------|-----|------|----|-------------|
-| userGroupId | URL | UUID | O  | ユーザーグループの識別子 |
-
-#### レスポンス
-
-| 名前               | 種類  | 形式      | 説明                                                                                                       |
-|-------------------|------|----------|-----------------------------------------------------------------------------------------------------------|
-| userGroupId       | Body | UUID     | ユーザーグループの識別子                                                                                              |
-| userGroupName     | Body | String   | ユーザーグループを識別できる名前                                                                                      |
-| userGroupTypeCode | Body | Enum     | ユーザーグループ種類<br />`ENTIRE`:プロジェクトメンバー全体を含むユーザーグループ<br />`INDIVIDUAL_MEMBER`:特定プロジェクトメンバーを含むユーザーグループ |
-| userGroupStatus   | Body | Enum     | ユーザーグループの現在状態<br/>- `CREATED`:作成済み<br/>- `DELETED`:削除済み                                                  |
-| members           | Body | Array    | プロジェクトメンバーリスト                                                                                               |
-| members.memberId  | Body | UUID     | プロジェクトメンバーの識別子                                                                                             |
-| createdYmdt       | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                         |
-| updatedYmdt       | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                         |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-    "userGroupName": "dev-team",
-    "userGroupStatus": "CREATED",
-	"userGroupTypeCode": "INDIVIDUAL_MEMBER",
-    "members": [
-        {
-            "memberId": "1321e759-2ef3-4b85-9921-b13e918b24b5"
-        }
-    ],
-    "createdYmdt": "2023-02-23T10:07:54+09:00",
-    "updatedYmdt": "2023-02-26T01:15:50+09:00"
-}
-```
-</details>
-
+---
 
 ### ユーザーグループの作成
 
@@ -4455,78 +4897,40 @@ POST /v1.0/user-groups
 
 #### 必要権限
 
-| 権限名                              | 説明         |
-|-----------------------------------|-------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:UserGroup.Create | ユーザーグループの作成 |
 
 #### リクエスト
 
-| 名前           | 種類  | 形式     | 必須 | 説明                                                             |
-|---------------|------|---------|----|-----------------------------------------------------------------|
-| userGroupName | Body | String  | O  | ユーザーグループを識別できる名前                                            |
-| memberIds     | Body | Array   | O  | プロジェクトメンバーの識別子リスト<br />`selectAllYN`がtrueの場合、該当フィールド値は無視される |
-| selectAllYN   | Body | Boolean | X  | プロジェクトメンバー全体の有無<br />trueの場合、該当グループは全メンバーに対して設定される              |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| userGroupName | Body | String | O | ユーザーグループを識別できる名前 |
+| memberIds | Body | Array | O | プロジェクトメンバーの識別子リスト |
+| selectAllYN | Body | Boolean | O | プロジェクトメンバー全体の有無<br/>- デフォルト値: `false` |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
-    "userGroupName": "dev-team",
-    "memberIds": ["1321e759-2ef3-4b85-9921-b13e918b24b5"]
+    "userGroupName": "userGroupName-example",
+    "memberIds": [],
+    "selectAllYN": false
 }
 ```
 
-```json
-{
-    "userGroupName": "dev-team",
-    "selectAllYN":true
-}
-```
+</p>
 </details>
 
 #### レスポンス
 
-| 名前         | 種類  | 形式  | 説明         |
-|-------------|------|------|-------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | userGroupId | Body | UUID | ユーザーグループの識別子 |
 
-
-### ユーザーグループの修正
-
-```http
-PUT /v1.0/user-groups/{userGroupId}
-```
-
-#### 必要権限
-
-| 権限名                              | 説明         |
-|-----------------------------------|-------------|
-| RDSforPostgreSQL:UserGroup.Modify | ユーザーグループの修正 |
-
-#### リクエスト
-
-| 名前           | 種類  | 形式     | 必須 | 説明                                                |
-|---------------|------|---------|----|----------------------------------------------------|
-| userGroupId   | URL  | UUID    | O  | ユーザーグループの識別子                                       |
-| userGroupName | Body | String  | X  | ユーザーグループを識別できる名前                               |
-| memberIds     | Body | Array   | X  | プロジェクトメンバーの識別子リスト                                   |
-| selectAllYN   | Body | Boolean | X  | プロジェクトメンバー全体の有無<br />trueの 場合、該当グループは全メンバーに対して設定される |
-
 <details><summary>例</summary>
-
-```json
-{
-    "userGroupName": "dev-team",
-    "memberIds": ["1321e759-2ef3-4b85-9921-b13e918b24b5","f9064b09-2b15-442e-a4b0-3a5a2754555e"]
-}
-```
-</details>
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
-
-<details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -4534,10 +4938,15 @@ PUT /v1.0/user-groups/{userGroupId}
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "userGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
+
+---
 
 ### ユーザーグループの削除
 
@@ -4547,21 +4956,59 @@ DELETE /v1.0/user-groups/{userGroupId}
 
 #### 必要権限
 
-| 権限名                              | 説明         |
-|-----------------------------------|-------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:UserGroup.Delete | ユーザーグループの削除 |
 
 #### リクエスト
 
-| 名前         | 種類 | 形式  | 必須 | 説明         |
-|-------------|-----|------|----|-------------|
-| userGroupId | URL | UUID | O  | ユーザーグループの識別子 |
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | O | ユーザーグループの識別子 |
 
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
 
+---
+
+### ユーザーグループ詳細を表示
+
+```http
+GET /v1.0/user-groups/{userGroupId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:UserGroup.Get | ユーザーグループ詳細を表示 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | O | ユーザーグループの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| userGroupId | Body | UUID | ユーザーグループの識別子 |
+| userGroupName | Body | String | ユーザーグループを識別できる名前 |
+| userGroupTypeCode | Body | Enum | ユーザーグループ種類<br/>- ENTIRE: `プロジェクトメンバー全体`<br/>- INDIVIDUAL_MEMBER: `ユーザー指定` |
+| userGroupStatus | Body | Enum | ユーザーグループの現在状態<br/>- CREATED<br/>- DELETED |
+| members | Body | Array | プロジェクトメンバーリスト |
+| members.memberId | Body | UUID | プロジェクトメンバーの識別子 |
+| createdYmdt | Body | DateTime | 作成日時 |
+| updatedYmdt | Body | DateTime | 修正日時 |
+
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -4569,11 +5016,66 @@ DELETE /v1.0/user-groups/{userGroupId}
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "userGroupName": "userGroupName-example",
+    "userGroupTypeCode": "ENTIRE",
+    "userGroupStatus": "CREATED",
+    "members": [
+        {
+            "memberId": "550e8400-e29b-41d4-a716-446655440000"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
+
+</p>
 </details>
 
+---
+
+### ユーザーグループの修正
+
+```http
+PUT /v1.0/user-groups/{userGroupId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:UserGroup.Modify | ユーザーグループの修正 |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | O | ユーザーグループの識別子 |
+| userGroupName | Body | String | X | ユーザーグループを識別できる名前 |
+| memberIds | Body | Array | X | プロジェクトメンバーの識別子リスト |
+| selectAllYN | Body | Boolean | O | プロジェクトメンバー全体の有無<br/>- デフォルト値: `false` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "userGroupName": "userGroupName-example",
+    "memberIds": [],
+    "selectAllYN": false
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
 ## 通知グループ
 
 ### 通知グループリストを表示
@@ -4584,8 +5086,8 @@ GET /v1.0/notification-groups
 
 #### 必要権限
 
-| 権限名                                    | 説明         |
-|-----------------------------------------|-------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:NotificationGroup.List | 通知グループリストを表示 |
 
 #### リクエスト
@@ -4594,19 +5096,20 @@ GET /v1.0/notification-groups
 
 #### レスポンス
 
-| 名前                                        | 種類  | 形式      | 説明                                                    |
-|--------------------------------------------|------|----------|--------------------------------------------------------|
-| notificationGroups                         | Body | Array    | 通知グループリスト                                              |
-| notificationGroups.notificationGroupId     | Body | UUID     | 通知グループの識別子                                            |
-| notificationGroups.notificationGroupName   | Body | String   | 通知グループを識別できる名前                                    |
-| notificationGroups.notificationGroupStatus | Body | Enum     | 通知グループの現在状態<br/>- `CREATED`:作成済み<br/>- `DELETED`:削除済み |
-| notificationGroups.notifyEmail             | Body | Boolean  | メール通知の有無                                              |
-| notificationGroups.notifySms               | Body | Boolean  | SMS通知の有無                                              |
-| notificationGroups.isEnabled               | Body | Boolean  | 有効かどうか                                                 |
-| notificationGroups.createdYmdt             | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                      |
-| notificationGroups.updatedYmdt             | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                      |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| notificationGroups | Body | Array |  |
+| notificationGroups.notificationGroupId | Body | UUID | 通知グループの識別子 |
+| notificationGroups.notificationGroupName | Body | String | 通知グループを識別できる名前 |
+| notificationGroups.notificationGroupStatus | Body | Enum | 通知グループの現在状態<br/>- CREATED: `作成済み`<br/>- DELETED: `削除済み` |
+| notificationGroups.notifyEmail | Body | Boolean | メール通知の有無 |
+| notificationGroups.notifySms | Body | Boolean | SMS通知の有無 |
+| notificationGroups.isEnabled | Body | Boolean | 有効かどうか |
+| notificationGroups.createdYmdt | Body | DateTime | 作成日時 |
+| notificationGroups.updatedYmdt | Body | DateTime | 修正日時 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -4617,91 +5120,23 @@ GET /v1.0/notification-groups
     },
     "notificationGroups": [
         {
-            "notificationGroupId": "b3901f17-9971-4d1e-8a81-8448cf533dc7",
-            "notificationGroupName": "dev-team-noti",
-            "notifyEmail": true,
+            "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "notificationGroupName": "notificationGroupName-example",
+            "notificationGroupStatus": "CREATED",
+            "notifyEmail": false,
             "notifySms": false,
-            "isEnabled": true,
-            "createdYmdt": "2023-02-20T13:34:13+09:00",
-            "updatedYmdt": "2023-02-20T13:34:13+09:00"
+            "isEnabled": false,
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
+
+</p>
 </details>
 
-
-### 通知グループ詳細を表示
-
-```http
-GET /v1.0/notification-groups/{notificationGroupId}
-```
-
-#### 必要権限
-
-| 権限名                                   | 説明         |
-|----------------------------------------|-------------|
-| RDSforPostgreSQL:NotificationGroup.Get | 通知グループ詳細を表示 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前                 | 種類 | 形式  | 必須 | 説明        |
-|---------------------|-----|------|----|------------|
-| notificationGroupId | URL | UUID | O  | 通知グループの識別子 |
-
-#### レスポンス
-
-| 名前                        | 種類  | 形式      | 説明                                                    |
-|----------------------------|------|----------|--------------------------------------------------------|
-| notificationGroupId        | Body | UUID     | 通知グループの識別子                                            |
-| notificationGroupName      | Body | String   | 通知グループを識別できる名前                                    |
-| notificationGroupStatus    | Body | Enum     | 通知グループの現在状態<br/>- `CREATED`:作成済み<br/>- `DELETED`:削除済み |
-| notifyEmail                | Body | Boolean  | メール通知の有無                                              |
-| notifySms                  | Body | Boolean  | SMS通知の有無                                              |
-| isEnabled                  | Body | Boolean  | 有効かどうか                                                 |
-| dbInstances                | Body | Array    | 監視対象のDBインスタンスリスト                                      |
-| dbInstances.dbInstanceId   | Body | UUID     | DBインスタンスの識別子                                          |
-| dbInstances.dbInstanceName | Body | String   | DBインスタンスを識別できる名前                                  |
-| userGroups                 | Body | Array    | ユーザーグループリスト                                             |
-| userGroups.userGroupId     | Body | UUID     | ユーザーグループの識別子                                           |
-| userGroups.userGroupName   | Body | String   | ユーザーグループを識別できる名前                                   |
-| createdYmdt                | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                      |
-| updatedYmdt                | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                      |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "notificationGroupId": "b3901f17-9971-4d1e-8a81-8448cf533dc7",
-    "notificationGroupName": "dev-team-noti",
-    "notifyEmail": true,
-    "notifySms": false,
-    "isEnabled": true,
-    "dbInstances": [
-        {
-            "dbInstanceId": "ed5cb985-526f-4c54-9ae0-40288593de65",
-            "dbInstanceName": "database"
-        }
-    ],
-    "userGroups": [
-        {
-            "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-            "userGroupName": "dev-team"
-        }
-    ],
-    "createdYmdt": "2023-02-20T13:34:13+09:00",
-    "updatedYmdt": "2023-02-20T13:34:13+09:00"
-}
-```
-</details>
-
+---
 
 ### 通知グループの作成
 
@@ -4711,80 +5146,46 @@ POST /v1.0/notification-groups
 
 #### 必要権限
 
-| 権限名                                      | 説明        |
-|-------------------------------------------|------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:NotificationGroup.Create | 通知グループの作成 |
 
 #### リクエスト
 
-| 名前                   | 種類  | 形式     | 必須 | 説明                         |
-|-----------------------|------|---------|----|-----------------------------|
-| notificationGroupName | Body | String  | O  | 通知グループを識別できる名前         |
-| notifyEmail           | Body | Boolean | X  | メール通知の有無<br/>- デフォルト値:`true` |
-| notifySms             | Body | Boolean | X  | SMS通知の有無<br/>- デフォルト値:`true` |
-| isEnabled             | Body | Boolean | X  | 有効かどうか<br/>- デフォルト値:`true`    |
-| dbInstanceIds         | Body | Array   | X  | 監視対象のDBインスタンスの識別子リスト      |
-| userGroupIds          | Body | Array   | X  | ユーザーグループの識別子リスト             |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| notificationGroupName | Body | String | O | 通知グループを識別できる名前 |
+| notifyEmail | Body | Boolean | X | メール通知の有無<br/>- デフォルト値: `true` |
+| notifySms | Body | Boolean | X | SMS通知の有無<br/>- デフォルト値: `true` |
+| isEnabled | Body | Boolean | X | 有効かどうか<br/>- デフォルト値: `true` |
+| dbInstanceIds | Body | Array | O | 監視対象のDBインスタンスの識別子リスト |
+| userGroupIds | Body | Array | O | ユーザーグループの識別子リスト |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
-    "notificationGroupName": "dev-team-noti",
-    "notifyEmail": false,
-    "isEnable": true,
-    "dbInstanceIds": ["ed5cb985-526f-4c54-9ae0-40288593de65"],
-    "userGroupIds": ["1aac0437-f32d-4923-ad3c-ac61c1cfdfe0"]
+    "notificationGroupName": "notificationGroupName-example",
+    "notifyEmail": true,
+    "notifySms": true,
+    "isEnabled": true,
+    "dbInstanceIds": [],
+    "userGroupIds": []
 }
 ```
+
+</p>
 </details>
 
 #### レスポンス
 
-| 名前                 | 種類  | 形式  | 説明        |
-|---------------------|------|------|------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | notificationGroupId | Body | UUID | 通知グループの識別子 |
 
-
-### 通知グループの修正
-
-```http
-PUT /v1.0/notification-groups/{notificationGroupId}
-```
-
-#### 必要権限
-
-| 権限名                                      | 説明        |
-|-------------------------------------------|------------|
-| RDSforPostgreSQL:NotificationGroup.Modify | 通知グループの修正 |
-
-#### リクエスト
-
-| 名前                   | 種類  | 形式     | 必須 | 説明                   |
-|-----------------------|------|---------|----|-----------------------|
-| notificationGroupId   | URL  | UUID    | O  | 通知グループの識別子           |
-| notificationGroupName | Body | String  | X  | 通知グループを識別できる名前   |
-| notifyEmail           | Body | Boolean | X  | メール通知の有無             |
-| notifySms             | Body | Boolean | X  | SMS通知の有無             |
-| isEnabled             | Body | Boolean | X  | 有効かどうか                |
-| dbInstanceIds         | Body | Array   | X  | 監視対象のDBインスタンスの識別子リスト |
-| userGroupIds          | Body | Array   | X  | ユーザーグループの識別子リスト       |
-
 <details><summary>例</summary>
-
-```json
-{
-    "notifyEmail": true,
-    "dbInstanceIds": ["ed5cb985-526f-4c54-9ae0-40288593de65", "d51b7da0-682f-47ff-b588-b739f6adc740"]
-}
-```
-</details>
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
-
-<details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -4792,10 +5193,15 @@ PUT /v1.0/notification-groups/{notificationGroupId}
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+</p>
 </details>
+
+---
 
 ### 通知グループの削除
 
@@ -4805,23 +5211,65 @@ DELETE /v1.0/notification-groups/{notificationGroupId}
 
 #### 必要権限
 
-| 権限名                                      | 説明        |
-|-------------------------------------------|------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:NotificationGroup.Delete | 通知グループの削除 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前                 | 種類 | 形式  | 必須 | 説明        |
-|---------------------|-----|------|----|------------|
-| notificationGroupId | URL | UUID | O  | 通知グループの識別子 |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O | 通知グループの識別子 |
 
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
 
+---
+
+### 通知グループ詳細を表示
+
+```http
+GET /v1.0/notification-groups/{notificationGroupId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:NotificationGroup.Get | 通知グループ詳細を表示 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O | 通知グループの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| notificationGroupId | Body | UUID | 通知グループの識別子 |
+| notificationGroupName | Body | String | 通知グループを識別できる名前 |
+| notificationGroupStatus | Body | Enum | 通知グループの現在状態<br/>- CREATED: `作成済み`<br/>- DELETED: `削除済み` |
+| notifyEmail | Body | Boolean | メール通知の有無 |
+| notifySms | Body | Boolean | SMS通知の有無 |
+| isEnabled | Body | Boolean | 有効かどうか |
+| dbInstances | Body | Array | 監視対象のDBインスタンスリスト |
+| dbInstances.dbInstanceId | Body | UUID | DBインスタンスの識別子 |
+| dbInstances.dbInstanceName | Body | String | DBインスタンスを識別できる名前 |
+| userGroups | Body | Array | ユーザーグループリスト |
+| userGroups.userGroupId | Body | UUID | ユーザーグループの識別子 |
+| userGroups.userGroupName | Body | String | ユーザーグループを識別できる名前 |
+| createdYmdt | Body | DateTime | 作成日時 |
+| updatedYmdt | Body | DateTime | 修正日時 |
+
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -4829,10 +5277,81 @@ DELETE /v1.0/notification-groups/{notificationGroupId}
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "notificationGroupName": "notificationGroupName-example",
+    "notificationGroupStatus": "CREATED",
+    "notifyEmail": false,
+    "notifySms": false,
+    "isEnabled": false,
+    "dbInstances": [
+        {
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbInstanceName": "dbInstanceName-example"
+        }
+    ],
+    "userGroups": [
+        {
+            "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "userGroupName": "userGroupName-example"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
+
+</p>
 </details>
+
+---
+
+### 通知グループの修正
+
+```http
+PUT /v1.0/notification-groups/{notificationGroupId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:NotificationGroup.Modify | 通知グループの修正 |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O | 通知グループの識別子 |
+| notificationGroupName | Body | String | X | 通知グループを識別できる名前 |
+| notifyEmail | Body | Boolean | X | メール通知の有無<br/>- デフォルト値: `false` |
+| notifySms | Body | Boolean | X | SMS通知の有無<br/>- デフォルト値: `false` |
+| isEnabled | Body | Boolean | X | 有効かどうか<br/>- デフォルト値: `false` |
+| dbInstanceIds | Body | Array | O | 監視対象のDBインスタンスの識別子リスト |
+| userGroupIds | Body | Array | O | ユーザーグループの識別子リスト |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "notificationGroupName": "notificationGroupName-example",
+    "notifyEmail": false,
+    "notifySms": false,
+    "isEnabled": false,
+    "dbInstanceIds": [],
+    "userGroupIds": []
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
 
 ### 監視設定リストを表示
 
@@ -4842,28 +5361,32 @@ GET /v1.0/notification-groups/{notificationGroupId}/watchdogs
 
 #### 必要権限
 
-| 権限名                                       | 説明         |
-|--------------------------------------------|-------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:NotificationWatchdog.List | 監視設定リストを表示 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O | 通知グループの識別子 |
+
 #### レスポンス
 
-| 名前                          | 種類  | 形式      | 説明                                                                    |
-|------------------------------|------|----------|------------------------------------------------------------------------|
-| notificationGroupId          | URL  | UUID     | 通知グループの識別子                                                            | 通知グループの識別子                                                           |
-| watchdogs                    | Body | Array    | 監視設定リスト                                                              |
-| watchdogs.watchdogId         | Body | UUID     | 監視設定の識別子                                                            |
-| watchdogs.metricName         | Body | Enum     | 監視対象の性能指標<br/>- 設定可能な性能指標は[性能指標リスト表示](#性能-指標-リスト-表示)項目を参照してください。 |
-| watchdogs.comparisonOperator | Body | Enum     | 監視対象の比較方法<br/>- `LE`: <=<br/>- `LT`: <<br/>- `GE`: >=<br/>- `GT`: >  |
-| watchdogs.threshold          | Body | Long     | 監視対象のしきい値                                                             |
-| watchdogs.duration           | Body | Long     | 監視対象の持続時間<br/>- 単位:`分`                                              |
-| watchdogs.createdYmdt        | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                      |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| notificationWatchdogs | Body | Array | 監視設定情報 |
+| notificationWatchdogs.watchdogId | Body | UUID | 監視設定の識別子 |
+| notificationWatchdogs.metricName | Body | String | 監視対象の性能指標 |
+| notificationWatchdogs.comparisonOperator | Body | Enum | 監視対象の比較方法<br/>- LE: `<=`<br/>- LT: `<`<br/>- GE: `>=`<br/>- GT: `>` |
+| notificationWatchdogs.threshold | Body | Number | 監視対象のしきい値 |
+| notificationWatchdogs.duration | Body | Number | 監視対象の持続時間 |
+| notificationWatchdogs.createdYmdt | Body | DateTime | 作成日時 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -4872,20 +5395,23 @@ GET /v1.0/notification-groups/{notificationGroupId}/watchdogs
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "watchdogs": [
+    "notificationWatchdogs": [
         {
-            "watchdogId": "b3901f17-9971-4d1e-8a81-8448cf533dc7",
-            "metricName": "DATABASE_STATUS",
+            "watchdogId": "550e8400-e29b-41d4-a716-446655440000",
+            "metricName": "metricName-example",
             "comparisonOperator": "LE",
-            "threshold": 0,
-            "duration": 5,
-            "createdYmdt": "2023-02-20T13:34:13+09:00",
-            "updatedYmdt": "2023-02-20T13:34:13+09:00"
+            "threshold": 1,
+            "duration": 1,
+            "createdYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
+
+</p>
 </details>
+
+---
 
 ### 監視設定の作成
 
@@ -4895,38 +5421,86 @@ POST /v1.0/notification-groups/{notificationGroupId}/watchdogs
 
 #### 必要権限
 
-| 権限名                                         | 説明        |
-|----------------------------------------------|------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:NotificationWatchdog.Create | 監視設定の作成 |
 
 #### リクエスト
 
-| 名前                 | 種類  | 形式  | 必須 | 説明                                                                    |
-|---------------------|------|------|----|------------------------------------------------------------------------|
-| notificationGroupId | URL  | UUID | O  | 通知グループの識別子                                                            |
-| metricName          | Body | Enum | O  | 監視対象の性能指標<br/>- 設定可能な性能指標は[性能指標リスト表示](#性能-指標-リスト-表示)項目を参照してください。 |
-| comparisonOperator  | Body | Enum | O  | 監視対象の比較方法<br/>- `LE`: <=<br/>- `LT`: <<br/>- `GE`: >=<br/>- `GT`: >  |
-| threshold           | Body | Long | O  | 監視対象しきい値                                                             |
-| duration            | Body | Long | O  | 監視対象持続時間<br/>- 単位:`分`                                              |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O | 通知グループの識別子 |
+| metricName | Body | String | O | 監視対象の性能指標 |
+| comparisonOperator | Body | Enum | O | 監視対象の比較方法<br/>- LE: `<=`<br/>- LT: `<`<br/>- GE: `>=`<br/>- GT: `>` |
+| threshold | Body | Number | O | 監視対象のしきい値<br/>- 最小値: `0` |
+| duration | Body | Number | O | 監視対象の持続時間（分）<br/>- 最小値: `0` |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
-    "metricName": "DATABASE_STATUS",
+    "metricName": "metricName-example",
     "comparisonOperator": "LE",
     "threshold": 0,
-    "duration": 5
+    "duration": 0
 }
 ```
+
+</p>
 </details>
 
 #### レスポンス
 
-| 名前        | 種類  | 形式  | 説明        |
-|------------|------|------|------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | watchdogId | Body | UUID | 監視設定の識別子 |
 
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "watchdogId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 通知グループの削除
+
+```http
+DELETE /v1.0/notification-groups/{notificationGroupId}/watchdogs/{watchdogId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:NotificationWatchdog.Delete | 通知グループの削除 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O | 通知グループの識別子 |
+| watchdogId | URL | UUID | O | 監視設定の識別子 |
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
 
 ### 監視設定の修正
 
@@ -4936,89 +5510,64 @@ PUT /v1.0/notification-groups/{notificationGroupId}/watchdogs/{watchdogId}
 
 #### 必要権限
 
-| 権限名                                         | 説明        |
-|----------------------------------------------|------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforPostgreSQL:NotificationWatchdog.Modify | 監視設定の修正 |
 
 #### リクエスト
 
-| 名前                 | 種類  | 形式  | 必須 | 説明                                                                    |
-|---------------------|------|------|----|------------------------------------------------------------------------|
-| notificationGroupId | URL  | UUID | O  | 通知グループの識別子                                                            |
-| watchdogId          | URL  | UUID | O  | 監視設定の識別子                                                            |
-| metricName          | Body | Enum | O  | 監視対象の性能指標<br/>- 設定可能な性能指標は[性能指標リスト表示](#性能-指標-リスト-表示)項目を参照してください。 |
-| comparisonOperator  | Body | Enum | O  | 監視対象の比較方法<br/>- `LE`: <=<br/>- `LT`: <<br/>- `GE`: >=<br/>- `GT`: >  |
-| threshold           | Body | Long | O  | 監視対象のしきい値                                                             |
-| duration            | Body | Long | O  | 監視対象の持続時間<br/>- 単位:`分`                                              |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O | 通知グループの識別子 |
+| watchdogId | URL | UUID | O | 監視設定の識別子 |
+| metricName | Body | String | O | 監視対象の性能指標 |
+| comparisonOperator | Body | Enum | O | 監視対象の比較方法<br/>- LE: `<=`<br/>- LT: `<`<br/>- GE: `>=`<br/>- GT: `>` |
+| threshold | Body | Number | O | 監視対象のしきい値<br/>- 最小値: `0` |
+| duration | Body | Number | O | 監視対象の持続時間（分）<br/>- 最小値: `0` |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
-    "metricName": "DATABASE_STATUS",
+    "metricName": "metricName-example",
     "comparisonOperator": "LE",
     "threshold": 0,
-    "duration": 10
+    "duration": 0
 }
 ```
+
+</p>
 </details>
 
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
 
-<details><summary>例</summary>
+---
+## モニタリング
 
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
-
-### 監視設定の削除
+### 統計情報照会
 
 ```http
-DELETE /v1.0/notification-groups/{notificationGroupId}/watchdogs/{watchdogId}
+GET /v1.0/metric-statistics
 ```
 
 #### 必要権限
 
-| 権限名                                         | 説明        |
-|----------------------------------------------|------------|
-| RDSforPostgreSQL:NotificationWatchdog.Delete | 監視設定の削除 |
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:Metric.List | 統計情報照会 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前                 | 種類 | 形式  | 必須 | 説明        |
-|---------------------|-----|------|----|------------|
-| notificationGroupId | URL | UUID | O  | 通知グループの識別子 |
-| watchdogId          | URL | UUID | O  | 監視設定の識別子 |
-
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
 
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-</details>
-
-## モニタリング
+---
 
 ### 性能指標リストを表示
 
@@ -5028,9 +5577,9 @@ GET /v1.0/metrics
 
 #### 必要権限
 
-| 権限名                         | 説明      |
-|------------------------------|----------|
-| RDSforPostgreSQL:Metric.List | 統計情報照会 |
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:Metric.List | 性能指標リストを表示 |
 
 #### リクエスト
 
@@ -5038,13 +5587,14 @@ GET /v1.0/metrics
 
 #### レスポンス
 
-| 名前                | 種類  | 形式    | 説明      |
-|--------------------|------|--------|----------|
-| metrics            | Body | Array  | 性能指標リスト |
-| metrics.metricName | Body | Enum   | 性能指標タイプ |
-| metrics.unit       | Body | String | 測定値単位  |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| metrics | Body | Array | 性能指標リスト |
+| metrics.metricName | Body | String | 性能指標タイプ |
+| metrics.unit | Body | String | 測定値単位 |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -5055,159 +5605,32 @@ GET /v1.0/metrics
     },
     "metrics": [
         {
-            "metricName": "CPU_USAGE",
-            "unit": "%"
+            "metricName": "metricName-example",
+            "unit": "unit-example"
         }
     ]
 }
 ```
+
+</p>
 </details>
 
-### 統計情報照会
-
-```http
-GET /v1.0/metric-statistics
-```
-
-#### 必要権限
-
-| 権限名                         | 説明      |
-|------------------------------|----------|
-| RDSforPostgreSQL:Metric.List | 統計情報照会 |
-
-#### リクエスト
-
-| 名前          | 種類   | 形式      | 必須 | 説明                                                       |
-|--------------|-------|----------|----|-----------------------------------------------------------|
-| dbInstanceId | Query | UUID     | O  | DBインスタンスの識別子                                             |
-| metricNames  | Query | Array    | O  | 照会する性能指標リスト<br/>- 最小サイズ:`1`                             |
-| from         | Query | Datetime | O  | 開始日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                         |
-| to           | Query | Datetime | O  | 終了日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                         |
-| interval     | Query | Number   | X  | 照会間隔<br/>- 単位:`分`<br/>- デフォルト値:開始/終了日時に応じて適切な値を自動選択する |
-
-#### レスポンス
-
-| 名前                               | 種類  | 形式       | 説明      |
-|-----------------------------------|------|-----------|----------|
-| metricStatistics                  | Body | Array     | 統計情報リスト |
-| metricStatistics.metricName       | Body | Enum      | 性能指標タイプ |
-| metricStatistics.unit             | Body | String    | 測定値単位  |
-| metricStatistics.values           | Body | Array     | 測定値リスト  |
-| metricStatistics.values.timestamp | Body | Timestamp | 測定時間   |
-| metricStatistics.values.value     | Body | Object    | 測定値     |
-
-<details><summary>例</summary>
-
-```json
-{
-    "metricStatistics": [
-        {
-            "metricName": "DATABASE_STATUS",
-            "unit": "",
-            "values": [
-                [
-                    1679298540,
-                    "1"
-                ],
-                [
-                    1679298600,
-                    "1"
-                ],
-                [
-                    1679298660,
-                    "1"
-                ]
-            ]
-        }
-    ]
-}
-```
-</details>
+---
 
 ## イベント
 
-### イベントリストを表示
+### イベントカテゴリー
 
-```
-GET /v1.0/events
-```
+イベントはカテゴリーで分類でき、以下のとおりです。
 
-#### 必要権限
-
-| 権限名                        | 説明       |
-|-----------------------------|-----------|
-| RDSforPostgreSQL:Event.List | イベントリスト表示 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前               | 種類   | 形式      | 必須 | 説明                                                                                                                                                                              |
-|-------------------|-------|----------|----|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| page              | Query | Number   | O  | 照会するリストのページ<br/>- 最小値:`1`                                                                                                                                                       |
-| size              | Query | Number   | O  | 照会するリストのページサイズ<br/>- 最小値:`1`<br/>- 最大値:`100`                                                                                                                                   |
-| from              | Query | Datetime | O  | 開始日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                |
-| to                | Query | Datetime | O  | 終了日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                |
-| eventCategoryType | Query | Enum     | O  | 照会するイベントカテゴリータイプ<br/>- `ALL`:全体<br/>- `BACKUP`:バックアップ<br/>- `DB_INSTANCE`:DBインスタンス<br/>- `DB_SECURITY_GROUP`:DBセキュリティグループ<br/>- `JOB`:作業<br/>- `TENANT`:テナント<br/>- `MONITORING`:モニタリング |
-| sourceId          | Query | String   | X  | イベントが発生した対象リソースの識別子                                                                                                                                                            |
-| keyword           | Query | String   | X  | イベントメッセージに含まれた文字列検索ワード                                                                                                                                                            |
-
-#### レスポンス
-
-| 名前                      | 種類  | 形式      | 説明                                                |
-|--------------------------|------|----------|----------------------------------------------------|
-| totalCounts              | Body | Number   | 全体のイベントリスト数                                        |
-| events                   | Body | Array    | イベントリスト                                            |
-| events.eventCategoryType | Body | Enum     | イベントカテゴリータイプ                                       |
-| events.eventCode         | Body | Enum     | 発生したイベントのタイプ<br/>- 詳細は[イベント](event/)項目を参照してください。 |
-| events.sourceId          | Body | String   | イベントソースの識別子                                       |
-| events.sourceName        | Body | String   | イベントソースを識別できる名前                               |
-| events.messages          | Body | Array    | イベントメッセージリスト                                        |
-| events.messages.langCode | Body | String   | 言語コード                                             |
-| events.messages.message  | Body | String   | イベントメッセージ                                           |
-| events.eventYmdt         | Body | DateTime | イベント発生日時(YYYY-MM-DDThh:mm:ss.SSSTZD)              |
-
-<details><summary>例</summary>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 28,
-    "events": [
-        {
-            "eventCategoryType": "DB_INSTANCE",
-            "eventCode": "DB_INSTANCE_02_01",
-            "sourceId": "76f00947-356e-4a20-8922-428368cc45ed",
-            "sourceName": "db-instance",
-            "messages": [
-                {
-                    "langCode": "EN",
-                    "message": "DB instance started"
-                },
-                {
-                    "langCode": "JA",
-                    "message": "DBインスタンスの起動"
-                },
-                {
-                    "langCode": "KO",
-                    "message": "DBインスタンス開始"
-                },
-                {
-                    "langCode": "ZH",
-                    "message": "DB instance started"
-                }
-            ],
-            "eventYmdt": "2023-03-20T16:31:59+09:00"
-        }
-    ]
-}
-```
-</details>
-
+| イベントカテゴリー | 説明 |
+|-------------|---------|
+| ALL         | 全体 |
+| BACKUP      | バックアップ |
+| DB_INSTANCE | DBインスタンス |
+| JOB         | 作業 |
+| TENANT      | テナント |
+| MONITORING  | モニタリング |
 
 ### 購読可能なイベントコードリストを表示
 
@@ -5217,9 +5640,9 @@ GET /v1.0/event-codes
 
 #### 必要権限
 
-| 権限名                        | 説明       |
-|-----------------------------|-----------|
-| RDSforPostgreSQL:Event.List | イベントリストを表示 |
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:Event.List | 購読可能なイベントコードリストを表示 |
 
 #### リクエスト
 
@@ -5227,13 +5650,14 @@ GET /v1.0/event-codes
 
 #### レスポンス
 
-| 名前                          | 種類  | 形式   | 説明         |
-|------------------------------|------|-------|-------------|
-| eventCodes                   | Body | Array | イベントコードリスト  |
-| eventCodes.eventCode         | Body | Enum  | イベントコード     |
-| eventCodes.eventCategoryType | Body | Enum  | イベントカテゴリータイプ |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| eventCodes | Body | Array | イベントコードリスト |
+| eventCodes.eventCode | Body | Enum | イベントコード |
+| eventCodes.eventCategoryType | Body | Enum | イベントカテゴリータイプ<br/>- ALL: `全体`<br/>- DB_INSTANCE: `DBインスタンスで発生したイベント`<br/>- DB_SECURITY_GROUP: `DBセキュリティグループで発生したイベント`<br/>- MONITORING: `モニタリングで発生したイベント`<br/>- JOB: `JOBで発生したイベント`<br/>- BACKUP: `バックアップで発生したイベント`<br/>- TENANT: `テナントで発生したイベント` |
 
 <details><summary>例</summary>
+<p>
 
 ```json
 {
@@ -5244,10 +5668,79 @@ GET /v1.0/event-codes
     },
     "eventCodes": [
         {
-            "eventCode": "DB_INSTANCE_02_01",
-            "eventCategoryType": "DB_INSTANCE"
+            "eventCode": "ENUM_VALUE",
+            "eventCategoryType": "ALL"
         }
     ]
 }
 ```
+
+</p>
 </details>
+
+---
+
+### イベントリストを表示
+
+```http
+GET /v1.0/events
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforPostgreSQL:Event.List | イベントリストを表示 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | 全体のイベントリスト数 |
+| events | Body | Array | イベントリスト |
+| events.eventCategoryType | Body | Enum | イベントカテゴリータイプ<br/>- ALL: `全体`<br/>- DB_INSTANCE: `DBインスタンスで発生したイベント`<br/>- DB_SECURITY_GROUP: `DBセキュリティグループで発生したイベント`<br/>- MONITORING: `モニタリングで発生したイベント`<br/>- JOB: `JOBで発生したイベント`<br/>- BACKUP: `バックアップで発生したイベント`<br/>- TENANT: `テナントで発生したイベント` |
+| events.eventCode | Body | Enum | 発生したイベントのタイプ |
+| events.sourceId | Body | UUID | イベントソースの識別子 |
+| events.sourceName | Body | String | イベントソースを識別できる名前 |
+| events.messages | Body | Array | イベントメッセージリスト |
+| events.messages.langCode | Body | Enum | 言語コード<br/>- KO<br/>- EN<br/>- JA<br/>- ZH |
+| events.messages.message | Body | String | イベントメッセージ |
+| events.eventYmdt | Body | DateTime | イベント発生日時 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "totalCounts": 1,
+    "events": [
+        {
+            "eventCategoryType": "ALL",
+            "eventCode": "ENUM_VALUE",
+            "sourceId": "550e8400-e29b-41d4-a716-446655440000",
+            "sourceName": "sourceName-example",
+            "messages": [
+                {
+                    "langCode": "KO",
+                    "message": "message-example"
+                }
+            ],
+            "eventYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---


### PR DESCRIPTION
nc-rds `feature/4321` 코드 기반으로 재생성된 KO 가이드에 대응하는 **EN/JA 번역 초안**입니다.
기존 `feature/4321`(KO 갱신) 브랜치 위에 쌓는 스택 PR이라, diff 는 EN/JA 추가·갱신분만 보입니다.

## 방식
- **용어 메모리(KO→EN→JA)**: 기존 발행 번역에서 실제 쓰인 용어를 1순위로 채택(예: 읽기 복제본→read replica/リードレプリカ, 시점 복원→point-in-time recovery/時点復元). glossary 코드 용어와 충돌 시 발행 번역 우선.
- **공통 정보 헤더(API host·인증·응답)**: 기존 발행 번역을 그대로 유지(재번역하지 않음).
- **환경별 리전 노출**: KO 와 동일하게 정합화(gov/ncgn=KR1, ngoic/ngovc/ngsc/ninc=KR4).
- **구조 보존**: 표/필드명/JSON/enum/heading 을 KO 와 1:1 전수 검증(미번역 한글 0, /ko/ 링크 0).

## 검토 요청
- 신규 enum/필드 라벨 일부는 발행 선례가 없어 표준 표현으로 파생(`<!-- TERM-UNRESOLVED -->` 주석 표시).
- ⚠ ngoic/ngovc/ngsc/ninc **헤더 엔드포인트 URL**: 발행 번역값을 유지했으나 KO 코드 생성물은 `{plat}-kr4-rds-proxy.cloud.toastoven.net` 로 달라 정합 확인 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)